### PR TITLE
Disabled Validation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -83,7 +83,7 @@ COPY pyproject.toml /workspace/pyproject.toml
 RUN pip install -e ".[dev]"
 
 # Install Backend Dependencies
-COPY backend/ /workspace/backend/
+COPY backend/pyproject.toml /workspace/backend/pyproject.toml
 RUN pip install -e /workspace/backend
 
 # Configure zsh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
-
 {
   "dockerComposeFile": "docker-compose.yml",
   "workspaceFolder": "/workspace",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-
 services:
   app:
     build:


### PR DESCRIPTION
Admins sometimes need to register parties in the past or at locations with active holds, but the current validation rules prevent this. This PR removes validation restrictions for admin users while keeping them in place for students.

Changes:

- Removed location hold validation from `create_party_from_admin_dto` and `update_party_from_admin_dto` in backend party service (admins already skipped date/Party Smart validation)
- Converted frontend `partyTableFormSchema` to `createPartyTableFormSchema(isAdmin)` function that conditionally skips the 2-business-day date validation for admins
- Added `useRole()` hook to PartyTableForm to determine if user is admin
- Made calendar date picker allow all dates for admins while keeping restrictions for non-admins

Closes #152 