### PR TITLE
Fixed Registration Checkbox to Reflect the Database

### DIFF
--- a/frontend/src/app/staff/_components/student/StudentTable.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTable.tsx
@@ -6,6 +6,7 @@ import { AccountService } from "@/lib/api/account/account.service";
 import { AdminStudentService } from "@/lib/api/student/admin-student.service";
 import { StudentDto } from "@/lib/api/student/student.types";
 import { PaginatedResponse } from "@/lib/shared";
+import { isCourseCompleted } from "@/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
@@ -250,7 +251,7 @@ export const StudentTable = () => {
       enableColumnFilter: false,
       cell: ({ row }) => {
         const student = row.original;
-        const isRegistered = !!student.last_registered;
+        const isRegistered = isCourseCompleted(student.last_registered);
         return (
           <Checkbox
             checked={isRegistered}


### PR DESCRIPTION
### What was causing the bug:
The "Is Registered" checkbox in the staff student table was using a simple existence check `student.last_registered` rather than validating whether the course completion was still valid. The app has a rule where Party Smart Course completion expires on August 1st each year, but the checkbox wasn't following that either. Also, any student with any `last_registered` date (even if expired years ago) would show as registered, contradicting the student-facing view which correctly implements the expiration logic.

### The fix:
Updated the checkbox logic to use the existing `isCourseCompleted()` util, which properly checks if the `last_registered` date is after the most recent August 1st, ensuring the staff view matches the student view and accurately reflects current registration status.

### Notes:
 - Found a promise that was missing an await and added it

Closes #148 
