### PR TITLE
Formatting Utils and Consolidation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,17 @@ repos:
         files: ^backend/.*\.py$
         pass_filenames: false
 
+  # JavaScript/TypeScript and other Prettier compatible files
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        # Runs prettier on staged, removing the `frontend/` prefix to work with relative filepaths
+        entry: bash -c 'cd frontend && npx prettier --write "${@/#frontend\//}"' --
+        language: system
+        files: ^frontend/.*\.(js|jsx|ts|tsx|json|css|md)$
+        pass_filenames: true
+
   # TypeScript type checking
   - repo: local
     hooks:
@@ -45,15 +56,4 @@ repos:
         entry: bash -c 'cd frontend && npx eslint --fix --max-warnings 0 "${@/#frontend\//}"' --
         language: system
         files: ^frontend/.*\.(js|jsx|ts|tsx)$
-        pass_filenames: true
-
-  # JavaScript/TypeScript and other Prettier compatible files
-  - repo: local
-    hooks:
-      - id: prettier
-        name: prettier
-        # Runs prettier on staged, removing the `frontend/` prefix to work with relative filepaths
-        entry: bash -c 'cd frontend && npx prettier --write "${@/#frontend\//}"' --
-        language: system
-        files: ^frontend/.*\.(js|jsx|ts|tsx|json|css|md)$
         pass_filenames: true

--- a/backend/src/core/utils/phone_utils.py
+++ b/backend/src/core/utils/phone_utils.py
@@ -1,0 +1,8 @@
+from typing import Annotated
+
+from pydantic import Field
+
+PhoneNumber = Annotated[
+    str,
+    Field(pattern=r"^\d{10}$", description="10-digit US phone number (digits only, no formatting)"),
+]

--- a/backend/src/modules/party/party_model.py
+++ b/backend/src/modules/party/party_model.py
@@ -2,6 +2,7 @@ import enum
 from typing import Annotated, Literal
 
 from pydantic import AwareDatetime, BaseModel, EmailStr, Field
+from src.core.utils.phone_utils import PhoneNumber
 from src.core.utils.query_utils import PaginatedResponse
 from src.modules.location.location_model import LocationDto
 from src.modules.student.student_model import ContactPreference, StudentDto
@@ -25,9 +26,7 @@ class ContactDto(BaseModel):
     email: EmailStr = Field(..., description="Email address of the contact")
     first_name: str = Field(..., min_length=1, description="First name of the contact")
     last_name: str = Field(..., min_length=1, description="Last name of the contact")
-    phone_number: str = Field(
-        ..., pattern=r"^\+?1?\d{9,15}$", description="Phone number of the contact"
-    )
+    phone_number: PhoneNumber
     contact_preference: ContactPreference = Field(
         ..., description="Preferred contact method: 'call' or 'text'"
     )

--- a/backend/src/modules/student/student_model.py
+++ b/backend/src/modules/student/student_model.py
@@ -2,6 +2,7 @@ import enum
 from typing import TYPE_CHECKING
 
 from pydantic import AwareDatetime, BaseModel, EmailStr, Field
+from src.core.utils.phone_utils import PhoneNumber
 from src.core.utils.query_utils import PaginatedResponse
 
 if TYPE_CHECKING:
@@ -18,13 +19,13 @@ class StudentData(BaseModel):
 
     contact_preference: ContactPreference
     last_registered: AwareDatetime | None = None
-    phone_number: str = Field(pattern=r"^\+?1?\d{9,15}$")
+    phone_number: PhoneNumber
 
 
 class StudentUpdateDto(BaseModel):
     """DTO for admin creating or updating a student (without names - those are in Account)."""
 
-    phone_number: str = Field(pattern=r"^\+?1?\d{9,15}$")
+    phone_number: PhoneNumber
     contact_preference: ContactPreference
     last_registered: AwareDatetime | None = None
     residence_place_id: str | None = Field(
@@ -35,7 +36,7 @@ class StudentUpdateDto(BaseModel):
 class SelfUpdateStudentDto(BaseModel):
     """DTO for students updating their own information."""
 
-    phone_number: str = Field(pattern=r"^\+?1?\d{9,15}$")
+    phone_number: PhoneNumber
     contact_preference: ContactPreference
 
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${avenirNext.variable} font-[family-name:var(--font-avenir-next)] antialiased h-screen overflow-hidden`}
+        className={`${avenirNext.variable} font-[family-name:var(--font-avenir-next)] antialiased`}
       >
         <Providers>
           <Header />

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -38,11 +38,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${avenirNext.variable} font-[family-name:var(--font-avenir-next)] antialiased`}
+        className={`${avenirNext.variable} font-[family-name:var(--font-avenir-next)] antialiased h-screen overflow-hidden flex flex-col`}
       >
         <Providers>
           <Header />
-          {children}
+          <div className="flex-1 overflow-hidden min-h-0">{children}</div>
         </Providers>
       </body>
     </html>

--- a/frontend/src/app/police/_components/EmbeddedMap.tsx
+++ b/frontend/src/app/police/_components/EmbeddedMap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PartyDto } from "@/lib/api/party/party.types";
+import { formatPhoneNumber } from "@/lib/utils";
 import {
   APIProvider,
   AdvancedMarker,
@@ -88,16 +89,6 @@ type PoiMarkersProps = {
 const PoiMarkers = ({ pois, activePoiKey, onSelect }: PoiMarkersProps) => {
   const map = useMap();
   const [selectedPoi, setSelectedPoi] = useState<(typeof pois)[0] | null>(null);
-
-  const formatPhoneNumber = (phone: string): string => {
-    const cleaned = phone.replace(/\D/g, "");
-    if (cleaned.length === 10) {
-      return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(
-        6
-      )}`;
-    }
-    return phone;
-  };
 
   const getShortAddress = (location: PartyDto["location"]): string => {
     const parts = [];

--- a/frontend/src/app/police/_components/PartyList.tsx
+++ b/frontend/src/app/police/_components/PartyList.tsx
@@ -31,7 +31,7 @@ import {
   getRemoteWarningCount,
 } from "@/lib/api/location/location.types";
 import { PartyDto } from "@/lib/api/party/party.types";
-import { cn, formatPhoneNumber } from "@/lib/utils";
+import { cn, formatPhoneNumber, formatTime } from "@/lib/utils";
 import { format } from "date-fns";
 import { EllipsisVertical } from "lucide-react";
 import Image from "next/image";
@@ -139,7 +139,7 @@ const PartyList = ({ parties = [], onSelect, activeParty }: PartyListProps) => {
                       <div>
                         <p className="content-bold font-bold text-secondary">
                           {format(party.party_datetime, "M/d/yyyy")} @{" "}
-                          {format(party.party_datetime, "h:mm a")}
+                          {formatTime(party.party_datetime)}
                         </p>
                         <p className="content-bold font-bold text-secondary">
                           {party.location.formatted_address}

--- a/frontend/src/app/police/_components/PartyList.tsx
+++ b/frontend/src/app/police/_components/PartyList.tsx
@@ -31,7 +31,7 @@ import {
   getRemoteWarningCount,
 } from "@/lib/api/location/location.types";
 import { PartyDto } from "@/lib/api/party/party.types";
-import { cn } from "@/lib/utils";
+import { cn, formatPhoneNumber } from "@/lib/utils";
 import { format } from "date-fns";
 import { EllipsisVertical } from "lucide-react";
 import Image from "next/image";
@@ -45,14 +45,6 @@ interface PartyListProps {
   onSelect?: (party: PartyDto) => void;
   activeParty?: PartyDto;
 }
-
-const formatPhoneNumber = (phone: string): string => {
-  const cleaned = phone.replace(/\D/g, "");
-  if (cleaned.length === 10) {
-    return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(6)}`;
-  }
-  return phone;
-};
 
 const PartyList = ({ parties = [], onSelect, activeParty }: PartyListProps) => {
   const [incidentDialogOpen, setIncidentDialogOpen] = useState(false);

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -14,6 +14,7 @@ import {
 import { LocationService } from "@/lib/api/location/location.service";
 import { LocationDto } from "@/lib/api/location/location.types";
 import { PaginatedResponse } from "@/lib/shared";
+import { formatTime } from "@/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { AxiosError } from "axios";
@@ -328,10 +329,7 @@ export const IncidentTable = () => {
       },
       cell: ({ row }) => {
         const date = new Date(row.original.incident_datetime);
-        return date.toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
-        });
+        return formatTime(date);
       },
       filterFn: (row, _columnId, filterValue) => {
         if (!filterValue) return true;

--- a/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
+++ b/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { IncidentDto } from "@/lib/api/incident/incident.types";
+import { formatTime } from "@/lib/utils";
 import { ChevronDown, MoreHorizontal } from "lucide-react";
 import { useSession } from "next-auth/react";
 
@@ -40,11 +41,7 @@ export default function IncidentSidebarCard({
                 })}
               </p>
               <p className="text-md font-medium">
-                {incidents.incident_datetime.toLocaleTimeString("en-US", {
-                  hour: "numeric",
-                  minute: "2-digit",
-                  hour12: true,
-                })}
+                {formatTime(incidents.incident_datetime)}
               </p>
             </div>
             {role === "admin" && (

--- a/frontend/src/app/staff/_components/party/PartyTable.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTable.tsx
@@ -13,6 +13,7 @@ import {
   ServerColumnMap,
   ServerTableParams,
 } from "@/lib/api/shared/query-params";
+import { formatTime } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { isAxiosError } from "axios";
 import { format } from "date-fns";
@@ -285,10 +286,7 @@ export const PartyTable = () => {
       meta: { filterType: "time", filterMode: "client" },
       cell: ({ row }) => {
         const date = new Date(row.original.party_datetime);
-        return date.toLocaleTimeString([], {
-          hour: "numeric",
-          minute: "2-digit",
-        });
+        return formatTime(date);
       },
     },
     {

--- a/frontend/src/app/staff/_components/party/PartyTableForm.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTableForm.tsx
@@ -24,18 +24,11 @@ import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { PartyDto } from "@/lib/api/party/party.types";
 import { AdminStudentService } from "@/lib/api/student/admin-student.service";
 import { StudentSuggestionDto } from "@/lib/api/student/student.types";
+import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
 import { addBusinessDays, format, isAfter, startOfDay } from "date-fns";
 import { useSession } from "next-auth/react";
 import { useMemo, useState } from "react";
 import * as z from "zod";
-
-const formatPhoneNumber = (value: string): string => {
-  const digits = value.replace(/\D/g, "").slice(0, 10);
-  if (!digits) return "";
-  if (digits.length <= 3) return `(${digits}`;
-  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-};
 
 export const createPartyTableFormSchema = (isAdmin: boolean) => {
   const partyDateSchema = isAdmin
@@ -70,14 +63,7 @@ export const createPartyTableFormSchema = (isAdmin: boolean) => {
       .min(1, "Contact email is required"),
     contactTwoFirstName: z.string().min(1, "First name is required"),
     contactTwoLastName: z.string().min(1, "Last name is required"),
-    contactTwoPhoneNumber: z
-      .string()
-      .min(1, "Phone number is required")
-      .refine(
-        (val) => val.replace(/\D/g, "").length >= 10,
-        "Phone number must be at least 10 digits"
-      )
-      .transform((val) => val.replace(/\D/g, "")),
+    contactTwoPhoneNumber: phoneNumberSchema,
     contactTwoPreference: z.enum(["call", "text"], {
       message: "Please select a contact preference",
     }),
@@ -350,7 +336,9 @@ export default function PartyTableForm({
               id="contact-two-phone-number"
               type="tel"
               placeholder="(123) 456-7890"
-              value={formatPhoneNumber(formData.contactTwoPhoneNumber || "")}
+              value={formatPhoneNumberInput(
+                formData.contactTwoPhoneNumber || ""
+              )}
               onChange={(e) => {
                 const digitsOnly = e.target.value
                   .replace(/\D/g, "")

--- a/frontend/src/app/staff/_components/student/StudentTableForm.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTableForm.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { ResidenceDto } from "@/lib/api/student/student.types";
+import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
 import { useState } from "react";
 import * as z from "zod";
@@ -29,14 +30,7 @@ export const studentTableFormSchema = z.object({
   first_name: z.string().min(1, "First name is required"),
   last_name: z.string().min(1, "Second name is required"),
   email: z.email("Please enter a valid email").min(1, "Email is required"),
-  phone_number: z
-    .string()
-    .min(1, "Phone number is required")
-    .refine(
-      (val) => val.replace(/\D/g, "").length >= 10,
-      "Phone number must be at least 10 digits"
-    )
-    .transform((val) => val.replace(/\D/g, "")),
+  phone_number: phoneNumberSchema,
   contact_preference: z.enum(["call", "text"], {
     message: "Please select a contact preference",
   }),
@@ -49,14 +43,6 @@ export const studentTableFormSchema = z.object({
   residence: z.custom<ResidenceDto | null>().default(null),
   residence_place_id: z.string().nullable().optional(),
 });
-
-const formatPhoneNumber = (value: string): string => {
-  const digits = value.replace(/\D/g, "").slice(0, 10);
-  if (!digits) return "";
-  if (digits.length <= 3) return `(${digits}`;
-  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-};
 
 type StudentTableFormValues = z.infer<typeof studentTableFormSchema>;
 
@@ -236,7 +222,9 @@ export default function StudentTableForm({
               id="phone-number"
               type="tel"
               placeholder="(123) 456-7890"
-              value={formatPhoneNumber((formData.phone_number as string) || "")}
+              value={formatPhoneNumberInput(
+                (formData.phone_number as string) || ""
+              )}
               onChange={(e) => {
                 const digitsOnly = e.target.value
                   .replace(/\D/g, "")

--- a/frontend/src/app/student/_components/EditPartyDialog.tsx
+++ b/frontend/src/app/student/_components/EditPartyDialog.tsx
@@ -58,7 +58,7 @@ export function EditPartyDialog({
         email: values.contactTwoEmail,
         first_name: values.secondContactFirstName,
         last_name: values.secondContactLastName,
-        phone_number: values.phoneNumber.replace(/\D/g, ""),
+        phone_number: values.phoneNumber,
         contact_preference: values.contactPreference,
       },
     };

--- a/frontend/src/app/student/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/student/_components/PartyRegistrationForm.tsx
@@ -36,7 +36,11 @@ import {
 import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { StudentDto } from "@/lib/api/student/student.types";
-import { isFromThisSchoolYear } from "@/lib/utils";
+import {
+  formatPhoneNumberInput,
+  isFromThisSchoolYear,
+  phoneNumberSchema,
+} from "@/lib/utils";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { useRef, useState } from "react";
@@ -56,9 +60,7 @@ const partyFormSchema = z.object({
   partyTime: z.string().min(1, "Party time is required"),
   secondContactFirstName: z.string().min(1, "First name is required"),
   secondContactLastName: z.string().min(1, "Last name is required"),
-  phoneNumber: z.string().regex(/^\+?1?\d{9,15}$/, {
-    message: "String must be a valid phone number",
-  }),
+  phoneNumber: phoneNumberSchema,
   contactPreference: z.enum(["call", "text"], {
     message: "Please select a contact preference",
   }),
@@ -171,7 +173,7 @@ export default function PartyRegistrationForm({
     }
     if (student?.phone_number) {
       const c1Digits = student.phone_number.replace(/\D/g, "");
-      const c2Digits = result.data.phoneNumber.replace(/\D/g, "");
+      const c2Digits = result.data.phoneNumber;
       if (c1Digits === c2Digits) {
         contactTwoErrors.phoneNumber =
           "Contact two phone number must be different from your phone number";
@@ -473,9 +475,15 @@ export default function PartyRegistrationForm({
               </FieldLabel>
               <Input
                 id="phone-number"
+                type="tel"
                 placeholder="(123) 456-7890"
-                value={formData.phoneNumber}
-                onChange={(e) => updateField("phoneNumber", e.target.value)}
+                value={formatPhoneNumberInput(formData.phoneNumber ?? "")}
+                onChange={(e) =>
+                  updateField(
+                    "phoneNumber",
+                    e.target.value.replace(/\D/g, "").slice(0, 10)
+                  )
+                }
                 aria-invalid={!!errors.phoneNumber}
                 className="content"
               />

--- a/frontend/src/app/student/_components/RegistrationTracker.tsx
+++ b/frontend/src/app/student/_components/RegistrationTracker.tsx
@@ -14,7 +14,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { IncidentDto } from "@/lib/api/incident/incident.types";
 import { PartyDto } from "@/lib/api/party/party.types";
 import { useCurrentStudent } from "@/lib/api/student/student.queries";
-import { formatPhoneNumber, isFromThisSchoolYear } from "@/lib/utils";
+import {
+  formatPhoneNumber,
+  formatTime,
+  isFromThisSchoolYear,
+} from "@/lib/utils";
 import { format } from "date-fns";
 import { MoreVertical, Pencil, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
@@ -114,7 +118,7 @@ export default function RegistrationTracker({
           <div>
             <div className="flex content-bold gap-6">
               <p>{format(party.party_datetime, "MM/dd/yyyy")}</p>
-              <p>Start: {format(party.party_datetime, "p")}</p>
+              <p>Start: {formatTime(party.party_datetime)}</p>
             </div>
             {showAddress && (
               <h2 className="content-bold my-2">
@@ -203,7 +207,7 @@ export default function RegistrationTracker({
         {incidents.map((incident) => (
           <div key={incident.id} className="mt-3">
             <p className="content">
-              {format(incident.incident_datetime, "p")} -{" "}
+              {formatTime(incident.incident_datetime)} -{" "}
               <span className="capitalize">{incident.severity}</span>
             </p>
             <p className="content ml-3 mt-1">{incident.description}</p>

--- a/frontend/src/app/student/_components/RegistrationTracker.tsx
+++ b/frontend/src/app/student/_components/RegistrationTracker.tsx
@@ -14,7 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { IncidentDto } from "@/lib/api/incident/incident.types";
 import { PartyDto } from "@/lib/api/party/party.types";
 import { useCurrentStudent } from "@/lib/api/student/student.queries";
-import { isFromThisSchoolYear } from "@/lib/utils";
+import { formatPhoneNumber, isFromThisSchoolYear } from "@/lib/utils";
 import { format } from "date-fns";
 import { MoreVertical, Pencil, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
@@ -26,17 +26,6 @@ interface RegistrationTrackerProps {
   error?: Error | null;
   incidents?: IncidentDto[];
 }
-
-const formatPhoneNumber = (phone: string | undefined): string => {
-  if (!phone) return "";
-  const cleaned = phone.replace(/\D/g, "");
-  if (cleaned.length === 10) {
-    return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(
-      6
-    )}`;
-  }
-  return phone;
-};
 
 export default function RegistrationTracker({
   data: parties = [],

--- a/frontend/src/app/student/_components/StudentInfo.tsx
+++ b/frontend/src/app/student/_components/StudentInfo.tsx
@@ -17,7 +17,11 @@ import {
 } from "@/components/ui/select";
 import { useUpdateStudent } from "@/lib/api/student/student.queries";
 import { StudentDto } from "@/lib/api/student/student.types";
-import { isFromThisSchoolYear } from "@/lib/utils";
+import {
+  formatPhoneNumberInput,
+  isFromThisSchoolYear,
+  phoneNumberSchema,
+} from "@/lib/utils";
 import { Pencil, TriangleAlert } from "lucide-react";
 import { useState } from "react";
 import * as z from "zod";
@@ -25,13 +29,7 @@ import * as z from "zod";
 const studentInfoSchema = z.object({
   first_name: z.string().min(1, "First name is required"),
   last_name: z.string().min(1, "Last name is required"),
-  phone_number: z
-    .string()
-    .min(1, "Phone number is required")
-    .refine(
-      (val) => val.replace(/\D/g, "").length >= 10,
-      "Phone number must be at least 10 digits"
-    ), // Ensures phone number is at least 10 digits regardless of format (ex: (123) 456-7890 or 1234567890)
+  phone_number: phoneNumberSchema,
   contact_preference: z.enum(["call", "text"], {
     message: "Please select a contact preference",
   }),
@@ -257,9 +255,15 @@ export default function StudentInfo({ initialData }: StudentInfoProps) {
                 </FieldLabel>
                 <Input
                   id="phone-number"
-                  placeholder="123-456-7890"
-                  value={formData.phone_number}
-                  onChange={(e) => updateField("phone_number", e.target.value)}
+                  type="tel"
+                  placeholder="(123) 456-7890"
+                  value={formatPhoneNumberInput(formData.phone_number)}
+                  onChange={(e) =>
+                    updateField(
+                      "phone_number",
+                      e.target.value.replace(/\D/g, "").slice(0, 10)
+                    )
+                  }
                   aria-invalid={!!errors.phone_number}
                   className="content"
                 />

--- a/frontend/src/app/student/new-party/page.tsx
+++ b/frontend/src/app/student/new-party/page.tsx
@@ -72,8 +72,7 @@ export default function RegistrationForm() {
         email: values.contactTwoEmail,
         first_name: values.secondContactFirstName,
         last_name: values.secondContactLastName,
-        // Strip non-digit characters from phone number before sending to backend
-        phone_number: values.phoneNumber.replace(/\D/g, ""),
+        phone_number: values.phoneNumber,
         contact_preference: values.contactPreference,
       },
     };

--- a/frontend/src/app/student/new-party/page.tsx
+++ b/frontend/src/app/student/new-party/page.tsx
@@ -97,7 +97,7 @@ export default function RegistrationForm() {
   };
 
   return (
-    <div>
+    <div className="h-full overflow-y-auto">
       <main className="mx-4 mt-4">
         <nav className="flex items-center content pb-2 lg:hidden">
           <ArrowLeft className="h-4" />

--- a/frontend/src/components/StudentSearch.tsx
+++ b/frontend/src/components/StudentSearch.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/popover";
 import { AdminStudentService } from "@/lib/api/student/admin-student.service";
 import { StudentSuggestionDto } from "@/lib/api/student/student.types";
-import { cn } from "@/lib/utils";
+import { cn, formatPhoneNumber } from "@/lib/utils";
 import { CheckIcon, Loader2Icon, UserIcon, XIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
@@ -30,12 +30,6 @@ interface StudentSearchProps {
   adminStudentService?: AdminStudentService;
   error?: string;
 }
-
-const formatPhoneNumber = (value: string): string => {
-  return value
-    ? `(${value.slice(0, 3)}) ${value.slice(3, 6)}-${value.slice(6, 10)}`
-    : value;
-};
 
 function highlightMatch(text: string, query: string): React.ReactNode {
   if (!query) return text;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -48,7 +48,7 @@ export const phoneNumberSchema = z
   .string()
   .min(1, "Phone number is required")
   .refine(
-    (val) => val.replace(/\D/g, "").length >= 10,
+    (val) => val.replace(/\D/g, "").length === 10,
     "Phone number must be at least 10 digits"
   )
   .transform((val) => val.replace(/\D/g, ""));

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,10 +1,50 @@
 import { type ClassValue, clsx } from "clsx";
 import { isAfter, isBefore, startOfDay } from "date-fns";
 import { twMerge } from "tailwind-merge";
+import * as z from "zod";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Format a 10-digit phone number string as (XXX) XXX-XXXX.
+ * Strips non-digit characters before formatting.
+ * Returns an empty string for null/undefined, or the original value if not 10 digits.
+ */
+export function formatPhoneNumber(phone: string | null | undefined): string {
+  if (!phone) return "";
+  const cleaned = phone.replace(/\D/g, "");
+  if (cleaned.length === 10) {
+    return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(6)}`;
+  }
+  return phone;
+}
+
+/**
+ * Progressive phone number formatter for input fields.
+ * Formats partial input as the user types: (XXX), (XXX) XXX, (XXX) XXX-XXXX.
+ */
+export function formatPhoneNumberInput(value: string): string {
+  const digits = value.replace(/\D/g, "").slice(0, 10);
+  if (!digits) return "";
+  if (digits.length <= 3) return `(${digits}`;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+}
+
+/**
+ * Zod schema for phone number fields in forms.
+ * Validates at least 10 digits and transforms to raw digits on parse.
+ */
+export const phoneNumberSchema = z
+  .string()
+  .min(1, "Phone number is required")
+  .refine(
+    (val) => val.replace(/\D/g, "").length >= 10,
+    "Phone number must be at least 10 digits"
+  )
+  .transform((val) => val.replace(/\D/g, ""));
 
 /**
  * Check if a date is before or after August 1st.

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -34,6 +34,13 @@ export function formatPhoneNumberInput(value: string): string {
 }
 
 /**
+ * Format a date as a human-readable time string, e.g. "8:30 PM".
+ */
+export function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+/**
  * Zod schema for phone number fields in forms.
  * Validates at least 10 digits and transforms to raw digits on parse.
  */


### PR DESCRIPTION
Our formatting for phone numbers and time was fragmented and inconsistent across the codebase

Changes:

- Made a reusable formatting util for phone numbers and phone number inputs. Replaced all relevant areas
- Made a reusable phone number schema for use in forms
- Made the backend phone number validation consistent with the frontend
- Made a reusable formatting util for time. Replaced all relevant areas

Extra
- Fixed a bug that prevented students from scrolling on the create party form
- Moved Prettier to be the first frontend pre-commit check since it is the most commonly triggered one  

Closes #204 
