### PR TITLE
fix: proximity search date filter and coordinate drift

### DIFF
--- a/backend/src/modules/party/party_router.py
+++ b/backend/src/modules/party/party_router.py
@@ -115,11 +115,11 @@ async def list_parties(
 @party_router.get("/nearby")
 async def get_parties_nearby(
     place_id: str = Query(..., description="Google Maps place ID"),
-    start_date: str = Query(
-        ..., pattern=r"^\d{4}-\d{2}-\d{2}$", description="Start date (YYYY-MM-DD format)"
+    start_datetime: datetime = Query(
+        ..., alias="start_date", description="Start of search window (ISO 8601 with timezone)"
     ),
-    end_date: str = Query(
-        ..., pattern=r"^\d{4}-\d{2}-\d{2}$", description="End date (YYYY-MM-DD format)"
+    end_datetime: datetime = Query(
+        ..., alias="end_date", description="End of search window (ISO 8601 with timezone)"
     ),
     party_service: PartyService = Depends(),
     location_service: LocationService = Depends(),
@@ -136,24 +136,23 @@ async def get_parties_nearby(
 
     Query Parameters:
     - place_id: Google Maps place ID from autocomplete selection
-    - start_date: Start date for the search range (YYYY-MM-DD format)
-    - end_date: End date for the search range (YYYY-MM-DD format)
+    - start_date: Start of the search window (ISO 8601 with timezone)
+    - end_date: End of the search window (ISO 8601 with timezone)
 
     Raises:
-    - 400: If place ID is invalid or dates are in wrong format
+    - 400: If place ID is invalid or datetimes are in wrong format
     - 404: If place ID is not found in Google Maps
     - 403: If user is not a police officer or admin
     """
-    # Parse date strings to datetime objects
-    try:
-        start_datetime = datetime.strptime(start_date, "%Y-%m-%d").replace(tzinfo=UTC)
-        end_datetime = datetime.strptime(end_date, "%Y-%m-%d").replace(tzinfo=UTC)
-        # Set end_datetime to end of day (23:59:59)
-        end_datetime = end_datetime.replace(hour=23, minute=59, second=59)
-    except ValueError as e:
-        raise UnprocessableEntityException(f"Invalid date format. Expected YYYY-MM-DD: {e}") from e
+    if start_datetime.tzinfo is None:
+        raise UnprocessableEntityException("start_date must include timezone information")
+    if end_datetime.tzinfo is None:
+        raise UnprocessableEntityException("end_date must include timezone information")
 
-    # Validate that start_date is not greater than end_date
+    # Normalize to UTC for consistent DB comparisons
+    start_datetime = start_datetime.astimezone(UTC)
+    end_datetime = end_datetime.astimezone(UTC)
+
     if start_datetime > end_datetime:
         raise BadRequestException("Start date must be less than or equal to end date")
 
@@ -182,10 +181,16 @@ async def get_parties_nearby(
         party=exact_party,
     )
 
+    # Use DB coordinates when available to avoid float precision drift vs stored DECIMAL values
+    search_lat = float(db_location.latitude) if db_location is not None else location_data.latitude
+    search_lon = (
+        float(db_location.longitude) if db_location is not None else location_data.longitude
+    )
+
     # Perform proximity search with date range (sorted by distance)
     nearby = await party_service.get_parties_by_radius_and_date_range(
-        latitude=location_data.latitude,
-        longitude=location_data.longitude,
+        latitude=search_lat,
+        longitude=search_lon,
         start_date=start_datetime,
         end_date=end_datetime,
     )

--- a/backend/src/modules/party/party_router.py
+++ b/backend/src/modules/party/party_router.py
@@ -156,14 +156,22 @@ async def get_parties_nearby(
     if start_datetime > end_datetime:
         raise BadRequestException("Start date must be less than or equal to end date")
 
-    # Resolve coordinates and address from Google Maps
-    location_data = await location_service.get_place_details(place_id)
-
     # Try to find the location in the DB (may not exist for unregistered addresses)
     try:
         db_location = await location_service.get_location_by_place_id(place_id)
     except LocationNotFoundException:
         db_location = None
+
+    # Only call Google Maps API when the location isn't in the DB
+    if db_location is not None:
+        formatted_address = db_location.formatted_address
+        search_lat = float(db_location.latitude)
+        search_lon = float(db_location.longitude)
+    else:
+        location_data = await location_service.get_place_details(place_id)
+        formatted_address = location_data.formatted_address
+        search_lat = location_data.latitude
+        search_lon = location_data.longitude
 
     # Find a party at this exact location within the date range (if DB location exists)
     exact_party = None
@@ -176,15 +184,9 @@ async def get_parties_nearby(
 
     exact_match = ExactMatchDto(
         google_place_id=place_id,
-        formatted_address=location_data.formatted_address,
+        formatted_address=formatted_address,
         location=db_location,
         party=exact_party,
-    )
-
-    # Use DB coordinates when available to avoid float precision drift vs stored DECIMAL values
-    search_lat = float(db_location.latitude) if db_location is not None else location_data.latitude
-    search_lon = (
-        float(db_location.longitude) if db_location is not None else location_data.longitude
     )
 
     # Perform proximity search with date range (sorted by distance)

--- a/backend/test/modules/party/party_router_test.py
+++ b/backend/test/modules/party/party_router_test.py
@@ -40,7 +40,7 @@ test_party_authentication = generate_auth_required_tests(
     (
         {"admin", "officer", "police_admin"},
         "GET",
-        "/api/parties/nearby?place_id=ChIJTest&start_date=2025-01-01&end_date=2025-12-31",
+        "/api/parties/nearby?place_id=ChIJTest&start_date=2025-01-01T00:00:00Z&end_date=2025-12-31T23:59:59Z",
         None,
     ),
     # POST endpoint requires conditional body - tested separately in
@@ -916,8 +916,8 @@ class TestPartyNearbyRouter:
         now = datetime.now(UTC)
         params = {
             "place_id": location_data.google_place_id,
-            "start_date": now.strftime("%Y-%m-%d"),
-            "end_date": (now + timedelta(days=7)).strftime("%Y-%m-%d"),
+            "start_date": now.isoformat(),
+            "end_date": (now + timedelta(days=7)).isoformat(),
         }
         response = await self.admin_client.get("/api/parties/nearby", params=params)
         data = assert_res_success(response, ProximitySearchResponse)
@@ -965,8 +965,8 @@ class TestPartyNearbyRouter:
 
         params = {
             "place_id": search_location_data.google_place_id,
-            "start_date": now.strftime("%Y-%m-%d"),
-            "end_date": (now + timedelta(days=1)).strftime("%Y-%m-%d"),
+            "start_date": now.isoformat(),
+            "end_date": (now + timedelta(days=1)).isoformat(),
         }
         response = await self.admin_client.get("/api/parties/nearby", params=params)
         data = assert_res_success(response, ProximitySearchResponse)
@@ -1009,8 +1009,8 @@ class TestPartyNearbyRouter:
 
         params = {
             "place_id": search_location_data.google_place_id,
-            "start_date": base_time.strftime("%Y-%m-%d"),
-            "end_date": (base_time + timedelta(hours=12)).strftime("%Y-%m-%d"),
+            "start_date": base_time.isoformat(),
+            "end_date": (base_time + timedelta(hours=12)).isoformat(),
         }
 
         response = await self.admin_client.get("/api/parties/nearby", params=params)
@@ -1028,8 +1028,8 @@ class TestPartyNearbyRouter:
         now = datetime.now(UTC)
         params = {
             "place_id": location_data.google_place_id,
-            "start_date": now.strftime("%Y-%m-%d"),
-            "end_date": (now + timedelta(days=1)).strftime("%Y-%m-%d"),
+            "start_date": now.isoformat(),
+            "end_date": (now + timedelta(days=1)).isoformat(),
         }
         response = await self.admin_client.get("/api/parties/nearby", params=params)
         data = assert_res_success(response, ProximitySearchResponse)
@@ -1059,8 +1059,8 @@ class TestPartyNearbyRouter:
         now = datetime.now(UTC)
         params = {
             "place_id": db_location.google_place_id,
-            "start_date": now.strftime("%Y-%m-%d"),
-            "end_date": (now + timedelta(days=1)).strftime("%Y-%m-%d"),
+            "start_date": now.isoformat(),
+            "end_date": (now + timedelta(days=1)).isoformat(),
         }
         response = await self.admin_client.get("/api/parties/nearby", params=params)
         data = assert_res_success(response, ProximitySearchResponse)
@@ -1094,8 +1094,8 @@ class TestPartyNearbyRouter:
 
         params = {
             "place_id": db_location.google_place_id,
-            "start_date": now.strftime("%Y-%m-%d"),
-            "end_date": (now + timedelta(days=1)).strftime("%Y-%m-%d"),
+            "start_date": now.isoformat(),
+            "end_date": (now + timedelta(days=1)).isoformat(),
         }
         response = await self.admin_client.get("/api/parties/nearby", params=params)
         data = assert_res_success(response, ProximitySearchResponse)
@@ -1106,42 +1106,116 @@ class TestPartyNearbyRouter:
         assert data.exact_match.party.id == party.id
 
     @pytest.mark.asyncio
+    async def test_nearby_uses_db_coordinates_when_available(self):
+        """Regression for #368: When a DB location exists, its stored coordinates are used as the
+        search center so that floating-point drift between Google Maps and DECIMAL DB values can't
+        push a party at the exact address outside the search radius."""
+        search_lat = 40.7128
+        search_lon = -74.0060
+
+        # DB location stored at exact coordinates
+        db_location = await self.location_utils.create_one(
+            latitude=search_lat,
+            longitude=search_lon,
+        )
+
+        # Google Maps returns coordinates with a tiny float offset that would otherwise shift the
+        # search center and risk excluding nearby parties
+        gmaps_lat = search_lat + 1e-7
+        gmaps_lon = search_lon + 1e-7
+        self.gmaps_utils.mock_place_details(
+            google_place_id=db_location.google_place_id,
+            formatted_address=db_location.formatted_address,
+            latitude=gmaps_lat,
+            longitude=gmaps_lon,
+        )
+
+        # Party at a location very close to the DB location (within radius from DB coords)
+        nearby_location = await self.location_utils.create_one(
+            latitude=search_lat + get_lat_offset_within_radius(),
+            longitude=search_lon,
+        )
+
+        now = datetime.now(UTC)
+        party = await self.party_utils.create_one(
+            location_id=nearby_location.id,
+            party_datetime=now + timedelta(hours=2),
+        )
+
+        params = {
+            "place_id": db_location.google_place_id,
+            "start_date": now.isoformat(),
+            "end_date": (now + timedelta(days=1)).isoformat(),
+        }
+        response = await self.admin_client.get("/api/parties/nearby", params=params)
+        data = assert_res_success(response, ProximitySearchResponse)
+
+        nearby_ids = [p.id for p in data.nearby]
+        assert party.id in nearby_ids
+
+    @pytest.mark.asyncio
+    async def test_nearby_date_filter_uses_full_timestamps(self):
+        """Regression for #369: Parties are filtered by the exact timestamps sent by the client,
+        not by UTC-midnight-to-midnight derived from a date-only string. This ensures an officer
+        searching for 'today' in a non-UTC timezone sees the same parties in nearby search as in
+        the all-parties list."""
+        search_lat = 40.7128
+        search_lon = -74.0060
+
+        search_location_data = await self.location_utils.next_data(
+            latitude=search_lat,
+            longitude=search_lon,
+        )
+        self.gmaps_utils.mock_place_details(**search_location_data.model_dump())
+
+        location = await self.location_utils.create_one(
+            latitude=search_lat + get_lat_offset_within_radius(),
+            longitude=search_lon,
+        )
+
+        # Party at 21:00 UTC: within a UTC-4 "today" window (04:00-03:59 UTC) but outside
+        # a naive UTC midnight-to-midnight window for the same calendar date
+        party_datetime = datetime(2024, 4, 27, 21, 0, 0, tzinfo=UTC)
+        party = await self.party_utils.create_one(
+            location_id=location.id,
+            party_datetime=party_datetime,
+        )
+
+        # Simulate a UTC-4 client sending its local-midnight-to-end-of-day window for April 27
+        start = datetime(2024, 4, 27, 4, 0, 0, tzinfo=UTC)  # midnight EDT = 04:00 UTC
+        end = datetime(2024, 4, 28, 3, 59, 59, tzinfo=UTC)  # 23:59:59 EDT = 03:59:59 UTC next day
+
+        params = {
+            "place_id": search_location_data.google_place_id,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        }
+        response = await self.admin_client.get("/api/parties/nearby", params=params)
+        data = assert_res_success(response, ProximitySearchResponse)
+
+        nearby_ids = [p.id for p in data.nearby]
+        assert party.id in nearby_ids
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "params",
         [
-            {"start_date": "2024-01-01", "end_date": "2024-01-02"},  # missing place_id
-            {"place_id": "ChIJtest123", "end_date": "2024-01-02"},  # missing start_date
-            {"place_id": "ChIJtest123", "start_date": "2024-01-01"},  # missing end_date
             {
-                "place_id": "ChIJtest123",
-                "start_date": "01-01-2024",
-                "end_date": "2024-01-02",
-            },  # MM-DD-YYYY
-            {
-                "place_id": "ChIJtest123",
-                "start_date": "2024-01-01",
-                "end_date": "01/02/2024",
-            },  # MM/DD/YYYY
-            {
-                "place_id": "ChIJtest123",
-                "start_date": "2024/01/01",
-                "end_date": "2024-01-02",
-            },  # slashes
-            {
-                "place_id": "ChIJtest123",
-                "start_date": "2024-1-1",
-                "end_date": "2024-01-02",
-            },  # no leading zeros
-            {
-                "place_id": "ChIJtest123",
-                "start_date": "2024-01-01",
-                "end_date": "24-01-02",
-            },  # 2-digit year
+                "start_date": "2024-01-01T00:00:00Z",
+                "end_date": "2024-01-02T23:59:59Z",
+            },  # missing place_id
+            {"place_id": "ChIJtest123", "end_date": "2024-01-02T23:59:59Z"},  # missing start_date
+            {"place_id": "ChIJtest123", "start_date": "2024-01-01T00:00:00Z"},  # missing end_date
             {
                 "place_id": "ChIJtest123",
                 "start_date": "not-a-date",
-                "end_date": "2024-01-02",
+                "end_date": "2024-01-02T23:59:59Z",
             },  # invalid string
+            {
+                "place_id": "ChIJtest123",
+                "start_date": "2024-01-01T00:00:00Z",
+                "end_date": "not-a-date",
+            },  # invalid end string
         ],
     )
     async def test_get_parties_nearby_validation_errors(self, params: dict[str, str]):

--- a/frontend/src/app/police/page.tsx
+++ b/frontend/src/app/police/page.tsx
@@ -161,6 +161,18 @@ export default function PolicePage() {
     });
   }, [advancedFilters, baseParties]);
 
+  // Include exact match party in map pins even though it's excluded from the nearby list
+  const exactMatchParty = nearbyData?.exact_match?.party;
+  const mapParties = useMemo(() => {
+    if (!exactMatchParty) return filteredParties;
+    const alreadyIncluded = filteredParties.some(
+      (p) => p.id === exactMatchParty.id
+    );
+    return alreadyIncluded
+      ? filteredParties
+      : [exactMatchParty, ...filteredParties];
+  }, [filteredParties, exactMatchParty]);
+
   // Reset to first page when the party list changes (filters/date range updated)
   useEffect(() => {
     setCurrentPage(0);
@@ -399,7 +411,7 @@ export default function PolicePage() {
           </h2>
           <div className="min-h-0 lg:flex-1 overflow-hidden rounded-md max-lg:h-80">
             <EmbeddedMap
-              parties={filteredParties}
+              parties={mapParties}
               activeParty={activeParty}
               center={
                 placeDetails

--- a/frontend/src/lib/api/party/party.service.ts
+++ b/frontend/src/lib/api/party/party.service.ts
@@ -3,6 +3,7 @@ import { ListQueryParams, toAxiosParams } from "@/lib/api/shared/query-params";
 import apiClient from "@/lib/network/apiClient";
 import { PaginatedResponse } from "@/lib/shared";
 import { AxiosInstance } from "axios";
+import { endOfDay } from "date-fns";
 import {
   AdminCreatePartyDto,
   PartyDto,
@@ -51,15 +52,13 @@ export class PartyService {
     startDate: Date,
     endDate: Date
   ): Promise<ProximitySearchResponse> {
-    const endOfDay = new Date(endDate);
-    endOfDay.setHours(23, 59, 59, 999);
     const response = await this.client.get<ProximitySearchResponseBackend>(
       "/parties/nearby",
       {
         params: {
           place_id: placeId,
           start_date: startDate.toISOString(),
-          end_date: endOfDay.toISOString(),
+          end_date: endOfDay(endDate).toISOString(),
         },
       }
     );

--- a/frontend/src/lib/api/party/party.service.ts
+++ b/frontend/src/lib/api/party/party.service.ts
@@ -3,7 +3,6 @@ import { ListQueryParams, toAxiosParams } from "@/lib/api/shared/query-params";
 import apiClient from "@/lib/network/apiClient";
 import { PaginatedResponse } from "@/lib/shared";
 import { AxiosInstance } from "axios";
-import { format } from "date-fns";
 import {
   AdminCreatePartyDto,
   PartyDto,
@@ -52,13 +51,15 @@ export class PartyService {
     startDate: Date,
     endDate: Date
   ): Promise<ProximitySearchResponse> {
+    const endOfDay = new Date(endDate);
+    endOfDay.setHours(23, 59, 59, 999);
     const response = await this.client.get<ProximitySearchResponseBackend>(
       "/parties/nearby",
       {
         params: {
           place_id: placeId,
-          start_date: format(startDate, "yyyy-MM-dd"),
-          end_date: format(endDate, "yyyy-MM-dd"),
+          start_date: startDate.toISOString(),
+          end_date: endOfDay.toISOString(),
         },
       }
     );


### PR DESCRIPTION
Proximity search was missing parties that showed up fine in the all-parties list.

Changes:

- Fixed nearby search ignoring the officer's local timezone when filtering by date — it now uses the same time window as the all-parties list
- Fixed nearby search sometimes missing a party at the exact searched address due to a small coordinate mismatch between Google Maps and what's stored in the DB
- Added regression tests for both bugs and updated existing nearby tests to match the new date format

Closes #368
Closes #369