### PR TITLE
Fix Router

### DIFF
--- a/backend/src/modules/location/location_router.py
+++ b/backend/src/modules/location/location_router.py
@@ -86,7 +86,7 @@ async def get_place_details(
         ) from e
 
 
-@location_router.get("/", response_model=PaginatedLocationResponse)
+@location_router.get("", response_model=PaginatedLocationResponse)
 async def get_locations(
     location_service: LocationService = Depends(),
     _=Depends(authenticate_staff_or_admin),
@@ -110,7 +110,7 @@ async def get_location(
     return await location_service.get_location_by_id(location_id)
 
 
-@location_router.post("/", status_code=201, response_model=LocationDto)
+@location_router.post("", status_code=201, response_model=LocationDto)
 async def create_location(
     data: LocationCreate,
     location_service: LocationService = Depends(),

--- a/backend/src/modules/party/party_router.py
+++ b/backend/src/modules/party/party_router.py
@@ -29,7 +29,7 @@ from .party_service import PartyService
 party_router = APIRouter(prefix="/api/parties", tags=["parties"])
 
 
-@party_router.post("/", status_code=201)
+@party_router.post("", status_code=201)
 async def create_party(
     party_data: CreatePartyDto,
     party_service: PartyService = Depends(),
@@ -64,7 +64,7 @@ async def create_party(
         raise ForbiddenException(detail="Invalid request type")
 
 
-@party_router.get("/")
+@party_router.get("")
 async def list_parties(
     page_number: int = Query(1, ge=1, description="Page number (1-indexed)"),
     page_size: int | None = Query(None, ge=1, le=100, description="Items per page (default: all)"),

--- a/backend/src/modules/student/student_router.py
+++ b/backend/src/modules/student/student_router.py
@@ -46,7 +46,7 @@ async def get_my_parties(
     return await party_service.get_parties_by_contact(user.id)
 
 
-@student_router.get("/")
+@student_router.get("")
 async def list_students(
     page_number: int | None = Query(
         None,
@@ -118,7 +118,7 @@ async def get_student(
     return await student_service.get_student_by_id(student_id)
 
 
-@student_router.post("/", status_code=201)
+@student_router.post("", status_code=201)
 async def create_student(
     payload: StudentCreate,
     student_service: StudentService = Depends(),

--- a/backend/test/modules/location/location_router_test.py
+++ b/backend/test/modules/location/location_router_test.py
@@ -14,8 +14,8 @@ from test.utils.http.assertions import assert_res_failure, assert_res_paginated,
 from test.utils.http.test_templates import generate_auth_required_tests
 
 test_location_authentication = generate_auth_required_tests(
-    ({"admin", "staff"}, "GET", "/api/locations/", None),
-    ({"admin"}, "POST", "/api/locations/", {"google_place_id": "ChIJ123abc"}),
+    ({"admin", "staff"}, "GET", "/api/locations", None),
+    ({"admin"}, "POST", "/api/locations", {"google_place_id": "ChIJ123abc"}),
     ({"admin", "staff"}, "GET", "/api/locations/1", None),
     ({"admin"}, "PUT", "/api/locations/1", {"google_place_id": "ChIJ123abc"}),
     ({"admin"}, "DELETE", "/api/locations/1", None),
@@ -35,7 +35,7 @@ async def sample_locations(location_utils: LocationTestUtils) -> list[LocationEn
 
 
 class TestLocationListRouter:
-    """Tests for GET /api/locations/ endpoint."""
+    """Tests for GET /api/locations endpoint."""
 
     admin_client: AsyncClient
     staff_client: AsyncClient
@@ -55,7 +55,7 @@ class TestLocationListRouter:
     @pytest.mark.asyncio
     async def test_list_locations_empty(self):
         """Test listing locations when database is empty."""
-        response = await self.staff_client.get("/api/locations/")
+        response = await self.staff_client.get("/api/locations")
 
         paginated = assert_res_paginated(
             response, LocationDto, total_records=0, page_size=0, total_pages=1
@@ -65,7 +65,7 @@ class TestLocationListRouter:
     @pytest.mark.asyncio
     async def test_list_locations_with_data(self, sample_locations: list[LocationEntity]):
         """Test listing locations when multiple locations exist."""
-        response = await self.staff_client.get("/api/locations/")
+        response = await self.staff_client.get("/api/locations")
 
         paginated = assert_res_paginated(
             response, LocationDto, total_records=3, page_size=3, total_pages=1
@@ -79,7 +79,7 @@ class TestLocationListRouter:
 
 
 class TestLocationCRUDRouter:
-    """Tests for CRUD operations on /api/locations/ endpoints."""
+    """Tests for CRUD operations on /api/locations endpoints."""
 
     admin_client: AsyncClient
     staff_client: AsyncClient
@@ -127,7 +127,7 @@ class TestLocationCRUDRouter:
             include={"google_place_id", "hold_expiration"},
         )
 
-        response = await self.admin_client.post("/api/locations/", json=request_data)
+        response = await self.admin_client.post("/api/locations", json=request_data)
         data = assert_res_success(response, LocationDto, status=201)
 
         self.location_utils.assert_matches(location_data, data)
@@ -147,7 +147,7 @@ class TestLocationCRUDRouter:
             include={"google_place_id", "hold_expiration"},
         )
 
-        response = await self.admin_client.post("/api/locations/", json=request_data)
+        response = await self.admin_client.post("/api/locations", json=request_data)
         assert_res_failure(response, LocationConflictException(location.google_place_id))
 
     @pytest.mark.asyncio

--- a/backend/test/modules/party/party_router_test.py
+++ b/backend/test/modules/party/party_router_test.py
@@ -22,7 +22,7 @@ from test.utils.http.assertions import (
 from test.utils.http.test_templates import generate_auth_required_tests
 
 test_party_authentication = generate_auth_required_tests(
-    ({"admin", "staff", "police"}, "GET", "/api/parties/", None),
+    ({"admin", "staff", "police"}, "GET", "/api/parties", None),
     ({"admin", "staff"}, "GET", "/api/parties/1", None),
     ({"admin"}, "DELETE", "/api/parties/1", None),
     (
@@ -33,12 +33,12 @@ test_party_authentication = generate_auth_required_tests(
     ),
     # POST endpoint requires condiitional body - tested separately in
     # TestPartyCreateAdminRouter and TestPartyCreateStudentRouter
-    # ({"student"}, "POST", "/api/parties/", {}),
+    # ({"student"}, "POST", "/api/parties", {}),
 )
 
 
 class TestPartyListRouter:
-    """Tests for GET /api/parties/ endpoint."""
+    """Tests for GET /api/parties endpoint."""
 
     admin_client: AsyncClient
     party_utils: PartyTestUtils
@@ -51,7 +51,7 @@ class TestPartyListRouter:
     @pytest.mark.asyncio
     async def test_list_parties_empty(self):
         """Test listing parties when database is empty."""
-        response = await self.admin_client.get("/api/parties/")
+        response = await self.admin_client.get("/api/parties")
         paginated = assert_res_paginated(
             response, PartyDto, total_records=0, page_size=0, total_pages=1
         )
@@ -62,7 +62,7 @@ class TestPartyListRouter:
         """Test listing parties when parties exist."""
         created_parties = await self.party_utils.create_many(i=3)
 
-        response = await self.admin_client.get("/api/parties/")
+        response = await self.admin_client.get("/api/parties")
         paginated = assert_res_paginated(
             response, PartyDto, total_records=3, page_size=3, total_pages=1
         )
@@ -135,7 +135,7 @@ class TestPartyDeleteRouter:
 
 
 class TestPartyCreateAdminRouter:
-    """Tests for POST /api/parties/ endpoint (admin creation)."""
+    """Tests for POST /api/parties endpoint (admin creation)."""
 
     admin_client: AsyncClient
     party_utils: PartyTestUtils
@@ -164,7 +164,7 @@ class TestPartyCreateAdminRouter:
         )
 
         response = await self.admin_client.post(
-            "/api/parties/", json=payload.model_dump(mode="json")
+            "/api/parties", json=payload.model_dump(mode="json")
         )
         data = assert_res_success(response, PartyDto, status=201)
 
@@ -183,7 +183,7 @@ class TestPartyCreateAdminRouter:
         )
 
         response = await self.admin_client.post(
-            "/api/parties/", json=payload.model_dump(mode="json")
+            "/api/parties", json=payload.model_dump(mode="json")
         )
         assert_res_failure(
             response,
@@ -199,12 +199,12 @@ class TestPartyCreateAdminRouter:
         payload_dict = payload.model_dump(mode="json")
         del payload_dict["contact_two"]
 
-        response = await self.admin_client.post("/api/parties/", json=payload_dict)
+        response = await self.admin_client.post("/api/parties", json=payload_dict)
         assert_res_validation_error(response)
 
 
 class TestPartyCreateStudentRouter:
-    """Tests for POST /api/parties/ endpoint (student creation)."""
+    """Tests for POST /api/parties endpoint (student creation)."""
 
     student_client: AsyncClient
     party_utils: PartyTestUtils
@@ -251,7 +251,7 @@ class TestPartyCreateStudentRouter:
         )
 
         response = await self.student_client.post(
-            "/api/parties/", json=payload.model_dump(mode="json")
+            "/api/parties", json=payload.model_dump(mode="json")
         )
         data = assert_res_success(response, PartyDto, status=201)
 

--- a/backend/test/modules/student/student_router_test.py
+++ b/backend/test/modules/student/student_router_test.py
@@ -26,9 +26,9 @@ from test.utils.http.assertions import (
 from test.utils.http.test_templates import generate_auth_required_tests
 
 test_student_authentication = generate_auth_required_tests(
-    ({"admin", "staff"}, "GET", "/api/students/", None),
+    ({"admin", "staff"}, "GET", "/api/students", None),
     ({"admin", "staff"}, "GET", "/api/students/12345", None),
-    ({"admin"}, "POST", "/api/students/", StudentTestUtils.get_sample_create_data()),
+    ({"admin"}, "POST", "/api/students", StudentTestUtils.get_sample_create_data()),
     ({"admin"}, "PUT", "/api/students/12345", StudentTestUtils.get_sample_data()),
     ({"admin"}, "DELETE", "/api/students/12345", None),
     ({"admin", "staff"}, "PATCH", "/api/students/12345/is-registered", {"is_registered": True}),
@@ -39,7 +39,7 @@ test_student_authentication = generate_auth_required_tests(
 
 
 class TestStudentListRouter:
-    """Tests for GET /api/students/ endpoint."""
+    """Tests for GET /api/students endpoint."""
 
     admin_client: AsyncClient
     student_utils: StudentTestUtils
@@ -52,7 +52,7 @@ class TestStudentListRouter:
     @pytest.mark.asyncio
     async def test_list_students_empty(self):
         """Test listing students when database is empty."""
-        response = await self.admin_client.get("/api/students/")
+        response = await self.admin_client.get("/api/students")
         paginated = assert_res_paginated(
             response,
             StudentDto,
@@ -67,7 +67,7 @@ class TestStudentListRouter:
         """Test listing students when multiple students exist."""
         students = await self.student_utils.create_many(i=3)
 
-        response = await self.admin_client.get("/api/students/")
+        response = await self.admin_client.get("/api/students")
         paginated = assert_res_paginated(
             response,
             StudentDto,
@@ -111,7 +111,7 @@ class TestStudentListRouter:
         if page_size is not None:
             params["page_size"] = page_size
 
-        response = await self.admin_client.get("/api/students/", params=params or None)
+        response = await self.admin_client.get("/api/students", params=params or None)
 
         # For default pagination (no params), expect page_size to equal total_records
         expected_page_number = page_number if page_number is not None else 1
@@ -141,12 +141,12 @@ class TestStudentListRouter:
     @pytest.mark.asyncio
     async def test_list_students_pagination_invalid_params(self, invalid_params: dict):
         """Test that invalid params return 422."""
-        response = await self.admin_client.get("/api/students/", params=invalid_params)
+        response = await self.admin_client.get("/api/students", params=invalid_params)
         assert_res_validation_error(response)
 
 
 class TestStudentCRUDRouter:
-    """Tests for CRUD operations on /api/students/ endpoints."""
+    """Tests for CRUD operations on /api/students endpoints."""
 
     admin_client: AsyncClient
     student_utils: StudentTestUtils
@@ -162,7 +162,7 @@ class TestStudentCRUDRouter:
         payload = await self.student_utils.next_student_create()
 
         response = await self.admin_client.post(
-            "/api/students/", json=payload.model_dump(mode="json")
+            "/api/students", json=payload.model_dump(mode="json")
         )
         data = assert_res_success(response, StudentDto, status=201)
 
@@ -176,7 +176,7 @@ class TestStudentCRUDRouter:
         payload = await self.student_utils.next_student_create(last_registered=dt)
 
         response = await self.admin_client.post(
-            "/api/students/", json=payload.model_dump(mode="json")
+            "/api/students", json=payload.model_dump(mode="json")
         )
         data = assert_res_success(response, StudentDto, status=201)
 
@@ -189,7 +189,7 @@ class TestStudentCRUDRouter:
         payload = await self.student_utils.next_student_create(account_id=999)
 
         response = await self.admin_client.post(
-            "/api/students/", json=payload.model_dump(mode="json")
+            "/api/students", json=payload.model_dump(mode="json")
         )
         assert_res_failure(response, AccountNotFoundException(999))
 
@@ -200,7 +200,7 @@ class TestStudentCRUDRouter:
         payload = await self.student_utils.next_student_create(account_id=account.id)
 
         response = await self.admin_client.post(
-            "/api/students/", json=payload.model_dump(mode="json")
+            "/api/students", json=payload.model_dump(mode="json")
         )
         assert_res_failure(response, InvalidAccountRoleException(account.id, AccountRole.ADMIN))
 
@@ -211,7 +211,7 @@ class TestStudentCRUDRouter:
         payload = await self.student_utils.next_student_create(account_id=student.account_id)
 
         response = await self.admin_client.post(
-            "/api/students/", json=payload.model_dump(mode="json")
+            "/api/students", json=payload.model_dump(mode="json")
         )
         assert_res_failure(response, StudentAlreadyExistsException(student.account_id))
 
@@ -222,7 +222,7 @@ class TestStudentCRUDRouter:
         payload = await self.student_utils.next_student_create(phone_number=student.phone_number)
 
         response = await self.admin_client.post(
-            "/api/students/", json=payload.model_dump(mode="json")
+            "/api/students", json=payload.model_dump(mode="json")
         )
         assert_res_failure(response, StudentConflictException(student.phone_number))
 


### PR DESCRIPTION
Currently when the frontend gets resources from the backend, it targets routes like GET /api/parties, while FastAPI expects routes like GET /api/parties/ due to base routes being defined like .get("/"). FastAPI accounts for this by automatically redirecting requests to the correct route with a 307 status code, but this bogs down the network tab with redundant info.

Changes:

Router definitions: Updated route decorators in the following modules to use empty strings instead of "/":
- location_router.py: GET "" and POST ""
- party_router.py: GET "" and POST ""
- student_router.py: GET "" and POST ""

Test updates: Updated all test files to use URLs without trailing slashes:
- location_router_test.py: Updated 8 test URLs
- party_router_test.py: Updated 11 test URLs
- student_router_test.py: Updated 14 test URLs

Closes #153 
