### PR TITLE
Police Admin

### DIFF
--- a/backend/script/reset_dev.py
+++ b/backend/script/reset_dev.py
@@ -20,6 +20,7 @@ from src.core.database import engine as async_engine
 from src.core.utils.bcrypt_utils import hash_password
 from src.modules.account.account_model import AccountRole
 from src.modules.incident.incident_model import IncidentSeverity
+from src.modules.police.police_model import PoliceRole
 from src.modules.student.student_model import ContactPreference, StudentData
 
 
@@ -110,6 +111,7 @@ async def reset_dev():
             police = entities.PoliceEntity(
                 email=police_data["email"],
                 hashed_password=hash_password(police_data["password"]),
+                role=PoliceRole(police_data.get("role", PoliceRole.OFFICER.value)),
             )
             session.add(police)
 

--- a/backend/src/core/authentication.py
+++ b/backend/src/core/authentication.py
@@ -6,9 +6,9 @@ from src.core.exceptions import CredentialsException, ForbiddenException
 from src.modules.account.account_model import AccountDto, AccountRole
 from src.modules.auth.auth_model import AccountAccessTokenPayload, PoliceAccessTokenPayload
 from src.modules.auth.auth_service import AuthService
-from src.modules.police.police_model import PoliceAccountDto
+from src.modules.police.police_model import PoliceAccountDto, PoliceRole
 
-StringRole = Literal["student", "admin", "staff", "police"]
+StringRole = Literal["student", "admin", "staff", "officer", "police_admin"]
 
 
 class HTTPBearer401(HTTPBearer):
@@ -35,9 +35,13 @@ def authenticate_by_role(*roles: StringRole):
         payload = auth_service.decode_access_token(token)
 
         if isinstance(payload, PoliceAccessTokenPayload):
-            if "police" not in roles:
+            if payload.role not in roles:
                 raise ForbiddenException(detail="Insufficient privileges")
-            return PoliceAccountDto(id=payload.sub, email=payload.email)
+            return PoliceAccountDto(
+                id=payload.sub,
+                email=payload.email,
+                role=PoliceRole(payload.role),
+            )
 
         elif isinstance(payload, AccountAccessTokenPayload):
             account = AccountDto(
@@ -61,7 +65,7 @@ def authenticate_by_role(*roles: StringRole):
 
 async def authenticate_user(
     account: AccountDto | PoliceAccountDto = Depends(
-        authenticate_by_role("student", "staff", "admin", "police")
+        authenticate_by_role("student", "staff", "admin", "officer", "police_admin")
     ),
 ) -> AccountDto | PoliceAccountDto:
     """
@@ -104,14 +108,22 @@ async def authenticate_student(
 
 
 async def authenticate_police_or_admin(
-    account: AccountDto | PoliceAccountDto = Depends(authenticate_by_role("police", "admin")),
+    account: AccountDto | PoliceAccountDto = Depends(
+        authenticate_by_role("officer", "police_admin", "admin")
+    ),
 ) -> PoliceAccountDto | AccountDto:
     return account
 
 
 async def authenticate_police_staff_or_admin(
     account: AccountDto | PoliceAccountDto = Depends(
-        authenticate_by_role("police", "staff", "admin")
+        authenticate_by_role("officer", "police_admin", "staff", "admin")
     ),
+) -> PoliceAccountDto | AccountDto:
+    return account
+
+
+async def authenticate_police_admin_or_admin(
+    account: AccountDto | PoliceAccountDto = Depends(authenticate_by_role("police_admin", "admin")),
 ) -> PoliceAccountDto | AccountDto:
     return account

--- a/backend/src/modules/account/account_model.py
+++ b/backend/src/modules/account/account_model.py
@@ -14,7 +14,8 @@ class Role(StrEnum):
     STUDENT = "student"
     STAFF = "staff"
     ADMIN = "admin"
-    POLICE = "police"
+    OFFICER = "officer"
+    POLICE_ADMIN = "police_admin"
 
 
 class AccountData(BaseModel):

--- a/backend/src/modules/auth/auth_model.py
+++ b/backend/src/modules/auth/auth_model.py
@@ -27,7 +27,7 @@ class PoliceAccessTokenPayload(BaseModel):
 
     sub: int  # Police account ID
     email: str
-    role: Literal["police"]
+    role: Literal["officer", "police_admin"]
     exp: AwareDatetime
     iat: AwareDatetime
 

--- a/backend/src/modules/auth/auth_router.py
+++ b/backend/src/modules/auth/auth_router.py
@@ -91,7 +91,7 @@ async def refresh_access_token(
 async def logout(
     data: RefreshTokenDto,
     auth_service: AuthService = Depends(),
-    _=Depends(authenticate_by_role("student", "admin", "staff", "police")),
+    _=Depends(authenticate_by_role("student", "admin", "staff", "officer", "police_admin")),
 ) -> None:
     """
     Logout by revoking the refresh token.

--- a/backend/src/modules/auth/auth_service.py
+++ b/backend/src/modules/auth/auth_service.py
@@ -85,7 +85,7 @@ class AuthService:
         payload = PoliceAccessTokenPayload(
             sub=police.id,
             email=police.email,
-            role="police",
+            role=police.role.value,
             exp=expires_at,
             iat=datetime.now(UTC),
         )

--- a/backend/src/modules/location/location_router.py
+++ b/backend/src/modules/location/location_router.py
@@ -32,7 +32,7 @@ async def autocomplete_address(
     input_data: AutocompleteInput,
     location_service: LocationService = Depends(),
     user: AccountDto | PoliceAccountDto = Depends(
-        authenticate_by_role("police", "student", "admin", "staff")
+        authenticate_by_role("officer", "police_admin", "student", "admin", "staff")
     ),
 ) -> list[AutocompleteResult]:
     """
@@ -66,7 +66,7 @@ async def get_place_details(
     place_id: str,
     location_service: LocationService = Depends(),
     user: AccountDto | PoliceAccountDto = Depends(
-        authenticate_by_role("police", "student", "admin", "staff")
+        authenticate_by_role("officer", "police_admin", "student", "admin", "staff")
     ),
 ) -> AddressData:
     """

--- a/backend/src/modules/party/party_router.py
+++ b/backend/src/modules/party/party_router.py
@@ -74,7 +74,7 @@ async def create_party(
 async def list_parties(
     request: Request,
     party_service: PartyService = Depends(),
-    _=Depends(authenticate_by_role("admin", "staff", "police")),
+    _=Depends(authenticate_by_role("admin", "staff", "officer", "police_admin")),
 ) -> PaginatedPartiesResponse:
     """
     Returns all party registrations with pagination, sorting, and filtering.

--- a/backend/src/modules/police/police_entity.py
+++ b/backend/src/modules/police/police_entity.py
@@ -1,10 +1,10 @@
 from typing import Self
 
-from sqlalchemy import Integer, String
+from sqlalchemy import Enum, Integer, String
 from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 from src.core.database import EntityBase
 from src.core.utils.bcrypt_utils import hash_password
-from src.modules.police.police_model import PoliceAccountDto, PoliceAccountUpdate
+from src.modules.police.police_model import PoliceAccountDto, PoliceAccountUpdate, PoliceRole
 
 
 class PoliceEntity(MappedAsDataclass, EntityBase):
@@ -13,12 +13,21 @@ class PoliceEntity(MappedAsDataclass, EntityBase):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
     email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    role: Mapped[PoliceRole] = mapped_column(
+        Enum(PoliceRole, native_enum=False, length=20),
+        nullable=False,
+        default=PoliceRole.OFFICER,
+    )
 
     @classmethod
     def from_data(cls, data: PoliceAccountUpdate) -> Self:
         """Create a PoliceEntity from a PoliceAccountUpdate model."""
-        return cls(email=data.email, hashed_password=hash_password(data.password))
+        return cls(
+            email=data.email,
+            hashed_password=hash_password(data.password),
+            role=data.role,
+        )
 
     def to_dto(self) -> PoliceAccountDto:
         """Convert the entity to a PoliceAccountDto."""
-        return PoliceAccountDto(id=self.id, email=self.email)
+        return PoliceAccountDto(id=self.id, email=self.email, role=self.role)

--- a/backend/src/modules/police/police_entity.py
+++ b/backend/src/modules/police/police_entity.py
@@ -4,7 +4,7 @@ from sqlalchemy import Enum, Integer, String
 from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 from src.core.database import EntityBase
 from src.core.utils.bcrypt_utils import hash_password
-from src.modules.police.police_model import PoliceAccountDto, PoliceAccountUpdate, PoliceRole
+from src.modules.police.police_model import PoliceAccountCreate, PoliceAccountDto, PoliceRole
 
 
 class PoliceEntity(MappedAsDataclass, EntityBase):
@@ -20,8 +20,8 @@ class PoliceEntity(MappedAsDataclass, EntityBase):
     )
 
     @classmethod
-    def from_data(cls, data: PoliceAccountUpdate) -> Self:
-        """Create a PoliceEntity from a PoliceAccountUpdate model."""
+    def from_data(cls, data: PoliceAccountCreate) -> Self:
+        """Create a PoliceEntity from a PoliceAccountCreate model."""
         return cls(
             email=data.email,
             hashed_password=hash_password(data.password),

--- a/backend/src/modules/police/police_model.py
+++ b/backend/src/modules/police/police_model.py
@@ -1,5 +1,12 @@
+from enum import StrEnum
+
 from pydantic import BaseModel, EmailStr
 from src.core.utils.query_utils import PaginatedResponse
+
+
+class PoliceRole(StrEnum):
+    OFFICER = "officer"
+    POLICE_ADMIN = "police_admin"
 
 
 class PoliceAccountDto(BaseModel):
@@ -7,6 +14,7 @@ class PoliceAccountDto(BaseModel):
 
     id: int
     email: EmailStr
+    role: PoliceRole
 
 
 class PoliceAccountUpdate(BaseModel):
@@ -14,6 +22,7 @@ class PoliceAccountUpdate(BaseModel):
 
     email: EmailStr
     password: str
+    role: PoliceRole
 
 
 class PaginatedPoliceResponse(PaginatedResponse["PoliceAccountDto"]):

--- a/backend/src/modules/police/police_model.py
+++ b/backend/src/modules/police/police_model.py
@@ -17,11 +17,18 @@ class PoliceAccountDto(BaseModel):
     role: PoliceRole
 
 
-class PoliceAccountUpdate(BaseModel):
-    """DTO for creating or updating Police credentials."""
+class PoliceAccountCreate(BaseModel):
+    """DTO for creating Police credentials."""
 
     email: EmailStr
     password: str
+    role: PoliceRole
+
+
+class PoliceAccountUpdate(BaseModel):
+    """DTO for updating police account details."""
+
+    email: EmailStr
     role: PoliceRole
 
 

--- a/backend/src/modules/police/police_router.py
+++ b/backend/src/modules/police/police_router.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter, Depends, Request, status
-from src.core.authentication import authenticate_admin
+from fastapi import APIRouter, Depends, Request, Response, status
+from src.core.authentication import authenticate_police_admin_or_admin
 from src.core.utils.query_utils import PAGINATED_OPENAPI_PARAMS
 from src.modules.police.police_model import (
     PaginatedPoliceResponse,
@@ -8,14 +8,14 @@ from src.modules.police.police_model import (
 )
 from src.modules.police.police_service import PoliceService
 
-police_router = APIRouter(prefix="/api/accounts/police", tags=["police"])
+police_router = APIRouter(prefix="/api/police", tags=["police"])
 
 
 @police_router.get("", openapi_extra=PAGINATED_OPENAPI_PARAMS)
 async def list_police(
     request: Request,
     police_service: PoliceService = Depends(),
-    _=Depends(authenticate_admin),
+    _=Depends(authenticate_police_admin_or_admin),
 ) -> PaginatedPoliceResponse:
     return await police_service.get_police_paginated(request)
 
@@ -24,16 +24,31 @@ async def list_police(
 async def create_police(
     data: PoliceAccountUpdate,
     police_service: PoliceService = Depends(),
-    _=Depends(authenticate_admin),
+    _=Depends(authenticate_police_admin_or_admin),
 ) -> PoliceAccountDto:
-    return await police_service.create_police(data.email, data.password)
+    return await police_service.create_police(data.email, data.password, data.role)
+
+
+@police_router.get("/csv", openapi_extra=PAGINATED_OPENAPI_PARAMS)
+async def get_police_csv(
+    request: Request,
+    police_service: PoliceService = Depends(),
+    _=Depends(authenticate_police_admin_or_admin),
+) -> Response:
+    police_accounts = await police_service.get_police_for_export(request)
+    excel_content = police_service.export_police_to_excel(police_accounts)
+    return Response(
+        content=excel_content,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": "attachment; filename=police_accounts.xlsx"},
+    )
 
 
 @police_router.get("/{police_id}")
 async def get_police(
     police_id: int,
     police_service: PoliceService = Depends(),
-    _=Depends(authenticate_admin),
+    _=Depends(authenticate_police_admin_or_admin),
 ) -> PoliceAccountDto:
     return await police_service.get_police_by_id(police_id)
 
@@ -43,15 +58,15 @@ async def update_police(
     police_id: int,
     data: PoliceAccountUpdate,
     police_service: PoliceService = Depends(),
-    _=Depends(authenticate_admin),
+    _=Depends(authenticate_police_admin_or_admin),
 ) -> PoliceAccountDto:
-    return await police_service.update_police(police_id, data.email, data.password)
+    return await police_service.update_police(police_id, data.email, data.password, data.role)
 
 
 @police_router.delete("/{police_id}")
 async def delete_police(
     police_id: int,
     police_service: PoliceService = Depends(),
-    _=Depends(authenticate_admin),
+    _=Depends(authenticate_police_admin_or_admin),
 ) -> PoliceAccountDto:
     return await police_service.delete_police(police_id)

--- a/backend/src/modules/police/police_router.py
+++ b/backend/src/modules/police/police_router.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends, Request, Response, status
 from src.core.authentication import authenticate_police_admin_or_admin
+from src.core.exceptions import ForbiddenException
 from src.core.utils.query_utils import PAGINATED_OPENAPI_PARAMS
+from src.modules.account.account_model import AccountDto
 from src.modules.police.police_model import (
     PaginatedPoliceResponse,
     PoliceAccountCreate,
@@ -68,6 +70,8 @@ async def update_police(
 async def delete_police(
     police_id: int,
     police_service: PoliceService = Depends(),
-    _=Depends(authenticate_police_admin_or_admin),
+    principal: AccountDto | PoliceAccountDto = Depends(authenticate_police_admin_or_admin),
 ) -> PoliceAccountDto:
+    if isinstance(principal, PoliceAccountDto) and principal.id == police_id:
+        raise ForbiddenException("Police admins cannot delete their own account")
     return await police_service.delete_police(police_id)

--- a/backend/src/modules/police/police_router.py
+++ b/backend/src/modules/police/police_router.py
@@ -3,6 +3,7 @@ from src.core.authentication import authenticate_police_admin_or_admin
 from src.core.utils.query_utils import PAGINATED_OPENAPI_PARAMS
 from src.modules.police.police_model import (
     PaginatedPoliceResponse,
+    PoliceAccountCreate,
     PoliceAccountDto,
     PoliceAccountUpdate,
 )
@@ -22,7 +23,7 @@ async def list_police(
 
 @police_router.post("", status_code=status.HTTP_201_CREATED)
 async def create_police(
-    data: PoliceAccountUpdate,
+    data: PoliceAccountCreate,
     police_service: PoliceService = Depends(),
     _=Depends(authenticate_police_admin_or_admin),
 ) -> PoliceAccountDto:
@@ -60,7 +61,7 @@ async def update_police(
     police_service: PoliceService = Depends(),
     _=Depends(authenticate_police_admin_or_admin),
 ) -> PoliceAccountDto:
-    return await police_service.update_police(police_id, data.email, data.password, data.role)
+    return await police_service.update_police(police_id, data.email, data.role)
 
 
 @police_router.delete("/{police_id}")

--- a/backend/src/modules/police/police_service.py
+++ b/backend/src/modules/police/police_service.py
@@ -106,9 +106,7 @@ class PoliceService:
             )
         return exporter.to_bytes()
 
-    async def update_police(
-        self, police_id: int, email: str, password: str, role: PoliceRole
-    ) -> PoliceAccountDto:
+    async def update_police(self, police_id: int, email: str, role: PoliceRole) -> PoliceAccountDto:
         police = await self._get_police_entity_by_id(police_id)
 
         if email.lower() != police.email.lower():
@@ -117,7 +115,6 @@ class PoliceService:
                 raise PoliceConflictException(email)
 
         police.email = email
-        police.hashed_password = hash_password(password)
         police.role = role
 
         try:

--- a/backend/src/modules/police/police_service.py
+++ b/backend/src/modules/police/police_service.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from fastapi import Depends, Request
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -5,11 +7,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.core.database import get_session
 from src.core.exceptions import ConflictException, CredentialsException, NotFoundException
 from src.core.utils.bcrypt_utils import hash_password, verify_password
+from src.core.utils.excel_utils import ExcelExporter
 from src.core.utils.query_utils import get_paginated_results, parse_pagination_params
 from src.modules.police.police_entity import PoliceEntity
 from src.modules.police.police_model import (
     PaginatedPoliceResponse,
     PoliceAccountDto,
+    PoliceRole,
 )
 
 
@@ -24,6 +28,8 @@ class PoliceConflictException(ConflictException):
 
 
 class PoliceService:
+    _ALLOWED_FIELDS: ClassVar[tuple[str, ...]] = ("id", "email", "role")
+
     def __init__(self, session: AsyncSession = Depends(get_session)):
         self.session = session
 
@@ -42,12 +48,16 @@ class PoliceService:
         )
         return result.scalar_one_or_none()
 
-    async def create_police(self, email: str, password: str) -> PoliceAccountDto:
+    async def create_police(self, email: str, password: str, role: PoliceRole) -> PoliceAccountDto:
         existing = await self._get_police_entity_by_email(email)
         if existing is not None:
             raise PoliceConflictException(email)
 
-        police = PoliceEntity(email=email, hashed_password=hash_password(password))
+        police = PoliceEntity(
+            email=email,
+            hashed_password=hash_password(password),
+            role=role,
+        )
         try:
             self.session.add(police)
             await self.session.commit()
@@ -62,7 +72,7 @@ class PoliceService:
         return police.to_dto()
 
     async def get_police_paginated(self, request: Request) -> PaginatedPoliceResponse:
-        allowed_fields = ["id", "email"]
+        allowed_fields = list(self._ALLOWED_FIELDS)
         base_query = select(PoliceEntity)
         query_params = parse_pagination_params(
             request,
@@ -80,7 +90,25 @@ class PoliceService:
         )
         return PaginatedPoliceResponse(**result.model_dump())
 
-    async def update_police(self, police_id: int, email: str, password: str) -> PoliceAccountDto:
+    async def get_police_for_export(self, request: Request) -> list[PoliceAccountDto]:
+        return (await self.get_police_paginated(request)).items
+
+    def export_police_to_excel(self, police_accounts: list[PoliceAccountDto]) -> bytes:
+        headers = ["Email", "Role"]
+        exporter = ExcelExporter(sheet_title="Police Accounts")
+        exporter.set_headers(headers)
+        for police in police_accounts:
+            exporter.add_row(
+                [
+                    police.email,
+                    "Police Admin" if police.role == PoliceRole.POLICE_ADMIN else "Officer",
+                ]
+            )
+        return exporter.to_bytes()
+
+    async def update_police(
+        self, police_id: int, email: str, password: str, role: PoliceRole
+    ) -> PoliceAccountDto:
         police = await self._get_police_entity_by_id(police_id)
 
         if email.lower() != police.email.lower():
@@ -90,6 +118,7 @@ class PoliceService:
 
         police.email = email
         police.hashed_password = hash_password(password)
+        police.role = role
 
         try:
             self.session.add(police)

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -26,7 +26,7 @@ from src.modules.auth.auth_service import AuthService
 from src.modules.incident.incident_service import IncidentService
 from src.modules.location.location_service import LocationService
 from src.modules.party.party_service import PartyService
-from src.modules.police.police_model import PoliceAccountDto
+from src.modules.police.police_model import PoliceAccountDto, PoliceRole
 from src.modules.police.police_service import PoliceService
 from src.modules.student.student_service import StudentService
 
@@ -123,8 +123,12 @@ async def create_test_client(
         # Generate JWT token based on role
         # Use fake DTOs — middleware reads from JWT only, no DB lookup needed.
         # Tests needing a real DB account use the student_client / student_account fixtures.
-        if role == "police":
-            police = PoliceAccountDto(id=99999, email="police@unc.edu")
+        if role in ("officer", "police_admin"):
+            police = PoliceAccountDto(
+                id=99999,
+                email=f"{role}@unc.edu",
+                role=PoliceRole(role),
+            )
             token, _ = auth_service.create_police_access_token(police)
         elif role in ("admin", "staff", "student"):
             fake_account = AccountDto(
@@ -197,7 +201,13 @@ async def student_client(
 
 @pytest_asyncio.fixture
 async def police_client(create_test_client: CreateClientCallable):
-    async for client in create_test_client("police"):
+    async for client in create_test_client("officer"):
+        yield client
+
+
+@pytest_asyncio.fixture
+async def police_admin_client(create_test_client: CreateClientCallable):
+    async for client in create_test_client("police_admin"):
         yield client
 
 

--- a/backend/test/modules/auth/auth_router_test.py
+++ b/backend/test/modules/auth/auth_router_test.py
@@ -9,7 +9,7 @@ from src.modules.auth.auth_service import (
     InvalidInternalSecretException,
     InvalidRefreshTokenException,
 )
-from src.modules.police.police_model import PoliceAccountDto
+from src.modules.police.police_model import PoliceAccountDto, PoliceRole
 from src.modules.student.student_model import StudentDto
 
 from test.modules.account.account_utils import AccountTestUtils
@@ -259,7 +259,12 @@ class TestAuthRouter:
 
         payload = self.auth_utils.decode_token(data.access_token)
         self.auth_utils.assert_police_token_payload(
-            payload, PoliceAccountDto(id=police_entity.id, email=police_entity.email)
+            payload,
+            PoliceAccountDto(
+                id=police_entity.id,
+                email=police_entity.email,
+                role=PoliceRole.OFFICER,
+            ),
         )
 
     @pytest.mark.asyncio

--- a/backend/test/modules/auth/auth_utils.py
+++ b/backend/test/modules/auth/auth_utils.py
@@ -114,7 +114,7 @@ class AuthTestUtils:
             payload = PoliceAccessTokenPayload(
                 sub=police.id,
                 email=police.email,
-                role="police",
+                role=police.role.value,
                 exp=expires_at,
                 iat=datetime.now(UTC),
             ).model_dump()
@@ -157,7 +157,7 @@ class AuthTestUtils:
             payload = payload.model_dump(mode="json")
         assert payload["sub"] == police.id
         assert payload["email"] == police.email
-        assert payload["role"] == "police"
+        assert payload["role"] == police.role.value
         for field in ("first_name", "last_name", "pid", "onyen"):
             assert field not in payload, f"Police token should not contain '{field}'"
 

--- a/backend/test/modules/incident/incident_csv_router_test.py
+++ b/backend/test/modules/incident/incident_csv_router_test.py
@@ -14,7 +14,7 @@ from test.utils.http.test_templates import (
 INCIDENT_HEADERS = ("Severity", "Address", "Date", "Time", "Description", "Reference ID")
 
 test_incident_csv_authentication = generate_auth_required_tests(
-    ({"admin", "staff", "police"}, "GET", "/api/incidents/csv", None),
+    ({"admin", "staff", "officer", "police_admin"}, "GET", "/api/incidents/csv", None),
 )
 
 test_incident_csv_empty = generate_csv_empty_test(

--- a/backend/test/modules/incident/incident_router_test.py
+++ b/backend/test/modules/incident/incident_router_test.py
@@ -13,11 +13,26 @@ from test.utils.http.assertions import (
 from test.utils.http.test_templates import generate_auth_required_tests
 
 test_incident_authentication = generate_auth_required_tests(
-    ({"admin", "staff", "police"}, "GET", "/api/incidents", None),
-    ({"admin", "staff", "police"}, "GET", "/api/locations/1/incidents", None),
-    ({"admin", "police"}, "POST", "/api/incidents", IncidentTestUtils.get_sample_create_data()),
-    ({"admin", "police"}, "PUT", "/api/incidents/1", IncidentTestUtils.get_sample_update_data()),
-    ({"admin", "police"}, "DELETE", "/api/incidents/1", None),
+    ({"admin", "staff", "officer", "police_admin"}, "GET", "/api/incidents", None),
+    (
+        {"admin", "staff", "officer", "police_admin"},
+        "GET",
+        "/api/locations/1/incidents",
+        None,
+    ),
+    (
+        {"admin", "officer", "police_admin"},
+        "POST",
+        "/api/incidents",
+        IncidentTestUtils.get_sample_create_data(),
+    ),
+    (
+        {"admin", "officer", "police_admin"},
+        "PUT",
+        "/api/incidents/1",
+        IncidentTestUtils.get_sample_update_data(),
+    ),
+    ({"admin", "officer", "police_admin"}, "DELETE", "/api/incidents/1", None),
 )
 
 

--- a/backend/test/modules/location/location_router_test.py
+++ b/backend/test/modules/location/location_router_test.py
@@ -57,7 +57,7 @@ test_location_authentication = generate_auth_required_tests(
     ({"admin"}, "PUT", "/api/locations/1", {"google_place_id": "ChIJ123abc"}),
     ({"admin"}, "DELETE", "/api/locations/1", None),
     (
-        {"admin", "staff", "student", "police"},
+        {"admin", "staff", "student", "officer", "police_admin"},
         "POST",
         "/api/locations/autocomplete",
         {"address": "123 Main St"},

--- a/backend/test/modules/party/party_router_test.py
+++ b/backend/test/modules/party/party_router_test.py
@@ -33,12 +33,12 @@ from test.utils.http.assertions import (
 from test.utils.http.test_templates import generate_auth_required_tests
 
 test_party_authentication = generate_auth_required_tests(
-    ({"admin", "staff", "police"}, "GET", "/api/parties", None),
-    ({"admin", "staff", "police"}, "GET", "/api/parties/csv", None),
+    ({"admin", "staff", "officer", "police_admin"}, "GET", "/api/parties", None),
+    ({"admin", "staff", "officer", "police_admin"}, "GET", "/api/parties/csv", None),
     ({"admin", "staff"}, "GET", "/api/parties/1", None),
     ({"student", "admin"}, "DELETE", "/api/parties/1", None),
     (
-        {"admin", "police"},
+        {"admin", "officer", "police_admin"},
         "GET",
         "/api/parties/nearby?place_id=ChIJTest&start_date=2025-01-01&end_date=2025-12-31",
         None,

--- a/backend/test/modules/police/police_router_test.py
+++ b/backend/test/modules/police/police_router_test.py
@@ -9,14 +9,25 @@ from test.utils.http.assertions import (
     assert_res_success,
     assert_res_validation_error,
 )
-from test.utils.http.test_templates import generate_auth_required_tests
+from test.utils.http.test_templates import assert_excel_response, generate_auth_required_tests
 
 test_police_auth = generate_auth_required_tests(
-    ({"admin"}, "GET", "/api/accounts/police", None),
-    ({"admin"}, "POST", "/api/accounts/police", {"email": "x@unc.edu", "password": "pass"}),
-    ({"admin"}, "GET", "/api/accounts/police/1", None),
-    ({"admin"}, "PUT", "/api/accounts/police/1", {"email": "x@unc.edu", "password": "pass"}),
-    ({"admin"}, "DELETE", "/api/accounts/police/1", None),
+    ({"admin", "police_admin"}, "GET", "/api/police", None),
+    (
+        {"admin", "police_admin"},
+        "POST",
+        "/api/police",
+        {"email": "x@unc.edu", "password": "pass", "role": "officer"},
+    ),
+    ({"admin", "police_admin"}, "GET", "/api/police/1", None),
+    (
+        {"admin", "police_admin"},
+        "PUT",
+        "/api/police/1",
+        {"email": "x@unc.edu", "password": "pass", "role": "officer"},
+    ),
+    ({"admin", "police_admin"}, "DELETE", "/api/police/1", None),
+    ({"admin", "police_admin"}, "GET", "/api/police/csv", None),
 )
 
 
@@ -32,7 +43,7 @@ class TestPoliceListRouter:
     @pytest.mark.asyncio
     async def test_list_police_empty(self) -> None:
         """Test listing police when none exist returns empty paginated response."""
-        response = await self.admin_client.get("/api/accounts/police")
+        response = await self.admin_client.get("/api/police")
         assert_res_paginated(response, PoliceAccountDto, total_records=0)
 
     @pytest.mark.asyncio
@@ -40,7 +51,7 @@ class TestPoliceListRouter:
         """Test listing police returns all created accounts."""
         police1, police2 = await self.police_utils.create_many(i=2)
 
-        response = await self.admin_client.get("/api/accounts/police")
+        response = await self.admin_client.get("/api/police")
         paginated = assert_res_paginated(response, PoliceAccountDto, total_records=2)
 
         returned = {item.id: item for item in paginated.items}
@@ -53,7 +64,7 @@ class TestPoliceListRouter:
         await self.police_utils.create_many(i=3)
 
         response = await self.admin_client.get(
-            "/api/accounts/police", params={"sort_by": "email", "sort_order": "asc"}
+            "/api/police", params={"sort_by": "email", "sort_order": "asc"}
         )
 
         paginated = assert_res_paginated(response, PoliceAccountDto, total_records=3)
@@ -67,7 +78,7 @@ class TestPoliceListRouter:
         await self.police_utils.create_many(i=2)
 
         response = await self.admin_client.get(
-            "/api/accounts/police", params={"email_contains": police.email}
+            "/api/police", params={"email_contains": police.email}
         )
 
         paginated = assert_res_paginated(response, PoliceAccountDto)
@@ -80,13 +91,30 @@ class TestPoliceListRouter:
         await self.police_utils.create_many(i=3)
 
         response = await self.admin_client.get(
-            "/api/accounts/police", params={"page_number": 1, "page_size": 2}
+            "/api/police", params={"page_number": 1, "page_size": 2}
         )
-
         paginated = assert_res_paginated(
             response, PoliceAccountDto, total_records=3, page_number=1, page_size=2
         )
         assert len(paginated.items) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_police_filter_by_role(self) -> None:
+        await self.police_utils.create_one(role="police_admin")
+        await self.police_utils.create_many(i=2, role="officer")
+
+        response = await self.admin_client.get("/api/police", params={"role": "police_admin"})
+        paginated = assert_res_paginated(response, PoliceAccountDto, total_records=1)
+        assert paginated.items[0].role.value == "police_admin"
+
+    @pytest.mark.asyncio
+    async def test_get_police_csv(self) -> None:
+        await self.police_utils.create_one(role="police_admin")
+        await self.police_utils.create_one(role="officer")
+
+        response = await self.admin_client.get("/api/police/csv")
+        rows = assert_excel_response(response, expected_headers=("Email", "Role"))
+        assert len(rows) == 3
 
 
 class TestPoliceCRUDRouter:
@@ -103,9 +131,7 @@ class TestPoliceCRUDRouter:
         """Test creating a new police account returns 201 with PoliceAccountDto."""
         data = await self.police_utils.next_data()
 
-        response = await self.admin_client.post(
-            "/api/accounts/police", json=data.model_dump(mode="json")
-        )
+        response = await self.admin_client.post("/api/police", json=data.model_dump(mode="json"))
 
         result = assert_res_success(response, PoliceAccountDto, status=201)
         assert result.email == data.email
@@ -117,9 +143,7 @@ class TestPoliceCRUDRouter:
         police = await self.police_utils.create_one()
         data = await self.police_utils.next_data(email=police.email)
 
-        response = await self.admin_client.post(
-            "/api/accounts/police", json=data.model_dump(mode="json")
-        )
+        response = await self.admin_client.post("/api/police", json=data.model_dump(mode="json"))
 
         assert_res_failure(response, PoliceConflictException(police.email))
 
@@ -128,7 +152,7 @@ class TestPoliceCRUDRouter:
         """Test creating a police account with invalid email returns 422."""
         data = await self.police_utils.next_dict(email="not-an-email")
 
-        response = await self.admin_client.post("/api/accounts/police", json=data)
+        response = await self.admin_client.post("/api/police", json=data)
 
         assert_res_validation_error(response, expected_fields=["email"])
 
@@ -137,7 +161,7 @@ class TestPoliceCRUDRouter:
         """Test getting a police account by ID."""
         police = await self.police_utils.create_one()
 
-        response = await self.admin_client.get(f"/api/accounts/police/{police.id}")
+        response = await self.admin_client.get(f"/api/police/{police.id}")
 
         result = assert_res_success(response, PoliceAccountDto)
         self.police_utils.assert_matches(police, result)
@@ -145,7 +169,7 @@ class TestPoliceCRUDRouter:
     @pytest.mark.asyncio
     async def test_get_police_by_id_not_found(self) -> None:
         """Test getting a non-existent police account returns 404."""
-        response = await self.admin_client.get("/api/accounts/police/99999")
+        response = await self.admin_client.get("/api/police/99999")
 
         assert_res_failure(response, PoliceNotFoundException(99999))
 
@@ -156,13 +180,14 @@ class TestPoliceCRUDRouter:
         update_data = await self.police_utils.next_data()
 
         response = await self.admin_client.put(
-            f"/api/accounts/police/{police.id}",
+            f"/api/police/{police.id}",
             json=update_data.model_dump(mode="json"),
         )
 
         result = assert_res_success(response, PoliceAccountDto)
         assert result.id == police.id
         assert result.email == update_data.email
+        assert result.role == update_data.role
 
     @pytest.mark.asyncio
     async def test_update_police_not_found(self) -> None:
@@ -170,7 +195,7 @@ class TestPoliceCRUDRouter:
         data = await self.police_utils.next_data()
 
         response = await self.admin_client.put(
-            "/api/accounts/police/99999", json=data.model_dump(mode="json")
+            "/api/police/99999", json=data.model_dump(mode="json")
         )
 
         assert_res_failure(response, PoliceNotFoundException(99999))
@@ -183,7 +208,7 @@ class TestPoliceCRUDRouter:
         data = await self.police_utils.next_data(email=police2.email)
 
         response = await self.admin_client.put(
-            f"/api/accounts/police/{police1.id}",
+            f"/api/police/{police1.id}",
             json=data.model_dump(mode="json"),
         )
 
@@ -197,7 +222,7 @@ class TestPoliceCRUDRouter:
         data = await self.police_utils.next_data(password=plain_password)
 
         await self.admin_client.put(
-            f"/api/accounts/police/{police.id}",
+            f"/api/police/{police.id}",
             json=data.model_dump(mode="json"),
         )
 
@@ -212,7 +237,7 @@ class TestPoliceCRUDRouter:
         """Test deleting a police account."""
         police = await self.police_utils.create_one()
 
-        response = await self.admin_client.delete(f"/api/accounts/police/{police.id}")
+        response = await self.admin_client.delete(f"/api/police/{police.id}")
 
         result = assert_res_success(response, PoliceAccountDto)
         self.police_utils.assert_matches(police, result)
@@ -223,6 +248,6 @@ class TestPoliceCRUDRouter:
     @pytest.mark.asyncio
     async def test_delete_police_not_found(self) -> None:
         """Test deleting a non-existent police account returns 404."""
-        response = await self.admin_client.delete("/api/accounts/police/99999")
+        response = await self.admin_client.delete("/api/police/99999")
 
         assert_res_failure(response, PoliceNotFoundException(99999))

--- a/backend/test/modules/police/police_router_test.py
+++ b/backend/test/modules/police/police_router_test.py
@@ -24,7 +24,7 @@ test_police_auth = generate_auth_required_tests(
         {"admin", "police_admin"},
         "PUT",
         "/api/police/1",
-        {"email": "x@unc.edu", "password": "pass", "role": "officer"},
+        {"email": "x@unc.edu", "role": "officer"},
     ),
     ({"admin", "police_admin"}, "DELETE", "/api/police/1", None),
     ({"admin", "police_admin"}, "GET", "/api/police/csv", None),
@@ -177,7 +177,7 @@ class TestPoliceCRUDRouter:
     async def test_update_police_success(self) -> None:
         """Test updating a police account."""
         police = await self.police_utils.create_one()
-        update_data = await self.police_utils.next_data()
+        update_data = await self.police_utils.next_update_data()
 
         response = await self.admin_client.put(
             f"/api/police/{police.id}",
@@ -192,7 +192,7 @@ class TestPoliceCRUDRouter:
     @pytest.mark.asyncio
     async def test_update_police_not_found(self) -> None:
         """Test updating a non-existent police account returns 404."""
-        data = await self.police_utils.next_data()
+        data = await self.police_utils.next_update_data()
 
         response = await self.admin_client.put(
             "/api/police/99999", json=data.model_dump(mode="json")
@@ -205,7 +205,7 @@ class TestPoliceCRUDRouter:
         """Test updating to a duplicate email returns 409."""
         police1 = await self.police_utils.create_one()
         police2 = await self.police_utils.create_one()
-        data = await self.police_utils.next_data(email=police2.email)
+        data = await self.police_utils.next_update_data(email=police2.email)
 
         response = await self.admin_client.put(
             f"/api/police/{police1.id}",
@@ -215,11 +215,11 @@ class TestPoliceCRUDRouter:
         assert_res_failure(response, PoliceConflictException(police2.email))
 
     @pytest.mark.asyncio
-    async def test_update_police_password_is_hashed(self) -> None:
-        """Test that password is hashed when updating police credentials."""
+    async def test_update_police_password_unchanged(self) -> None:
+        """Test updating police account does not modify password hash."""
         police = await self.police_utils.create_one()
-        plain_password = "my_plain_password_123"
-        data = await self.police_utils.next_data(password=plain_password)
+        original_hashed_password = police.hashed_password
+        data = await self.police_utils.next_update_data()
 
         await self.admin_client.put(
             f"/api/police/{police.id}",
@@ -229,8 +229,7 @@ class TestPoliceCRUDRouter:
         all_police = await self.police_utils.get_all()
         all_by_id = {p.id: p for p in all_police}
         updated = all_by_id[police.id]
-        assert updated.hashed_password != plain_password
-        assert self.police_utils.verify_password(plain_password, updated.hashed_password)
+        assert updated.hashed_password == original_hashed_password
 
     @pytest.mark.asyncio
     async def test_delete_police_success(self) -> None:

--- a/backend/test/modules/police/police_router_test.py
+++ b/backend/test/modules/police/police_router_test.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import AsyncClient
+from src.core.exceptions import ForbiddenException
 from src.modules.police.police_model import PoliceAccountDto
 from src.modules.police.police_service import PoliceConflictException, PoliceNotFoundException
 from test.modules.police.police_utils import PoliceTestUtils
@@ -119,11 +120,18 @@ class TestPoliceListRouter:
 
 class TestPoliceCRUDRouter:
     admin_client: AsyncClient
+    police_admin_client: AsyncClient
     police_utils: PoliceTestUtils
 
     @pytest.fixture(autouse=True)
-    def _setup(self, admin_client: AsyncClient, police_utils: PoliceTestUtils):
+    def _setup(
+        self,
+        admin_client: AsyncClient,
+        police_admin_client: AsyncClient,
+        police_utils: PoliceTestUtils,
+    ):
         self.admin_client = admin_client
+        self.police_admin_client = police_admin_client
         self.police_utils = police_utils
 
     @pytest.mark.asyncio
@@ -250,3 +258,10 @@ class TestPoliceCRUDRouter:
         response = await self.admin_client.delete("/api/police/99999")
 
         assert_res_failure(response, PoliceNotFoundException(99999))
+
+    @pytest.mark.asyncio
+    async def test_police_admin_cannot_delete_own_account(self) -> None:
+        response = await self.police_admin_client.delete("/api/police/99999")
+        assert_res_failure(
+            response, ForbiddenException("Police admins cannot delete their own account")
+        )

--- a/backend/test/modules/police/police_service_test.py
+++ b/backend/test/modules/police/police_service_test.py
@@ -76,7 +76,6 @@ class TestPoliceService:
         result = await self.police_service.update_police(
             police_entity.id,
             "updated@unc.edu",
-            "newpassword",
             police_entity.role,
         )
 
@@ -91,7 +90,6 @@ class TestPoliceService:
         result = await self.police_service.update_police(
             police_entity.id,
             police_entity.email,
-            "newpassword",
             PoliceRole.POLICE_ADMIN,
         )
         assert result.role == PoliceRole.POLICE_ADMIN
@@ -104,7 +102,6 @@ class TestPoliceService:
             await self.police_service.update_police(
                 99999,
                 "updated@unc.edu",
-                "newpassword",
                 data.role,
             )
 
@@ -118,9 +115,23 @@ class TestPoliceService:
             await self.police_service.update_police(
                 police1.id,
                 police2.email,
-                "newpassword",
                 police1.role,
             )
+
+    @pytest.mark.asyncio
+    async def test_update_police_does_not_change_password(self) -> None:
+        police_entity = await self.police_utils.create_one()
+        original_hashed_password = police_entity.hashed_password
+
+        await self.police_service.update_police(
+            police_entity.id,
+            "updated-no-password@unc.edu",
+            police_entity.role,
+        )
+
+        all_police = await self.police_utils.get_all()
+        updated = next(p for p in all_police if p.id == police_entity.id)
+        assert updated.hashed_password == original_hashed_password
 
     @pytest.mark.asyncio
     async def test_delete_police_success(self) -> None:

--- a/backend/test/modules/police/police_service_test.py
+++ b/backend/test/modules/police/police_service_test.py
@@ -1,6 +1,6 @@
 import pytest
 from src.core.exceptions import CredentialsException
-from src.modules.police.police_model import PoliceAccountDto
+from src.modules.police.police_model import PoliceAccountDto, PoliceRole
 from src.modules.police.police_service import (
     PoliceConflictException,
     PoliceNotFoundException,
@@ -43,7 +43,7 @@ class TestPoliceService:
         """Test successfully creating a new police account."""
         data = await self.police_utils.next_data()
 
-        result = await self.police_service.create_police(data.email, data.password)
+        result = await self.police_service.create_police(data.email, data.password, data.role)
 
         assert isinstance(result, PoliceAccountDto)
         assert result.email == data.email
@@ -55,7 +55,11 @@ class TestPoliceService:
         police_entity = await self.police_utils.create_one()
 
         with pytest.raises(PoliceConflictException):
-            await self.police_service.create_police(police_entity.email, "newpassword")
+            await self.police_service.create_police(
+                police_entity.email,
+                "newpassword",
+                police_entity.role,
+            )
 
     @pytest.mark.asyncio
     async def test_create_multiple_police(self) -> None:
@@ -70,18 +74,39 @@ class TestPoliceService:
         police_entity = await self.police_utils.create_one()
 
         result = await self.police_service.update_police(
-            police_entity.id, "updated@unc.edu", "newpassword"
+            police_entity.id,
+            "updated@unc.edu",
+            "newpassword",
+            police_entity.role,
         )
 
         assert isinstance(result, PoliceAccountDto)
         assert result.id == police_entity.id
         assert result.email == "updated@unc.edu"
+        assert result.role == police_entity.role
+
+    @pytest.mark.asyncio
+    async def test_update_police_role_success(self) -> None:
+        police_entity = await self.police_utils.create_one(role=PoliceRole.OFFICER)
+        result = await self.police_service.update_police(
+            police_entity.id,
+            police_entity.email,
+            "newpassword",
+            PoliceRole.POLICE_ADMIN,
+        )
+        assert result.role == PoliceRole.POLICE_ADMIN
 
     @pytest.mark.asyncio
     async def test_update_police_not_found(self) -> None:
         """Test updating non-existent police raises PoliceNotFoundException."""
+        data = await self.police_utils.next_data()
         with pytest.raises(PoliceNotFoundException):
-            await self.police_service.update_police(99999, "updated@unc.edu", "newpassword")
+            await self.police_service.update_police(
+                99999,
+                "updated@unc.edu",
+                "newpassword",
+                data.role,
+            )
 
     @pytest.mark.asyncio
     async def test_update_police_duplicate_email(self) -> None:
@@ -90,7 +115,12 @@ class TestPoliceService:
         police2 = await self.police_utils.create_one()
 
         with pytest.raises(PoliceConflictException):
-            await self.police_service.update_police(police1.id, police2.email, "newpassword")
+            await self.police_service.update_police(
+                police1.id,
+                police2.email,
+                "newpassword",
+                police1.role,
+            )
 
     @pytest.mark.asyncio
     async def test_delete_police_success(self) -> None:

--- a/backend/test/modules/police/police_utils.py
+++ b/backend/test/modules/police/police_utils.py
@@ -3,13 +3,14 @@ from typing import Any, TypedDict, Unpack, override
 import bcrypt
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.modules.police.police_entity import PoliceEntity
-from src.modules.police.police_model import PoliceAccountDto, PoliceAccountUpdate
+from src.modules.police.police_model import PoliceAccountDto, PoliceAccountUpdate, PoliceRole
 from test.utils.resource_test_utils import ResourceTestUtils
 
 
 class PoliceUpdateOverrides(TypedDict, total=False):
     email: str
     password: str
+    role: PoliceRole
 
 
 class PoliceTestUtils(
@@ -34,6 +35,7 @@ class PoliceTestUtils(
         return {
             "email": f"police{count}@unc.edu",
             "password": PoliceTestUtils.TEST_PASSWORD,
+            "role": PoliceRole.OFFICER,
         }
 
     @override
@@ -48,6 +50,9 @@ class PoliceTestUtils(
 
         assert resource1.email == resource2.email, (
             f"Email mismatch: {resource1.email} != {resource2.email}"
+        )
+        assert resource1.role == resource2.role, (
+            f"Role mismatch: {resource1.role} != {resource2.role}"
         )
 
         if isinstance(resource1, PoliceEntity) and isinstance(resource2, PoliceEntity):

--- a/backend/test/modules/police/police_utils.py
+++ b/backend/test/modules/police/police_utils.py
@@ -3,7 +3,12 @@ from typing import Any, TypedDict, Unpack, override
 import bcrypt
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.modules.police.police_entity import PoliceEntity
-from src.modules.police.police_model import PoliceAccountDto, PoliceAccountUpdate, PoliceRole
+from src.modules.police.police_model import (
+    PoliceAccountCreate,
+    PoliceAccountDto,
+    PoliceAccountUpdate,
+    PoliceRole,
+)
 from test.utils.resource_test_utils import ResourceTestUtils
 
 
@@ -16,7 +21,7 @@ class PoliceUpdateOverrides(TypedDict, total=False):
 class PoliceTestUtils(
     ResourceTestUtils[
         PoliceEntity,
-        PoliceAccountUpdate,
+        PoliceAccountCreate,
         PoliceAccountDto,
     ]
 ):
@@ -26,7 +31,7 @@ class PoliceTestUtils(
         super().__init__(
             session,
             entity_class=PoliceEntity,
-            data_class=PoliceAccountUpdate,
+            data_class=PoliceAccountCreate,
         )
 
     @override
@@ -41,8 +46,8 @@ class PoliceTestUtils(
     @override
     def assert_matches(
         self,
-        resource1: PoliceEntity | PoliceAccountUpdate | PoliceAccountDto | None,
-        resource2: PoliceEntity | PoliceAccountUpdate | PoliceAccountDto | None,
+        resource1: PoliceEntity | PoliceAccountCreate | PoliceAccountDto | None,
+        resource2: PoliceEntity | PoliceAccountCreate | PoliceAccountDto | None,
     ) -> None:
         """Assert that two police resources match."""
         assert resource1 is not None, "First resource is None"
@@ -70,8 +75,8 @@ class PoliceTestUtils(
         if isinstance(resource1, PoliceAccountDto) and isinstance(resource2, PoliceEntity):
             assert resource1.id == resource2.id, f"ID mismatch: {resource1.id} != {resource2.id}"
 
-        if isinstance(resource1, PoliceAccountUpdate) and isinstance(
-            resource2, PoliceAccountUpdate
+        if isinstance(resource1, PoliceAccountCreate) and isinstance(
+            resource2, PoliceAccountCreate
         ):
             assert resource1.password == resource2.password, (
                 f"Password mismatch: {resource1.password} != {resource2.password}"
@@ -100,8 +105,18 @@ class PoliceTestUtils(
         return await super().next_dict(**overrides)
 
     @override
-    async def next_data(self, **overrides: Unpack[PoliceUpdateOverrides]) -> PoliceAccountUpdate:
+    async def next_data(self, **overrides: Unpack[PoliceUpdateOverrides]) -> PoliceAccountCreate:
         return await super().next_data(**overrides)
+
+    async def next_update_dict(self, **overrides: Unpack[PoliceUpdateOverrides]) -> dict:
+        data = await self.next_data(**overrides)
+        return {"email": data.email, "role": data.role.value}
+
+    async def next_update_data(
+        self, **overrides: Unpack[PoliceUpdateOverrides]
+    ) -> PoliceAccountUpdate:
+        data = await self.next_data(**overrides)
+        return PoliceAccountUpdate(email=data.email, role=data.role)
 
     @override
     async def next_entity(self, **overrides: Unpack[PoliceUpdateOverrides]) -> PoliceEntity:

--- a/backend/test/utils/http/test_templates.py
+++ b/backend/test/utils/http/test_templates.py
@@ -10,7 +10,7 @@ from src.core.authentication import StringRole
 from src.core.exceptions import CredentialsException, ForbiddenException
 from test.utils.http.assertions import assert_res_failure, assert_res_paginated
 
-all_roles: set[StringRole] = {"admin", "staff", "student", "police"}
+all_roles: set[StringRole] = {"admin", "staff", "student", "officer", "police_admin"}
 
 
 def generate_auth_required_tests(*params: tuple[set[StringRole], str, str, dict | None]):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -121,7 +121,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -714,7 +713,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1938,7 +1936,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4197,7 +4194,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
       "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4208,7 +4204,6 @@
       "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4219,7 +4214,6 @@
       "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4282,7 +4276,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -4859,7 +4852,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5339,7 +5331,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6311,7 +6302,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6485,7 +6475,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7673,7 +7662,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9843,7 +9831,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9877,7 +9864,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10136,7 +10122,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10167,7 +10152,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10180,7 +10164,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.65.0.tgz",
       "integrity": "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11389,7 +11372,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11648,7 +11630,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12290,7 +12271,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/shared/mock_data.json
+++ b/frontend/shared/mock_data.json
@@ -2,13 +2,15 @@
   "police": [
     {
       "id": 1,
-      "email": "police@example.com",
-      "password": "securepassword"
+      "email": "officer@example.com",
+      "password": "securepassword",
+      "role": "officer"
     },
     {
       "id": 2,
-      "email": "police2@example.com",
-      "password": "securepassword"
+      "email": "policeadmin@example.com",
+      "password": "securepassword",
+      "role": "police_admin"
     }
   ],
   "accounts": [

--- a/frontend/src/app/api/auth/police/login/route.ts
+++ b/frontend/src/app/api/auth/police/login/route.ts
@@ -3,6 +3,7 @@ import {
   policeLogin,
   setAuthCookies,
 } from "@/lib/api/auth/auth.service";
+import { PoliceRole } from "@/lib/api/police/police.types";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(req: NextRequest) {
@@ -22,6 +23,13 @@ export async function POST(req: NextRequest) {
     const data = await policeLogin({ email, password });
 
     const payload = decodeJwtPayload(data.access_token);
+    const payloadRole = payload.role;
+    if (payloadRole !== "officer" && payloadRole !== "police_admin") {
+      return NextResponse.json(
+        { error: "Invalid token role" },
+        { status: 401 }
+      );
+    }
     const policeId = String(payload.sub);
 
     const res = NextResponse.json({ ok: true });
@@ -31,7 +39,7 @@ export async function POST(req: NextRequest) {
       id: policeId,
       email: payload.email,
       name: payload.email,
-      role: "police",
+      role: payloadRole as PoliceRole,
     });
 
     return res;

--- a/frontend/src/app/police/admin/_components/PoliceAdminTable.tsx
+++ b/frontend/src/app/police/admin/_components/PoliceAdminTable.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import PoliceAccountForm, {
+  type PoliceAccountFormValues,
+} from "@/app/staff/_components/account/PoliceAccountForm";
+import { useSidebar } from "@/app/staff/_components/shared/sidebar/SidebarContext";
+import { TableTemplate } from "@/app/staff/_components/shared/table/TableTemplate";
+import { Button } from "@/components/ui/button";
+import { useSnackbar } from "@/contexts/SnackbarContext";
+import {
+  useDeletePoliceAccount,
+  useDownloadPoliceAccountsCsv,
+  usePoliceAccountsPaginated,
+  useUpdatePoliceAccount,
+} from "@/lib/api/account/account.queries";
+import type {
+  PoliceAccountDto,
+  PoliceAccountUpdate,
+} from "@/lib/api/police/police.types";
+import {
+  DEFAULT_TABLE_PARAMS,
+  type ServerColumnMap,
+  type ServerTableParams,
+} from "@/lib/api/shared/query-params";
+import { formatRoleLabel } from "@/lib/utils";
+import { ColumnDef } from "@tanstack/react-table";
+import { Download } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { useMemo, useState } from "react";
+
+const SERVER_COLUMN_MAP: ServerColumnMap = {
+  email: { backendField: "email", filterOperator: "contains" },
+  role: { backendField: "role", filterOperator: "eq" },
+};
+
+export default function PoliceAdminTable() {
+  const { data: session } = useSession();
+  const { openSidebar, closeSidebar } = useSidebar();
+  const { openSnackbar } = useSnackbar();
+  const [serverParams, setServerParams] =
+    useState<ServerTableParams>(DEFAULT_TABLE_PARAMS);
+
+  const policeAccountsQuery = usePoliceAccountsPaginated(serverParams);
+  const downloadPoliceAccountsCsv = useDownloadPoliceAccountsCsv({
+    onError: (error: Error) => {
+      openSnackbar(
+        error.message || "Failed to export police accounts",
+        "error"
+      );
+    },
+  });
+
+  const updatePoliceAccountMutation = useUpdatePoliceAccount({
+    onError: (
+      error: Error,
+      variables: { id: number; data: PoliceAccountUpdate }
+    ) => {
+      openSidebar(
+        `edit-police-${variables.id}`,
+        "Edit Police Account",
+        "Update police account credentials",
+        <PoliceAccountForm
+          title="Edit Police Account"
+          onSubmit={(data) => handlePoliceEditSubmit(variables.id, data)}
+          submissionError={error.message}
+          editData={{ email: variables.data.email, role: variables.data.role }}
+        />
+      );
+    },
+    onSuccess: () => {
+      closeSidebar();
+      openSnackbar("Police account updated successfully", "success");
+    },
+  });
+
+  const deletePoliceAccountMutation = useDeletePoliceAccount({
+    onSuccess: () => {
+      openSnackbar("Police account deleted successfully", "success");
+    },
+    onError: (error: Error) => {
+      openSnackbar(error.message || "Failed to delete police account", "error");
+    },
+  });
+
+  const currentPoliceId = session?.id ? Number(session.id) : null;
+
+  const handleEdit = (row: PoliceAccountDto) => {
+    openSidebar(
+      `edit-police-${row.id}`,
+      "Edit Police Account",
+      "Update police account credentials",
+      <PoliceAccountForm
+        title="Edit Police Account"
+        onSubmit={(data) => handlePoliceEditSubmit(row.id, data)}
+        editData={{ email: row.email, role: row.role }}
+      />
+    );
+  };
+
+  const handleDelete = (row: PoliceAccountDto) => {
+    if (row.id === currentPoliceId) {
+      openSnackbar("You cannot delete your own account", "error");
+      return;
+    }
+    deletePoliceAccountMutation.mutate(row.id);
+  };
+
+  const handlePoliceEditSubmit = async (
+    policeId: number,
+    data: PoliceAccountFormValues
+  ) => {
+    updatePoliceAccountMutation.mutate({
+      id: policeId,
+      data: {
+        email: data.email,
+        password: data.password,
+        role: data.role,
+      },
+    });
+  };
+
+  const columns: ColumnDef<PoliceAccountDto>[] = useMemo(
+    () => [
+      {
+        accessorKey: "email",
+        header: "Email",
+        enableColumnFilter: true,
+      },
+      {
+        accessorKey: "role",
+        header: "Role",
+        enableColumnFilter: true,
+        cell: ({ row }) =>
+          formatRoleLabel(row.getValue("role") as PoliceAccountDto["role"]),
+      },
+    ],
+    []
+  );
+
+  const tableData = policeAccountsQuery.data?.items ?? [];
+
+  return (
+    <div className="h-full min-h-0 flex flex-col gap-4">
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          onClick={() => downloadPoliceAccountsCsv.mutate(serverParams)}
+          disabled={downloadPoliceAccountsCsv.isPending}
+        >
+          <Download className="mr-2 h-4 w-4" />
+          {downloadPoliceAccountsCsv.isPending
+            ? "Exporting..."
+            : "Export Excel"}
+        </Button>
+      </div>
+      <TableTemplate
+        data={tableData}
+        columns={columns}
+        resourceName="Police Account"
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        isLoading={policeAccountsQuery.isLoading}
+        isFetching={policeAccountsQuery.isFetching}
+        error={(policeAccountsQuery.error as Error | null) ?? null}
+        getDeleteDescription={(row: PoliceAccountDto) =>
+          `Are you sure you want to delete police account ${row.email}? This action cannot be undone.`
+        }
+        isDeleting={deletePoliceAccountMutation.isPending}
+        serverMeta={
+          policeAccountsQuery.data
+            ? {
+                totalRecords: policeAccountsQuery.data.total_records,
+                totalPages: policeAccountsQuery.data.total_pages,
+              }
+            : undefined
+        }
+        onStateChange={setServerParams}
+        columnMap={SERVER_COLUMN_MAP}
+        canManageRows={session?.role === "police_admin"}
+        canDeleteRow={(row) => row.id !== currentPoliceId}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/police/admin/_components/PoliceAdminTable.tsx
+++ b/frontend/src/app/police/admin/_components/PoliceAdminTable.tsx
@@ -113,7 +113,6 @@ export default function PoliceAdminTable() {
       id: policeId,
       data: {
         email: data.email,
-        password: data.password,
         role: data.role,
       },
     });

--- a/frontend/src/app/police/admin/page.tsx
+++ b/frontend/src/app/police/admin/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import PoliceAdminTable from "@/app/police/admin/_components/PoliceAdminTable";
+import GenericSidebar from "@/app/staff/_components/shared/sidebar/GenericSidebar";
+import { SidebarProvider } from "@/app/staff/_components/shared/sidebar/SidebarContext";
+
+export default function PoliceAdminPage() {
+  return (
+    <SidebarProvider>
+      <main className="h-[calc(100vh-var(--app-header-height))] overflow-hidden bg-background px-4 py-4 md:px-6 md:py-6">
+        <div className="mx-auto h-full max-w-6xl min-h-0 flex flex-col">
+          <header className="mb-4">
+            <h1 className="page-title text-secondary">
+              Police Admin Dashboard
+            </h1>
+          </header>
+          <div className="flex-1 min-h-0">
+            <PoliceAdminTable />
+          </div>
+        </div>
+      </main>
+      <GenericSidebar />
+    </SidebarProvider>
+  );
+}

--- a/frontend/src/app/staff/_components/account/AccountTable.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTable.tsx
@@ -310,7 +310,6 @@ export const AccountTable = () => {
       id: policeId,
       data: {
         email: data.email,
-        password: data.password,
         role: data.role as PoliceRole,
       },
     });

--- a/frontend/src/app/staff/_components/account/AccountTable.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTable.tsx
@@ -15,12 +15,16 @@ import type {
   AccountRole,
   AccountTableRow,
 } from "@/lib/api/account/account.types";
-import type { PoliceAccountUpdate } from "@/lib/api/police/police.types";
+import type {
+  PoliceAccountUpdate,
+  PoliceRole,
+} from "@/lib/api/police/police.types";
 import {
   DEFAULT_TABLE_PARAMS,
   ServerColumnMap,
   ServerTableParams,
 } from "@/lib/api/shared/query-params";
+import { formatRoleLabel } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { isAxiosError } from "axios";
 import { useMemo, useState } from "react";
@@ -84,7 +88,7 @@ export const AccountTable = () => {
         last_name: "-",
         pid: "-",
         onyen: "-",
-        role: "police" as const,
+        role: p.role,
         _isPolice: true,
       })
     );
@@ -190,7 +194,7 @@ export const AccountTable = () => {
           title="Edit Police Account"
           onSubmit={(data) => handlePoliceEditSubmit(variables.id, data)}
           submissionError={errorMessage}
-          editData={{ email: variables.data.email }}
+          editData={{ email: variables.data.email, role: variables.data.role }}
         />
       );
     },
@@ -225,7 +229,7 @@ export const AccountTable = () => {
         <PoliceAccountForm
           title="Edit Police Account"
           onSubmit={(data) => handlePoliceEditSubmit(row.id, data)}
-          editData={{ email: row.email }}
+          editData={{ email: row.email, role: row.role as PoliceRole }}
         />
       );
     } else {
@@ -307,6 +311,7 @@ export const AccountTable = () => {
       data: {
         email: data.email,
         password: data.password,
+        role: data.role as PoliceRole,
       },
     });
   };
@@ -342,8 +347,8 @@ export const AccountTable = () => {
       header: "Role",
       enableColumnFilter: true,
       cell: ({ row }) => {
-        const role = row.getValue("role") as string;
-        return role.charAt(0).toUpperCase() + role.slice(1);
+        const role = row.getValue("role") as AccountTableRow["role"];
+        return formatRoleLabel(role);
       },
     },
   ];

--- a/frontend/src/app/staff/_components/account/PoliceAccountForm.tsx
+++ b/frontend/src/app/staff/_components/account/PoliceAccountForm.tsx
@@ -22,7 +22,6 @@ import * as z from "zod";
 
 export const policeAccountFormSchema = z.object({
   email: z.email({ pattern: z.regexes.html5Email }).min(1, "Email is required"),
-  password: z.string().min(1, "Password is required"),
   role: z.enum(["officer", "police_admin"]),
 });
 
@@ -43,7 +42,6 @@ export default function PoliceAccountForm({
 }: PoliceAccountFormProps) {
   const [formData, setFormData] = useState<Partial<PoliceAccountFormValues>>({
     email: editData?.email ?? "",
-    password: "",
     role: editData?.role ?? "officer",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -112,19 +110,6 @@ export default function PoliceAccountForm({
               aria-invalid={!!errors.email}
             />
             {errors.email && <FieldError>{errors.email}</FieldError>}
-          </Field>
-
-          <Field data-invalid={!!errors.password}>
-            <FieldLabel htmlFor="police-password">Password</FieldLabel>
-            <Input
-              id="police-password"
-              type="password"
-              placeholder="Enter new password"
-              value={formData.password}
-              onChange={(e) => updateField("password", e.target.value)}
-              aria-invalid={!!errors.password}
-            />
-            {errors.password && <FieldError>{errors.password}</FieldError>}
           </Field>
 
           <Field data-invalid={!!errors.role}>

--- a/frontend/src/app/staff/_components/account/PoliceAccountForm.tsx
+++ b/frontend/src/app/staff/_components/account/PoliceAccountForm.tsx
@@ -9,19 +9,28 @@ import {
   FieldSet,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PoliceRole } from "@/lib/api/police/police.types";
 import { useState } from "react";
 import * as z from "zod";
 
 export const policeAccountFormSchema = z.object({
   email: z.email({ pattern: z.regexes.html5Email }).min(1, "Email is required"),
   password: z.string().min(1, "Password is required"),
+  role: z.enum(["officer", "police_admin"]),
 });
 
 export type PoliceAccountFormValues = z.infer<typeof policeAccountFormSchema>;
 
 interface PoliceAccountFormProps {
   onSubmit: (data: PoliceAccountFormValues) => void | Promise<void>;
-  editData?: { email: string };
+  editData?: { email: string; role: PoliceRole };
   submissionError?: string | null;
   title?: string;
 }
@@ -35,6 +44,7 @@ export default function PoliceAccountForm({
   const [formData, setFormData] = useState<Partial<PoliceAccountFormValues>>({
     email: editData?.email ?? "",
     password: "",
+    role: editData?.role ?? "officer",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -115,6 +125,25 @@ export default function PoliceAccountForm({
               aria-invalid={!!errors.password}
             />
             {errors.password && <FieldError>{errors.password}</FieldError>}
+          </Field>
+
+          <Field data-invalid={!!errors.role}>
+            <FieldLabel htmlFor="police-role">Role</FieldLabel>
+            <Select
+              value={formData.role}
+              onValueChange={(value) =>
+                updateField("role", value as PoliceAccountFormValues["role"])
+              }
+            >
+              <SelectTrigger id="police-role" aria-invalid={!!errors.role}>
+                <SelectValue placeholder="Select role" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="officer">Officer</SelectItem>
+                <SelectItem value="police_admin">Police Admin</SelectItem>
+              </SelectContent>
+            </Select>
+            {errors.role && <FieldError>{errors.role}</FieldError>}
           </Field>
 
           <Field orientation="vertical">

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -92,6 +92,8 @@ export type TableProps<T> = {
   serverMeta?: { totalRecords: number; totalPages: number };
   onStateChange?: (params: ServerTableParams) => void;
   columnMap?: ServerColumnMap;
+  canManageRows?: boolean;
+  canDeleteRow?: (row: T) => boolean;
 };
 
 export function TableTemplate<T extends object>({
@@ -113,11 +115,14 @@ export function TableTemplate<T extends object>({
   serverMeta,
   onStateChange,
   columnMap,
+  canManageRows,
+  canDeleteRow,
 }: TableProps<T>) {
   const isServerMode = !!serverMeta;
   const { isOpen, openSidebar, closeSidebar } = useSidebar();
   const { data: session } = useSession();
   const role = session?.role;
+  const hasManagePermission = canManageRows ?? role === "admin";
 
   const sortedData = useMemo(
     () => (sortBy ? [...data].sort(sortBy) : data),
@@ -277,13 +282,17 @@ export function TableTemplate<T extends object>({
   };
 
   const confirmDelete = () => {
-    if (itemToDelete && onDelete) {
+    if (
+      itemToDelete &&
+      onDelete &&
+      (canDeleteRow ? canDeleteRow(itemToDelete) : true)
+    ) {
       onDelete(itemToDelete);
     }
   };
 
   const columnsWithActions: ColumnDef<T, unknown>[] =
-    role === "admin" && (onEdit || onDelete)
+    hasManagePermission && (onEdit || onDelete)
       ? [
           ...columns,
           {
@@ -308,15 +317,16 @@ export function TableTemplate<T extends object>({
                         Edit
                       </DropdownMenuItem>
                     )}
-                    {onDelete && (
-                      <DropdownMenuItem
-                        onClick={() => handleDeleteClick(row.original)}
-                        variant="destructive"
-                      >
-                        <Trash2 className="mr-2 h-4 w-4" />
-                        Delete
-                      </DropdownMenuItem>
-                    )}
+                    {onDelete &&
+                      (canDeleteRow ? canDeleteRow(row.original) : true) && (
+                        <DropdownMenuItem
+                          onClick={() => handleDeleteClick(row.original)}
+                          variant="destructive"
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
@@ -414,7 +424,7 @@ export function TableTemplate<T extends object>({
               />
             </div>
             <div className="shrink-0 ml-auto">
-              {onCreateNewRow && role === "admin" && (
+              {onCreateNewRow && hasManagePermission && (
                 <Button onClick={onCreateNewRow} className="h-9">
                   <Plus className="mr-1" />
                   <p>New row</p>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -52,6 +52,14 @@ export default function Header({ className }: { className?: string }) {
                 </DropdownMenuItem>
               </Link>
             )}
+            {role === "police_admin" && (
+              <Link href="/police/admin">
+                <DropdownMenuItem>
+                  <Image src={user} alt="user" />
+                  <span>Police Admin Dashboard</span>
+                </DropdownMenuItem>
+              </Link>
+            )}
             <DropdownMenuItem
               onClick={() => signOut({ callbackUrl: "/login" })}
             >

--- a/frontend/src/lib/api/account/account.queries.ts
+++ b/frontend/src/lib/api/account/account.queries.ts
@@ -42,11 +42,25 @@ export function useAccounts(
 }
 
 export function usePoliceAccounts(
+  serverParams?: ServerTableParams,
   options?: UseQueryOptions<PoliceAccountDto[]>
 ) {
   return useQuery({
-    queryKey: POLICE_ACCOUNTS_KEY,
-    queryFn: () => accountService.listPoliceAccounts(),
+    queryKey: [...POLICE_ACCOUNTS_KEY, serverParams ?? "all"],
+    queryFn: async () =>
+      (await accountService.listPoliceAccounts(serverParams)).items,
+    ...options,
+  });
+}
+
+export function usePoliceAccountsPaginated(
+  serverParams?: ServerTableParams,
+  options?: UseQueryOptions<PaginatedResponse<PoliceAccountDto>>
+) {
+  return useQuery({
+    queryKey: [...POLICE_ACCOUNTS_KEY, "paginated", serverParams ?? "all"],
+    queryFn: () => accountService.listPoliceAccounts(serverParams),
+    placeholderData: keepPreviousData,
     ...options,
   });
 }
@@ -184,5 +198,18 @@ export function useDeletePoliceAccount(
       queryClient.invalidateQueries({ queryKey: POLICE_ACCOUNTS_KEY });
       options?.onSuccess?.(...params);
     },
+  });
+}
+
+export function useDownloadPoliceAccountsCsv(
+  options?: OptimisticMutationOptions<
+    void,
+    Error,
+    ServerTableParams | undefined
+  >
+) {
+  return useMutation({
+    ...options,
+    mutationFn: (params) => accountService.downloadPoliceAccountsCsv(params),
   });
 }

--- a/frontend/src/lib/api/account/account.service.ts
+++ b/frontend/src/lib/api/account/account.service.ts
@@ -83,15 +83,16 @@ export class AccountService {
   }
 
   /**
-   * List police accounts (GET /api/accounts/police)
+   * List police accounts (GET /api/police)
    */
-  async listPoliceAccounts(): Promise<PoliceAccountDto[]> {
+  async listPoliceAccounts(
+    params?: ServerTableParams
+  ): Promise<PaginatedResponse<PoliceAccountDto>> {
     try {
-      const response =
-        await this.client.get<PaginatedResponse<PoliceAccountDto>>(
-          "/accounts/police"
-        );
-      return response.data.items;
+      const response = await this.client.get<
+        PaginatedResponse<PoliceAccountDto>
+      >("/police", { params: params ? toAxiosParams(params) : undefined });
+      return response.data;
     } catch (error) {
       console.error("Failed to fetch police accounts:", error);
       throw new Error("Failed to fetch police accounts");
@@ -99,7 +100,34 @@ export class AccountService {
   }
 
   /**
-   * Update police account (PUT /api/accounts/police/{police_id})
+   * Download police accounts as Excel (GET /api/police/csv)
+   */
+  async downloadPoliceAccountsCsv(params?: ServerTableParams): Promise<void> {
+    try {
+      const response = await this.client.get("/police/csv", {
+        params: params ? toAxiosParams(params) : undefined,
+        responseType: "blob",
+      });
+
+      const blob = new Blob([response.data], {
+        type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "police_accounts.xlsx";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Failed to download police accounts Excel:", error);
+      throw new Error("Failed to download police accounts export");
+    }
+  }
+
+  /**
+   * Update police account (PUT /api/police/{police_id})
    */
   async updatePoliceAccount(
     policeId: number,
@@ -107,7 +135,7 @@ export class AccountService {
   ): Promise<PoliceAccountDto> {
     try {
       const response = await this.client.put<PoliceAccountDto>(
-        `/accounts/police/${policeId}`,
+        `/police/${policeId}`,
         data
       );
       return response.data;
@@ -118,12 +146,12 @@ export class AccountService {
   }
 
   /**
-   * Delete police account (DELETE /api/accounts/police/{police_id})
+   * Delete police account (DELETE /api/police/{police_id})
    */
   async deletePoliceAccount(policeId: number): Promise<PoliceAccountDto> {
     try {
       const response = await this.client.delete<PoliceAccountDto>(
-        `/accounts/police/${policeId}`
+        `/police/${policeId}`
       );
       return response.data;
     } catch (error) {

--- a/frontend/src/lib/api/account/account.types.ts
+++ b/frontend/src/lib/api/account/account.types.ts
@@ -1,13 +1,15 @@
+import type { PoliceRole } from "@/lib/api/police/police.types";
+
 /**
  * Account role types matching backend AccountRole enum
  */
 export type AccountRole = "student" | "staff" | "admin";
 
 /**
- * All application-level roles, including police which authenticates
+ * All application-level roles, including police identities which authenticate
  * separately from SAML-based accounts.
  */
-export type AppRole = AccountRole | "police";
+export type AppRole = AccountRole | PoliceRole;
 
 /**
  * DTO for creating/updating an Account

--- a/frontend/src/lib/api/police/police.types.ts
+++ b/frontend/src/lib/api/police/police.types.ts
@@ -10,12 +10,25 @@ type PoliceAccountDto = {
 };
 
 /**
- * DTO for updating Police credentials
+ * DTO for creating police accounts
  */
-type PoliceAccountUpdate = {
+type PoliceAccountCreate = {
   email: string;
   password: string;
   role: PoliceRole;
 };
 
-export type { PoliceAccountDto, PoliceAccountUpdate, PoliceRole };
+/**
+ * DTO for updating police account details
+ */
+type PoliceAccountUpdate = {
+  email: string;
+  role: PoliceRole;
+};
+
+export type {
+  PoliceAccountCreate,
+  PoliceAccountDto,
+  PoliceAccountUpdate,
+  PoliceRole,
+};

--- a/frontend/src/lib/api/police/police.types.ts
+++ b/frontend/src/lib/api/police/police.types.ts
@@ -1,9 +1,12 @@
+type PoliceRole = "officer" | "police_admin";
+
 /**
  * DTO for Police Account responses
  */
 type PoliceAccountDto = {
   id: number;
   email: string;
+  role: PoliceRole;
 };
 
 /**
@@ -12,6 +15,7 @@ type PoliceAccountDto = {
 type PoliceAccountUpdate = {
   email: string;
   password: string;
+  role: PoliceRole;
 };
 
-export type { PoliceAccountDto, PoliceAccountUpdate };
+export type { PoliceAccountDto, PoliceAccountUpdate, PoliceRole };

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -50,6 +50,7 @@ function parseRelativeDate(dateStr: string | null): Date | null {
 export const POLICE_ACCOUNTS: PoliceAccountDto[] = mockData.police.map((p) => ({
   id: p.id,
   email: p.email,
+  role: p.role as PoliceAccountDto["role"],
 }));
 
 // Parse Accounts

--- a/frontend/src/lib/shared.ts
+++ b/frontend/src/lib/shared.ts
@@ -8,7 +8,13 @@ type PaginatedResponse<T> = {
   total_pages: number;
 };
 
-type StringRole = "staff" | "admin" | "student" | "police" | "unauthenticated";
+type StringRole =
+  | "staff"
+  | "admin"
+  | "student"
+  | "officer"
+  | "police_admin"
+  | "unauthenticated";
 
 /**
  * Extends UseMutationOptions with an optional `onOptimisticUpdate` callback

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import type { AppRole } from "@/lib/api/account/account.types";
 import { type ClassValue, clsx } from "clsx";
 import { isAfter, isBefore, startOfDay } from "date-fns";
 import { twMerge } from "tailwind-merge";
@@ -68,4 +69,16 @@ export function isFromThisSchoolYear(date: Date | null | undefined): boolean {
     : augustFirst;
 
   return isAfter(startOfDay(date), startOfDay(mostRecentAugust1));
+}
+
+const ROLE_LABELS: Record<AppRole, string> = {
+  student: "Student",
+  staff: "Staff",
+  admin: "Admin",
+  officer: "Officer",
+  police_admin: "Police Admin",
+};
+
+export function formatRoleLabel(role: AppRole): string {
+  return ROLE_LABELS[role];
 }

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -5,7 +5,8 @@ import { NextRequest, NextResponse } from "next/server";
 const ALLOWED_ROLES_FOR_PATH: Record<string, AppRole[]> = {
   "/student": ["student"],
   "/staff": ["staff", "admin"],
-  "/police": ["police", "admin"],
+  "/police/admin": ["police_admin"],
+  "/police": ["officer", "police_admin", "admin"],
 };
 
 function getRequiredRolesForPath(pathname: string): AppRole[] | null {
@@ -18,7 +19,8 @@ function getRequiredRolesForPath(pathname: string): AppRole[] | null {
 function getDefaultRoleForPath(pathname: string): AppRole | null {
   if (pathname.startsWith("/student")) return "student";
   if (pathname.startsWith("/staff")) return "staff";
-  if (pathname.startsWith("/police")) return "police";
+  if (pathname.startsWith("/police/admin")) return "police_admin";
+  if (pathname.startsWith("/police")) return "officer";
   return null;
 }
 
@@ -29,8 +31,10 @@ function getDashboardPath(role: AppRole | undefined): string {
     case "staff":
     case "admin":
       return "/staff";
-    case "police":
+    case "officer":
       return "/police";
+    case "police_admin":
+      return "/police/admin";
     default:
       return "/login";
   }
@@ -64,7 +68,7 @@ export async function proxy(req: NextRequest) {
 
   const defaultRole = getDefaultRoleForPath(pathname);
 
-  if (defaultRole === "police") {
+  if (defaultRole === "officer" || defaultRole === "police_admin") {
     const loginUrl = new URL("/login/police", req.url);
     loginUrl.searchParams.set("callbackUrl", pathname);
     return NextResponse.redirect(loginUrl);


### PR DESCRIPTION
### Motivation

We need a new role that can manage specifically police officers without having access to students/staff/admins.

### Changes

 - Added `officer`/`police_admin` roles across police models, DTOs, auth payloads, and guards.
 - Implemented `/api/police` list/update/export routes with police-admin authorization and role persistence.
 - Built `/police/admin` dashboard using `TableTemplate` with edit/delete/search/filter/pagination/export.
 - Updated frontend auth, routing, and navigation for police-admin access and role-aware session handling.

Closes #290 
