### PR TITLE
fix: use detail for API error payloads

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -24,7 +24,7 @@ app.add_middleware(
 def handle_http_exception(req: Request, exc: HTTPException):
     return JSONResponse(
         status_code=exc.status_code,
-        content={"message": exc.detail},
+        content={"detail": exc.detail},
         headers=exc.headers,
     )
 
@@ -33,7 +33,7 @@ def handle_http_exception(req: Request, exc: HTTPException):
 def handle_general_exception(req: Request, exc: Exception):
     return JSONResponse(
         status_code=500,
-        content={"message": "An unexpected error occurred.", "detail": str(exc)},
+        content={"detail": "An unexpected error occurred."},
     )
 
 

--- a/backend/test/utils/http/assertions.py
+++ b/backend/test/utils/http/assertions.py
@@ -116,15 +116,15 @@ def assert_res_failure(res: Response, expected_error: HTTPException) -> dict[str
     data = res.json()
     assert data is not None, "Expected response data but got None"
     assert isinstance(data, dict), f"Expected dict response but got {type(data).__name__}"
-    assert "message" in data, "Expected 'message' in response data but got None"
+    assert "detail" in data, "Expected 'detail' in response data but got None"
 
-    message = data["message"]
-    assert isinstance(message, str), (
-        f"Expected 'message' to be a string but got {type(message).__name__}"
+    detail = data["detail"]
+    assert isinstance(detail, str), (
+        f"Expected 'detail' to be a string but got {type(detail).__name__}"
     )
 
-    assert message == expected_error.detail, (
-        f"Expected error message '{expected_error.detail}', got '{message}'"
+    assert detail == expected_error.detail, (
+        f"Expected error detail '{expected_error.detail}', got '{detail}'"
     )
 
     return data

--- a/frontend/src/app/api/auth/police/login/route.ts
+++ b/frontend/src/app/api/auth/police/login/route.ts
@@ -47,9 +47,11 @@ export async function POST(req: NextRequest) {
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
       const detail =
-        typeof error.response.data?.message === "string"
-          ? error.response.data.message
-          : "Forbidden";
+        typeof error.response.data?.detail === "string"
+          ? error.response.data.detail
+          : typeof error.response.data?.message === "string"
+            ? error.response.data.message
+            : "Forbidden";
 
       return NextResponse.json({ detail }, { status: 403 });
     }

--- a/frontend/src/app/staff/_components/account/AccountTable.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTable.tsx
@@ -77,8 +77,8 @@ const getErrorMessage = (error: Error): string => {
       case 500:
         return "Server error. Please try again later.";
     }
-    if (detail?.message) return String(detail.message);
     if (detail?.detail) return String(detail.detail);
+    if (detail?.message) return String(detail.message);
     if (error.message) return error.message;
   }
   return "Operation failed";

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -168,7 +168,9 @@ export const IncidentTable = () => {
   const createMutation = useCreateIncident({
     onError: (error: Error) => {
       const errorMessage = isAxiosError(error)
-        ? error.response?.data?.message || error.message
+        ? error.response?.data?.detail ||
+          error.response?.data?.message ||
+          error.message
         : error.message || "Failed to create incident";
       reopenCreateSidebar(errorMessage);
     },
@@ -185,7 +187,9 @@ export const IncidentTable = () => {
       variables: { id: number; payload: Partial<IncidentCreateDto> }
     ) => {
       const errorMessage = isAxiosError(error)
-        ? error.response?.data?.message || error.message
+        ? error.response?.data?.detail ||
+          error.response?.data?.message ||
+          error.message
         : error.message || "Failed to update incident";
 
       const targetIncident =

--- a/frontend/src/app/staff/_components/location/LocationTable.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTable.tsx
@@ -61,7 +61,9 @@ export const LocationTable = () => {
     onError: (error: Error) => {
       console.error("Failed to create location:", error);
       const errorMessage = isAxiosError(error)
-        ? error.response?.data?.message || error.message
+        ? error.response?.data?.detail ||
+          error.response?.data?.message ||
+          error.message
         : error.message;
       const userMessage =
         isAxiosError(error) && error.status === 409
@@ -92,7 +94,9 @@ export const LocationTable = () => {
     ) => {
       console.error("Failed to update location:", error);
       const errorMessage = isAxiosError(error)
-        ? error.response?.data?.message || error.message
+        ? error.response?.data?.detail ||
+          error.response?.data?.message ||
+          error.message
         : error.message;
       const userMessage =
         isAxiosError(error) && error.status === 409

--- a/frontend/src/app/staff/_components/party/PartyTable.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTable.tsx
@@ -79,8 +79,8 @@ const getErrorMessage = (error: Error): string => {
       case 500:
         return "Server error. Please try again later.";
     }
-    if (detail?.message) return String(detail.message);
     if (detail?.detail) return String(detail.detail);
+    if (detail?.message) return String(detail.message);
     if (error.message) return error.message;
   }
   return "Operation failed";

--- a/frontend/src/app/staff/_components/student/StudentTable.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTable.tsx
@@ -62,8 +62,8 @@ const getErrorMessage = (error: Error): string => {
       case 500:
         return "Server error. Please try again later.";
     }
-    if (detail?.message) return String(detail.message);
     if (detail?.detail) return String(detail.detail);
+    if (detail?.message) return String(detail.message);
     if (error.message) return error.message;
   }
   return "Operation failed";

--- a/frontend/src/lib/network/apiClient.ts
+++ b/frontend/src/lib/network/apiClient.ts
@@ -158,7 +158,10 @@ export const setupErrorInterceptor = (showError: (message: string) => void) => {
 
       // Get error message
       const message =
-        error.response?.data?.message || error.message || "An error occurred";
+        error.response?.data?.detail ||
+        error.response?.data?.message ||
+        error.message ||
+        "An error occurred";
 
       showError(message);
       return Promise.reject(error);


### PR DESCRIPTION
## Summary
- return API HTTPException payloads under detail instead of message
- align backend test failure assertion helper with detail field
- update frontend error extraction to prefer detail while keeping message fallback for compatibility

## Testing
- pre-commit hooks passed locally during commit (ruff, pyright, prettier, tsc, eslint)

Closes #347