### PR TITLE
Student register party form cleanup

### DIFF
--- a/frontend/src/app/student/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/student/_components/PartyRegistrationForm.tsx
@@ -3,7 +3,6 @@
 import AddressSearch from "@/components/AddressSearch";
 import DatePicker from "@/components/DatePicker";
 import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
 import {
   Dialog,
   DialogContent,
@@ -22,11 +21,6 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -42,7 +36,6 @@ import {
   phoneNumberSchema,
 } from "@/lib/utils";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
-import { CalendarIcon } from "lucide-react";
 import { useRef, useState } from "react";
 import * as z from "zod";
 
@@ -133,20 +126,6 @@ export default function PartyRegistrationForm({
     data: PartyFormValues;
     placeId: string;
   } | null>(null);
-
-  // Check if the form is complete enough to enable the submit button
-  const isFormComplete =
-    !!formData.address &&
-    !!placeId &&
-    !!formData.partyDate &&
-    !!formData.partyTime &&
-    !!formData.secondContactFirstName &&
-    !!formData.secondContactLastName &&
-    !!formData.phoneNumber &&
-    !!formData.contactPreference &&
-    !!formData.contactTwoEmail &&
-    (student?.phone_number != null ||
-      (!!formData.studentPhoneNumber && !!formData.studentContactPreference));
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -282,79 +261,33 @@ export default function PartyRegistrationForm({
       <FieldGroup>
         <FieldSet>
           <div className="flex flex-col gap-4 lg:gap-6">
-            <div className="sm:grid sm:grid-cols-2 sm:gap-6 lg:gap-8 mt-2">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:gap-8">
               <Field data-invalid={!!errors.partyDate}>
                 <FieldLabel htmlFor="party-date" className="content-bold">
                   Event Date
                 </FieldLabel>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      id="party-date"
-                      variant="outline"
-                      aria-invalid={!!errors.partyDate}
-                      className={`w-full justify-between items-center content bg-white input-shadow ${
-                        !formData.partyDate && "text-muted-foreground"
-                      }`}
-                    >
-                      {formData.partyDate ? (
-                        (formData.partyDate, "PPP")
-                      ) : (
-                        <span>Pick a date</span>
-                      )}
-                      <CalendarIcon className="h-4 w-4 text-black shrink-0" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    <Calendar
-                      mode="single"
-                      selected={formData.partyDate}
-                      onSelect={(date) =>
-                        updateField("partyDate", date as Date)
-                      }
-                      disabled={(date) =>
-                        !isAfter(
-                          startOfDay(date),
-                          addBusinessDays(startOfDay(new Date()), 1)
-                        )
-                      }
-                    />
-                  </PopoverContent>
-                </Popover>
+                <DatePicker
+                  id="party-date"
+                  value={formData.partyDate ?? null}
+                  onChange={(date) => updateField("partyDate", date as Date)}
+                  disabled={(date) =>
+                    !isAfter(
+                      startOfDay(date),
+                      addBusinessDays(startOfDay(new Date()), 1)
+                    )
+                  }
+                  aria-invalid={!!errors.partyDate}
+                />
+                <FieldDescription>
+                  Must be at least 2 business days from today
+                </FieldDescription>
                 {errors.partyDate && (
                   <FieldError>{errors.partyDate}</FieldError>
                 )}
               </Field>
 
-              <div className="grid grid-cols-2 gap-4">
-                <Field data-invalid={!!errors.partyDate}>
-                  <FieldLabel htmlFor="party-date">Party Date</FieldLabel>
-                  <DatePicker
-                    id="party-date"
-                    value={formData.partyDate ?? null}
-                    onChange={(date) => updateField("partyDate", date as Date)}
-                    disabled={(date) =>
-                      !isAfter(
-                        startOfDay(date),
-                        addBusinessDays(startOfDay(new Date()), 1)
-                      )
-                    }
-                    aria-invalid={!!errors.partyDate}
-                  />
-                  <FieldDescription>
-                    Must be at least 2 business days from today
-                  </FieldDescription>
-                  {errors.partyDate && (
-                    <FieldError>{errors.partyDate}</FieldError>
-                  )}
-                </Field>
-              </div>
-
               <Field data-invalid={!!errors.partyTime}>
-                <FieldLabel
-                  htmlFor="party-time"
-                  className="content-bold mt-4 sm:mt-0"
-                >
+                <FieldLabel htmlFor="party-time" className="content-bold">
                   Event Time
                 </FieldLabel>
                 <Input
@@ -363,9 +296,7 @@ export default function PartyRegistrationForm({
                   value={formData.partyTime}
                   onChange={(e) => updateField("partyTime", e.target.value)}
                   aria-invalid={!!errors.partyTime}
-                  className={`w-full justify-between items-center content bg-white input-shadow ${
-                    !formData.partyDate && "text-muted-foreground"
-                  }`}
+                  className="w-full content bg-white input-shadow"
                 />
                 {errors.partyTime && (
                   <FieldError>{errors.partyTime}</FieldError>
@@ -411,29 +342,28 @@ export default function PartyRegistrationForm({
             )}
           </div>
 
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 lg:gap-6">
             <h2 className="subhead-content">Your Contact Information</h2>
             <p className="content-sub italic">
               {student?.phone_number != null
                 ? "You can edit preferences in your Account Settings."
                 : "Please provide your contact information to complete registration."}
             </p>
-            <div className="sm:grid sm:grid-cols-2 sm:gap-4">
-              <Field className="mb-4 sm:mb-2">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+              <Field>
                 <FieldLabel className="content-bold">First Name</FieldLabel>
                 <p className="content">{student?.first_name}</p>
               </Field>
-              <Field className="mb-4 sm:mb-2">
+              <Field>
                 <FieldLabel className="content-bold">Last Name</FieldLabel>
                 <p className="content">{student?.last_name}</p>
               </Field>
-              <Field
-                data-invalid={!!errors.studentPhoneNumber}
-                className="mb-4 sm:mb-2"
-              >
+              <Field data-invalid={!!errors.studentPhoneNumber}>
                 <FieldLabel className="content-bold">Phone Number</FieldLabel>
                 {student?.phone_number != null ? (
-                  <p className="content">{student.phone_number}</p>
+                  <p className="content">
+                    {formatPhoneNumberInput(student.phone_number)}
+                  </p>
                 ) : (
                   <>
                     <Input
@@ -458,10 +388,7 @@ export default function PartyRegistrationForm({
                   </>
                 )}
               </Field>
-              <Field
-                data-invalid={!!errors.studentContactPreference}
-                className="mb-4 sm:mb-2"
-              >
+              <Field data-invalid={!!errors.studentContactPreference}>
                 <FieldLabel className="content-bold">
                   Contact Preference
                 </FieldLabel>
@@ -498,7 +425,7 @@ export default function PartyRegistrationForm({
                   </>
                 )}
               </Field>
-              <Field className="sm:mb-2">
+              <Field>
                 <FieldLabel className="content-bold">Email</FieldLabel>
                 <p className="content">{student?.email}</p>
               </Field>
@@ -507,7 +434,7 @@ export default function PartyRegistrationForm({
 
           <div className="flex flex-col gap-4 lg:gap-6">
             <h2 className="subhead-content">Second Contact Information</h2>
-            <div className="lg:flex lg:flex-row lg:gap-8">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
               <Field data-invalid={!!errors.secondContactFirstName}>
                 <FieldLabel
                   htmlFor="second-contact-first-name"
@@ -523,7 +450,7 @@ export default function PartyRegistrationForm({
                     updateField("secondContactFirstName", e.target.value)
                   }
                   aria-invalid={!!errors.secondContactFirstName}
-                  className="content mb-4 lg:mb-0"
+                  className="content"
                 />
                 {errors.secondContactFirstName && (
                   <FieldError>{errors.secondContactFirstName}</FieldError>
@@ -552,59 +479,64 @@ export default function PartyRegistrationForm({
                 )}
               </Field>
             </div>
-            <Field data-invalid={!!errors.phoneNumber}>
-              <FieldLabel htmlFor="phone-number" className="content-bold">
-                Phone Number
-              </FieldLabel>
-              <Input
-                id="phone-number"
-                type="tel"
-                placeholder="(123) 456-7890"
-                value={formatPhoneNumberInput(formData.phoneNumber ?? "")}
-                onChange={(e) =>
-                  updateField(
-                    "phoneNumber",
-                    e.target.value.replace(/\D/g, "").slice(0, 10)
-                  )
-                }
-                aria-invalid={!!errors.phoneNumber}
-                className="content"
-              />
-              {errors.phoneNumber && (
-                <FieldError>{errors.phoneNumber}</FieldError>
-              )}
-            </Field>
-
-            <Field data-invalid={!!errors.contactPreference}>
-              <FieldLabel htmlFor="contact-preference" className="content-bold">
-                Contact Preference
-              </FieldLabel>
-              <Select
-                value={formData.contactPreference}
-                onValueChange={(value) =>
-                  updateField("contactPreference", value as "call" | "text")
-                }
-              >
-                <SelectTrigger
-                  id="contact-preference"
-                  aria-invalid={!!errors.contactPreference}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+              <Field data-invalid={!!errors.phoneNumber}>
+                <FieldLabel htmlFor="phone-number" className="content-bold">
+                  Phone Number
+                </FieldLabel>
+                <Input
+                  id="phone-number"
+                  type="tel"
+                  placeholder="(123) 456-7890"
+                  value={formatPhoneNumberInput(formData.phoneNumber ?? "")}
+                  onChange={(e) =>
+                    updateField(
+                      "phoneNumber",
+                      e.target.value.replace(/\D/g, "").slice(0, 10)
+                    )
+                  }
+                  aria-invalid={!!errors.phoneNumber}
                   className="content"
+                />
+                {errors.phoneNumber && (
+                  <FieldError>{errors.phoneNumber}</FieldError>
+                )}
+              </Field>
+
+              <Field data-invalid={!!errors.contactPreference}>
+                <FieldLabel
+                  htmlFor="contact-preference"
+                  className="content-bold"
                 >
-                  <SelectValue placeholder="Select your preference" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="call" className="content">
-                    Call
-                  </SelectItem>
-                  <SelectItem value="text" className="content">
-                    Text
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              {errors.contactPreference && (
-                <FieldError>{errors.contactPreference}</FieldError>
-              )}
-            </Field>
+                  Contact Preference
+                </FieldLabel>
+                <Select
+                  value={formData.contactPreference}
+                  onValueChange={(value) =>
+                    updateField("contactPreference", value as "call" | "text")
+                  }
+                >
+                  <SelectTrigger
+                    id="contact-preference"
+                    aria-invalid={!!errors.contactPreference}
+                    className="content"
+                  >
+                    <SelectValue placeholder="Select your preference" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="call" className="content">
+                      Call
+                    </SelectItem>
+                    <SelectItem value="text" className="content">
+                      Text
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                {errors.contactPreference && (
+                  <FieldError>{errors.contactPreference}</FieldError>
+                )}
+              </Field>
+            </div>
 
             <Field data-invalid={!!errors.contactTwoEmail}>
               <FieldLabel htmlFor="contact-email" className="content-bold">
@@ -631,16 +563,7 @@ export default function PartyRegistrationForm({
               submitting. After submitting, all contacts will receive email
               confirmation for your event
             </p>
-            <Button
-              type="submit"
-              disabled={isSubmitting || !isFormComplete}
-              title={
-                !isFormComplete
-                  ? "Please fill in all required fields"
-                  : undefined
-              }
-              className="!w-fit"
-            >
+            <Button type="submit" disabled={isSubmitting} className="!w-fit">
               {isSubmitting ? "Submitting..." : "Submit Event"}
             </Button>
           </Field>

--- a/frontend/src/app/student/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/student/_components/PartyRegistrationForm.tsx
@@ -343,12 +343,14 @@ export default function PartyRegistrationForm({
           </div>
 
           <div className="flex flex-col gap-4 lg:gap-6">
-            <h2 className="subhead-content">Your Contact Information</h2>
-            <p className="content-sub italic">
-              {student?.phone_number != null
-                ? "You can edit preferences in your Account Settings."
-                : "Please provide your contact information to complete registration."}
-            </p>
+            <div className="flex flex-col gap-1">
+              <h2 className="subhead-content">Your Contact Information</h2>
+              <p className="content-sub italic">
+                {student?.phone_number != null
+                  ? "You can edit preferences in your Account Settings."
+                  : "Please provide your contact information to complete registration."}
+              </p>
+            </div>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
               <Field>
                 <FieldLabel className="content-bold">First Name</FieldLabel>

--- a/frontend/src/app/student/new-party/page.tsx
+++ b/frontend/src/app/student/new-party/page.tsx
@@ -121,9 +121,7 @@ export default function RegistrationForm() {
               <Link href="/student">Back</Link>
             </nav>
             <div className="px-8 py-6 lg:px-18 lg:py-0 lg:pb-12">
-              <h1 className="page-title max-w-md md:mb-4">
-                Off Campus Student Life Party Registration Form
-              </h1>
+              <h1 className="page-title md:mb-4">Party Registration</h1>
 
               <Link
                 href="/student/about-party-smart"

--- a/frontend/src/app/student/new-party/page.tsx
+++ b/frontend/src/app/student/new-party/page.tsx
@@ -121,7 +121,7 @@ export default function RegistrationForm() {
               <Link href="/student">Back</Link>
             </nav>
             <div className="px-8 py-6 lg:px-18 lg:py-0 lg:pb-12">
-              <h1 className="page-title md:mb-4">Party Registration</h1>
+              <h1 className="page-title md:mb-4">Register Party</h1>
 
               <Link
                 href="/student/about-party-smart"


### PR DESCRIPTION
High level motivation for making the changes

The student party registration form had duplicated date inputs, unclear validation UX (submit button disabled without showing what was missing), and inconsistent responsive spacing that made sections look cramped/misaligned. This cleanup improves clarity and usability so students can complete the form with fewer mistakes and better visual flow.

Changes:

- Removed the duplicated event date UI and kept a single `DatePicker` path for `partyDate`, including removing unused popover/calendar imports and related dead code
- Updated submit behavior to rely on form validation feedback instead of completeness gating, so clicking submit now surfaces field-level errors immediately
- Formatted displayed student phone numbers in the "Your Contact Information" section using `formatPhoneNumberInput(...)` for consistency with other phone fields
- Shortened the new party page title from "Off Campus Student Life Party Registration Form" to "Party Registration" and removed the narrow title width cap
- Standardized section and field spacing/layout by using explicit base grid/gap classes across breakpoints (`grid-cols-1 gap-4` -> `sm:grid-cols-2 sm:gap-6`) to eliminate cramped stacking
- Updated second contact field layout to span full width before wrapping and align with the same responsive structure used elsewhere in the form

Closes #341 