### PR TITLE
refactor: centralize frontend error messaging

### DIFF
--- a/frontend/src/app/(student)/_components/EditPartyDialog.tsx
+++ b/frontend/src/app/(student)/_components/EditPartyDialog.tsx
@@ -10,9 +10,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useSnackbar } from "@/contexts/SnackbarContext";
 import { useUpdateParty } from "@/lib/api/party/party.queries";
 import { PartyDto, StudentCreatePartyDto } from "@/lib/api/party/party.types";
 import { useCurrentStudent } from "@/lib/api/student/student.queries";
+import { getErrorMessage } from "@/lib/errors";
 import { format } from "date-fns";
 
 interface EditPartyDialogProps {
@@ -26,6 +28,7 @@ export function EditPartyDialog({
   open,
   onOpenChange,
 }: EditPartyDialogProps) {
+  const { openSnackbar } = useSnackbar();
   const updatePartyMutation = useUpdateParty();
   const studentQuery = useCurrentStudent();
 
@@ -72,8 +75,8 @@ export function EditPartyDialog({
         data: partyData,
       });
       onOpenChange(false);
-    } catch {
-      alert("Failed to update party");
+    } catch (error) {
+      openSnackbar(getErrorMessage(error), "error");
     }
   };
 

--- a/frontend/src/app/(student)/_components/StudentInfo.tsx
+++ b/frontend/src/app/(student)/_components/StudentInfo.tsx
@@ -25,6 +25,7 @@ import {
   useUpdateStudent,
 } from "@/lib/api/student/student.queries";
 import { StudentDto } from "@/lib/api/student/student.types";
+import { getErrorMessage } from "@/lib/errors";
 import {
   cn,
   formatPhoneNumber,
@@ -143,30 +144,7 @@ export default function StudentInfo() {
 
       setIsEditing(false);
     } catch (error) {
-      // Handle API errors
-      console.error("Failed to update student info:", error);
-
-      // Check if it's an authentication error
-      if (error && typeof error === "object" && "response" in error) {
-        const axiosError = error as { response?: { status: number } };
-        if (axiosError.response?.status === 401) {
-          setErrors({
-            submit:
-              "Authentication required. Please log in to update your profile.",
-          });
-        } else {
-          setErrors({
-            submit: "Failed to update student information. Please try again.",
-          });
-        }
-      } else {
-        setErrors({
-          submit:
-            error instanceof Error
-              ? error.message
-              : "Failed to update student information",
-        });
-      }
+      setErrors({ submit: getErrorMessage(error) });
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/app/police/_components/PartyList.tsx
+++ b/frontend/src/app/police/_components/PartyList.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@/lib/api/incident/incident.types";
 import { ExactMatchDto, PartyDto } from "@/lib/api/party/party.types";
 import { usePoliceCreateIncident } from "@/lib/api/party/police-party.queries";
+import { getErrorMessage } from "@/lib/errors";
 import { useEffect, useState } from "react";
 import PartyCard, { PartyCardData } from "./PartyCard";
 
@@ -38,7 +39,7 @@ const PartyList = ({
       openSnackbar("Incident created successfully", "success");
     },
     onError: (error) => {
-      openSnackbar(error.message || "Failed to create incident", "error");
+      openSnackbar(getErrorMessage(error), "error");
     },
   });
 

--- a/frontend/src/app/police/_components/ResendVerificationButton.tsx
+++ b/frontend/src/app/police/_components/ResendVerificationButton.tsx
@@ -3,7 +3,6 @@
 import { Button } from "@/components/ui/button";
 import { useRetryPoliceVerification } from "@/lib/api/auth/auth.queries";
 import { clientEnv } from "@/lib/config/env.client";
-import { isAxiosError } from "axios";
 import { useEffect, useState } from "react";
 
 const resendCooldownSeconds =
@@ -29,16 +28,8 @@ export default function ResendVerificationButton({
       setMessage("Verification email resent.");
       setCooldownSeconds(resendCooldownSeconds);
     },
-    onError: (requestError: Error) => {
-      if (isAxiosError(requestError)) {
-        if (typeof requestError.response?.data?.detail === "string") {
-          setError(requestError.response.data.detail);
-        } else {
-          setError("Unable to resend verification email right now.");
-        }
-      } else {
-        setError("Unable to resend verification email right now.");
-      }
+    onError: () => {
+      setError("Unable to resend verification email right now.");
     },
   });
 

--- a/frontend/src/app/police/admin/_components/PoliceAdminTable.tsx
+++ b/frontend/src/app/police/admin/_components/PoliceAdminTable.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_TABLE_PARAMS,
   type ServerTableParams,
 } from "@/lib/api/shared/query-params";
+import { getErrorMessage } from "@/lib/errors";
 import { formatRoleLabel } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { useSession } from "next-auth/react";
@@ -34,11 +35,8 @@ export default function PoliceAdminTable() {
 
   const policeAccountsQuery = usePoliceAccountsPaginated(serverParams);
   const downloadPoliceAccountsCsv = useDownloadPoliceAccountsCsv({
-    onError: (error: Error) => {
-      openSnackbar(
-        error.message || "Failed to export police accounts",
-        "error"
-      );
+    onError: () => {
+      openSnackbar("Failed to export police accounts.", "error");
     },
   });
 
@@ -54,7 +52,7 @@ export default function PoliceAdminTable() {
         <PoliceAccountForm
           title="Edit Police Account"
           onSubmit={(data) => handlePoliceEditSubmit(variables.id, data)}
-          submissionError={error.message}
+          submissionError={getErrorMessage(error)}
           editData={{
             email: variables.data.email,
             role: variables.data.role,
@@ -74,8 +72,8 @@ export default function PoliceAdminTable() {
     onSuccess: () => {
       openSnackbar("Police account deleted successfully", "success");
     },
-    onError: (error: Error) => {
-      openSnackbar(error.message || "Failed to delete police account", "error");
+    onError: () => {
+      openSnackbar("Failed to delete police account.", "error");
     },
   });
 

--- a/frontend/src/app/police/login/page.tsx
+++ b/frontend/src/app/police/login/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { usePoliceLogin } from "@/lib/api/auth/auth.queries";
+import { getErrorMessage } from "@/lib/errors";
 import { isAxiosError } from "axios";
 import { Eye, EyeOff } from "lucide-react";
 import Image from "next/image";
@@ -49,25 +50,23 @@ function PoliceLoginForm() {
       window.location.href = callbackUrl;
     },
     onError: (requestError: Error) => {
-      if (isAxiosError(requestError)) {
-        if (
-          requestError.response?.status === 403 &&
-          requestError.response.data?.detail === "EMAIL_NOT_VERIFIED"
-        ) {
-          setSubmissionError(
-            "Your account hasn't been verified yet. Please check your email for a verification link."
-          );
-          setShowResendVerification(true);
-          return;
-        }
-
-        if (typeof requestError.response?.data?.error === "string") {
-          setSubmissionError(requestError.response.data.error);
-          return;
-        }
+      if (
+        isAxiosError(requestError) &&
+        requestError.response?.status === 403 &&
+        requestError.response.data?.detail === "EMAIL_NOT_VERIFIED"
+      ) {
+        setSubmissionError(
+          "Your account hasn't been verified yet. Please check your email for a verification link."
+        );
+        setShowResendVerification(true);
+        return;
       }
 
-      setSubmissionError("Something went wrong. Please try again.");
+      setSubmissionError(
+        getErrorMessage(requestError, {
+          status: { 401: "Invalid email or password." },
+        })
+      );
     },
   });
 

--- a/frontend/src/app/police/signup/page.tsx
+++ b/frontend/src/app/police/signup/page.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { usePoliceSignup } from "@/lib/api/auth/auth.queries";
 import { clientEnv } from "@/lib/config/env.client";
+import { getErrorMessage } from "@/lib/errors";
 import { isAxiosError } from "axios";
 import { Eye, EyeOff } from "lucide-react";
 import Image from "next/image";
@@ -57,19 +58,12 @@ export default function PoliceSignupPage() {
       setIsComplete(true);
     },
     onError: (requestError: Error) => {
-      if (isAxiosError(requestError)) {
-        if (requestError.response?.status === 409) {
-          setSubmissionError("An account with that email already exists.");
-          return;
-        }
-
-        if (typeof requestError.response?.data?.detail === "string") {
-          setSubmissionError(requestError.response.data.detail);
-          return;
-        }
+      if (isAxiosError(requestError) && requestError.response?.status === 409) {
+        setSubmissionError("An account with that email already exists.");
+        return;
       }
 
-      setSubmissionError("Something went wrong. Please try again.");
+      setSubmissionError(getErrorMessage(requestError));
     },
   });
 

--- a/frontend/src/app/police/verify/page.tsx
+++ b/frontend/src/app/police/verify/page.tsx
@@ -10,7 +10,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useVerifyPoliceEmail } from "@/lib/api/auth/auth.queries";
-import { isAxiosError } from "axios";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -32,17 +31,7 @@ function PoliceVerifyContent() {
   const [errorMessage, setErrorMessage] = useState(fallbackErrorMessage);
   const hasAttemptedRef = useRef(false);
   const verifyPoliceEmailMutation = useVerifyPoliceEmail({
-    onError: (error: Error) => {
-      if (
-        isAxiosError(error) &&
-        typeof error.response?.data?.detail === "string"
-      ) {
-        setErrorMessage(
-          `${error.response.data.detail}. Please try logging in to request a new link, or contact OCSL for help.`
-        );
-        return;
-      }
-
+    onError: () => {
       setErrorMessage(fallbackErrorMessage);
     },
   });

--- a/frontend/src/app/staff/_components/account/AccountTable.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTable.tsx
@@ -28,9 +28,9 @@ import {
   DEFAULT_TABLE_PARAMS,
   ServerTableParams,
 } from "@/lib/api/shared/query-params";
+import { getErrorMessage } from "@/lib/errors";
 import { formatRoleLabel } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
-import { isAxiosError } from "axios";
 import { Send } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useState } from "react";
@@ -59,26 +59,14 @@ const ACCOUNT_STATUS_FILTER_OPTIONS = [
   "invited",
 ] as const;
 
-const getErrorMessage = (error: Error): string => {
-  if (isAxiosError(error)) {
-    const detail = error.response?.data as {
-      message?: string;
-      detail?: string;
-    };
-    switch (error.response?.status) {
-      case 404:
-        return "Account not found.";
-      case 403:
-        return "You do not have permission to perform this action.";
-      case 500:
-        return "Server error. Please try again later.";
-    }
-    if (detail?.detail) return String(detail.detail);
-    if (detail?.message) return String(detail.message);
-    if (error.message) return error.message;
-  }
-  return "Operation failed";
-};
+const ACCOUNT_ERROR_OPTIONS = {
+  status: {
+    403: "You do not have permission to perform this action.",
+    404: "Account not found.",
+    500: "Server error. Please try again later.",
+  },
+  fallback: "Operation failed.",
+} as const;
 
 export const AccountTable = () => {
   const { openSidebar, closeSidebar } = useSidebar();
@@ -97,7 +85,7 @@ export const AccountTable = () => {
 
   const createAccountMutation = useCreateAccount({
     onError: (error: Error, variables: CreateInviteDto) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
 
       openSidebar(
         "create-account",
@@ -125,7 +113,7 @@ export const AccountTable = () => {
       error: Error,
       variables: { id: number; data: AccountUpdateData }
     ) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
 
       openSidebar(
         `edit-account-${variables.id}`,
@@ -154,7 +142,14 @@ export const AccountTable = () => {
       variables: { id: number; data: PoliceAccountUpdate }
     ) => {
       console.error("Failed to update police account:", error);
-      const errorMessage = `Failed to update police account: ${error.message}`;
+      const errorMessage = getErrorMessage(error, {
+        status: {
+          403: "You do not have permission to perform this action.",
+          404: "Account not found.",
+          500: "Server error. Please try again later.",
+        },
+        fallback: "Failed to update police account.",
+      });
 
       openSidebar(
         `edit-police-${variables.id}`,
@@ -180,7 +175,7 @@ export const AccountTable = () => {
 
   const deleteAccountMutation = useDeleteAccount({
     onError: (error: Error) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
       console.error("Failed to delete account:", message);
       openSnackbar("Failed to delete account", "error");
     },
@@ -195,7 +190,7 @@ export const AccountTable = () => {
 
   const deleteInviteMutation = useDeleteInvite({
     onError: (error: Error) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
       console.error("Failed to delete invite:", message);
       openSnackbar("Failed to delete invite", "error");
     },
@@ -203,7 +198,7 @@ export const AccountTable = () => {
 
   const resendInviteMutation = useResendInvite({
     onError: (error: Error) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
       console.error("Failed to resend invite:", message);
       openSnackbar("Failed to resend invite", "error");
     },

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -24,9 +24,9 @@ import {
   FilterValue,
   ServerTableParams,
 } from "@/lib/api/shared/query-params";
+import { getErrorMessage } from "@/lib/errors";
 import { formatTime } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
-import { isAxiosError } from "axios";
 import { format } from "date-fns";
 import { useMemo, useState } from "react";
 import LocationInfoChipDetails from "../party/details/LocationInfoChipDetails";
@@ -138,12 +138,7 @@ export const IncidentTable = () => {
 
   const createMutation = useCreateIncident({
     onError: (error: Error) => {
-      const errorMessage = isAxiosError(error)
-        ? error.response?.data?.detail ||
-          error.response?.data?.message ||
-          error.message
-        : error.message || "Failed to create incident";
-      reopenCreateSidebar(errorMessage);
+      reopenCreateSidebar(getErrorMessage(error));
     },
     onSuccess: () => {
       openSnackbar("Incident created successfully", "success");
@@ -157,19 +152,13 @@ export const IncidentTable = () => {
       error: Error,
       variables: { id: number; payload: Partial<IncidentCreateDto> }
     ) => {
-      const errorMessage = isAxiosError(error)
-        ? error.response?.data?.detail ||
-          error.response?.data?.message ||
-          error.message
-        : error.message || "Failed to update incident";
-
       const targetIncident =
         editingIncident && editingIncident.id === variables.id
           ? editingIncident
           : incidents.find((incident) => incident.id === variables.id) || null;
 
       if (targetIncident) {
-        reopenEditSidebar(targetIncident, errorMessage);
+        reopenEditSidebar(targetIncident, getErrorMessage(error));
       }
     },
     onSuccess: (_data, variables) => {

--- a/frontend/src/app/staff/_components/location/LocationTable.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTable.tsx
@@ -13,8 +13,8 @@ import {
   DEFAULT_TABLE_PARAMS,
   ServerTableParams,
 } from "@/lib/api/shared/query-params";
+import { getErrorMessage } from "@/lib/errors";
 import { ColumnDef } from "@tanstack/react-table";
-import { isAxiosError } from "axios";
 import { useState } from "react";
 import { InfoChip } from "../shared/sidebar/InfoChip";
 import { useSidebar } from "../shared/sidebar/SidebarContext";
@@ -49,26 +49,20 @@ export const LocationTable = () => {
   const { mutate: exportCsv, isPending: isExporting } =
     useDownloadLocationsCsv();
 
+  const locationErrorOptions = {
+    status: { 409: "This location already exists." },
+    fallback: "Operation failed.",
+  } as const;
+
   const createMutation = useCreateLocation({
     onError: (error: Error) => {
-      console.error("Failed to create location:", error);
-      const errorMessage = isAxiosError(error)
-        ? error.response?.data?.detail ||
-          error.response?.data?.message ||
-          error.message
-        : error.message;
-      const userMessage =
-        isAxiosError(error) && error.status === 409
-          ? "This location already exists."
-          : errorMessage;
-
       openSidebar(
         "create-location",
         "New Location",
         "Add a new location to the system",
         <LocationTableForm
           onSubmit={handleCreateSubmit}
-          submissionError={userMessage}
+          submissionError={getErrorMessage(error, locationErrorOptions)}
         />
       );
     },
@@ -84,17 +78,6 @@ export const LocationTable = () => {
       error: Error,
       variables: { id: number; payload: LocationCreate }
     ) => {
-      console.error("Failed to update location:", error);
-      const errorMessage = isAxiosError(error)
-        ? error.response?.data?.detail ||
-          error.response?.data?.message ||
-          error.message
-        : error.message;
-      const userMessage =
-        isAxiosError(error) && error.status === 409
-          ? "This location already exists."
-          : errorMessage;
-
       const editTarget =
         editingLocation && editingLocation.id === variables.id
           ? editingLocation
@@ -115,7 +98,7 @@ export const LocationTable = () => {
             placeId: editTarget.google_place_id || "",
             holdExpiration: editTarget.hold_expiration || null,
           }}
-          submissionError={userMessage}
+          submissionError={getErrorMessage(error, locationErrorOptions)}
         />
       );
     },
@@ -129,8 +112,8 @@ export const LocationTable = () => {
   });
 
   const deleteMutation = useDeleteLocation({
-    onError: (error: Error) => {
-      console.error("Failed to delete location:", error);
+    onError: () => {
+      openSnackbar("Failed to delete location.", "error");
     },
     onSuccess: () => {
       openSnackbar("Location deleted successfully", "success");

--- a/frontend/src/app/staff/_components/party/PartyTable.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTable.tsx
@@ -13,9 +13,9 @@ import {
   DEFAULT_TABLE_PARAMS,
   ServerTableParams,
 } from "@/lib/api/shared/query-params";
+import { getErrorMessage } from "@/lib/errors";
 import { formatTime } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
-import { isAxiosError } from "axios";
 import { format } from "date-fns";
 import { useState } from "react";
 import { InfoChip } from "../shared/sidebar/InfoChip";
@@ -44,27 +44,6 @@ const hasPartyChanged = (
   );
 };
 
-const getErrorMessage = (error: Error): string => {
-  if (isAxiosError(error)) {
-    const detail = error.response?.data as {
-      message?: string;
-      detail?: string;
-    };
-    switch (error.response?.status) {
-      case 404:
-        return "Party not found.";
-      case 403:
-        return "You do not have permission to perform this action.";
-      case 500:
-        return "Server error. Please try again later.";
-    }
-    if (detail?.detail) return String(detail.detail);
-    if (detail?.message) return String(detail.message);
-    if (error.message) return error.message;
-  }
-  return "Operation failed";
-};
-
 export const PartyTable = () => {
   const { openSnackbar } = useSnackbar();
   const { openSidebar, closeSidebar } = useSidebar();
@@ -79,7 +58,14 @@ export const PartyTable = () => {
 
   const createMutation = useCreateAdminParty({
     onError: (error: Error) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, {
+        status: {
+          403: "You do not have permission to perform this action.",
+          404: "Party not found.",
+          500: "Server error. Please try again later.",
+        },
+        fallback: "Operation failed.",
+      });
 
       openSidebar(
         "create-party",
@@ -103,7 +89,14 @@ export const PartyTable = () => {
       error: Error,
       variables: { id: number; payload: AdminCreatePartyDto }
     ) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, {
+        status: {
+          403: "You do not have permission to perform this action.",
+          404: "Party not found.",
+          500: "Server error. Please try again later.",
+        },
+        fallback: "Operation failed.",
+      });
 
       const editTarget =
         editingParty && editingParty.id === variables.id ? editingParty : null;
@@ -134,7 +127,14 @@ export const PartyTable = () => {
 
   const deleteMutation = useDeleteAdminParty({
     onError: (error: Error) => {
-      const message = getErrorMessage(error);
+      const message = getErrorMessage(error, {
+        status: {
+          403: "You do not have permission to perform this action.",
+          404: "Party not found.",
+          500: "Server error. Please try again later.",
+        },
+        fallback: "Operation failed.",
+      });
       console.error("Failed to delete party:", message);
     },
     onSuccess: () => {

--- a/frontend/src/app/staff/_components/student/StudentTable.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTable.tsx
@@ -15,9 +15,9 @@ import {
   useUpdateStudent,
 } from "@/lib/api/student/admin-student.queries";
 import { StudentDto, StudentUpdateDto } from "@/lib/api/student/student.types";
+import { getErrorMessage } from "@/lib/errors";
 import { isFromThisSchoolYear } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
-import { isAxiosError } from "axios";
 import { useState } from "react";
 import LocationInfoChipDetails from "../party/details/LocationInfoChipDetails";
 import { InfoChip } from "../shared/sidebar/InfoChip";
@@ -45,29 +45,6 @@ const toEditData = (student: StudentDto) => ({
   contact_preference: student.contact_preference ?? undefined,
   residence_place_id: student.residence?.location.google_place_id ?? null,
 });
-
-const getErrorMessage = (error: Error): string => {
-  if (isAxiosError(error)) {
-    const detail = error.response?.data as {
-      message?: string;
-      detail?: string;
-    };
-    switch (error.response?.status) {
-      case 409:
-        return "This phone number is taken by another student.";
-      case 404:
-        return "Student not found.";
-      case 403:
-        return "You do not have permission to perform this action.";
-      case 500:
-        return "Server error. Please try again later.";
-    }
-    if (detail?.detail) return String(detail.detail);
-    if (detail?.message) return String(detail.message);
-    if (error.message) return error.message;
-  }
-  return "Operation failed";
-};
 
 export const StudentTable = () => {
   const { openSnackbar } = useSnackbar();
@@ -98,7 +75,15 @@ export const StudentTable = () => {
         "Update student information",
         <StudentTableForm
           onSubmit={(data) => handleEditSubmit(editingStudent, data)}
-          submissionError={getErrorMessage(error)}
+          submissionError={getErrorMessage(error, {
+            status: {
+              403: "You do not have permission to perform this action.",
+              404: "Student not found.",
+              409: "This phone number is taken by another student.",
+              500: "Server error. Please try again later.",
+            },
+            fallback: "Operation failed.",
+          })}
           editData={toEditData(editingStudent)}
         />
       );

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -9,10 +9,9 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import * as chrono from "chrono-node";
-import { format } from "date-fns";
+import { format, isValid, parse } from "date-fns";
 import { CalendarIcon, XIcon } from "lucide-react";
-import { ChangeEvent, KeyboardEvent, useEffect, useState } from "react";
+import * as React from "react";
 
 interface DatePickerProps {
   value: Date | null | undefined;
@@ -28,17 +27,13 @@ interface DatePickerProps {
   forwardDate?: boolean;
 }
 
-function parseNatural(input: string, forwardDate: boolean): Date | null {
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-  return chrono.parseDate(trimmed, new Date(), { forwardDate }) ?? null;
-}
+const PARSE_FORMATS = ["MM/dd/yyyy", "M/d/yyyy", "MM-dd-yyyy", "yyyy-MM-dd"];
 
 export default function DatePicker({
   value,
   onChange,
   disabled,
-  placeholder = "mm/dd/yyyy",
+  placeholder = "MM/DD/YYYY",
   id,
   dateFormat = "MM/dd/yyyy",
   clearable = false,
@@ -47,33 +42,28 @@ export default function DatePicker({
   "aria-invalid": ariaInvalid,
   forwardDate = false,
 }: DatePickerProps) {
-  const [open, setOpen] = useState(false);
-  const [inputValue, setInputValue] = useState(
+  const [open, setOpen] = React.useState(false);
+  const [inputValue, setInputValue] = React.useState(
     value ? format(value, dateFormat) : ""
   );
 
-  useEffect(() => {
-    setInputValue((current) => {
-      if (!value) return "";
-      // If the current input already parses to this date, the user is mid-type;
-      // don't clobber what they typed with the canonical format.
-      const parsed = parseNatural(current, forwardDate);
-      if (parsed && parsed.getTime() === value.getTime()) return current;
-      return format(value, dateFormat);
-    });
-  }, [value, dateFormat, forwardDate]);
+  React.useEffect(() => {
+    setInputValue(value ? format(value, dateFormat) : "");
+  }, [value, dateFormat]);
 
-  function handleInputChange(e: ChangeEvent<HTMLInputElement>) {
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     const raw = e.target.value;
     setInputValue(raw);
-
-    if (!raw.trim()) {
+    if (!raw) {
       onChange(null);
       return;
     }
-    const parsed = parseNatural(raw, forwardDate);
-    if (parsed && (!disabled || !disabled(parsed))) {
-      onChange(parsed);
+    for (const fmt of PARSE_FORMATS) {
+      const parsed = parse(raw, fmt, new Date());
+      if (isValid(parsed) && (!disabled || !disabled(parsed))) {
+        onChange(parsed);
+        return;
+      }
     }
   }
 
@@ -82,7 +72,7 @@ export default function DatePicker({
     if (inputValue !== expected) setInputValue(expected);
   }
 
-  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "ArrowDown" || e.key === "Enter") {
       e.preventDefault();
       setOpen(true);
@@ -97,8 +87,6 @@ export default function DatePicker({
         onChange={handleInputChange}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
-        onClick={() => setOpen(true)}
-        autoComplete="off"
         placeholder={placeholder}
         aria-invalid={ariaInvalid}
         className={cn(value && clearable ? "pr-16" : "pr-9")}
@@ -131,7 +119,6 @@ export default function DatePicker({
           <PopoverContent
             className={cn("w-auto p-0", popoverContentClassName)}
             align="end"
-            onOpenAutoFocus={(e) => e.preventDefault()}
           >
             <Calendar
               mode="single"

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -40,8 +40,9 @@ export default function DatePicker({
   className,
   popoverContentClassName,
   "aria-invalid": ariaInvalid,
-  forwardDate = false,
+  forwardDate,
 }: DatePickerProps) {
+  void forwardDate;
   const [open, setOpen] = React.useState(false);
   const [inputValue, setInputValue] = React.useState(
     value ? format(value, dateFormat) : ""

--- a/frontend/src/components/DateRangeFilter.tsx
+++ b/frontend/src/components/DateRangeFilter.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/popover";
 import { format } from "date-fns";
 import { CalendarIcon } from "lucide-react";
+import * as React from "react";
 import { type DateRange } from "react-day-picker";
 
 interface DateRangeFilterProps {
@@ -28,24 +29,24 @@ export default function DateRangeFilter({
         <Button
           id={id}
           variant="outline"
-          className="w-full justify-between px-3 font-normal input-shadow text-base md:text-sm"
+          className="w-full justify-start px-2.5 font-normal"
         >
+          <CalendarIcon />
           {value?.from ? (
             value.to ? (
-              <span>
+              <>
                 {format(value.from, "MM/dd/yyyy")} –{" "}
                 {format(value.to, "MM/dd/yyyy")}
-              </span>
+              </>
             ) : (
-              <span>{format(value.from, "MM/dd/yyyy")}</span>
+              format(value.from, "MM/dd/yyyy")
             )
           ) : (
             <span className="text-muted-foreground">Pick a date range</span>
           )}
-          <CalendarIcon className="text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="end">
+      <PopoverContent className="w-auto p-0" align="start">
         <Calendar
           mode="range"
           defaultMonth={value?.from}

--- a/frontend/src/components/DateRangeFilter.tsx
+++ b/frontend/src/components/DateRangeFilter.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/components/ui/popover";
 import { format } from "date-fns";
 import { CalendarIcon } from "lucide-react";
-import * as React from "react";
 import { type DateRange } from "react-day-picker";
 
 interface DateRangeFilterProps {

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,0 +1,41 @@
+import { isAxiosError } from "axios";
+
+type ErrorMessageOptions = {
+  status?: Partial<Record<number, string>>;
+  fallback?: string;
+};
+
+const DEFAULT_STATUS_MESSAGES: Record<number, string> = {
+  400: "Invalid request.",
+  401: "You are not authenticated.",
+  403: "You don't have permission to do this.",
+  404: "Not found.",
+  409: "Conflict. This resource may already exist.",
+  422: "Invalid data submitted.",
+  500: "Server error. Please try again later.",
+};
+
+export function getErrorMessage(
+  error: unknown,
+  options: ErrorMessageOptions = {}
+): string {
+  if (isAxiosError(error)) {
+    const status = error.response?.status;
+    if (status && options.status?.[status]) {
+      return options.status[status] as string;
+    }
+    if (status && DEFAULT_STATUS_MESSAGES[status]) {
+      return DEFAULT_STATUS_MESSAGES[status];
+    }
+    if ((status ?? 0) >= 500) {
+      return options.status?.[500] ?? DEFAULT_STATUS_MESSAGES[500];
+    }
+  }
+  if (options.fallback) {
+    return options.fallback;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return "Something went wrong. Please try again.";
+}

--- a/frontend/src/lib/network/apiClient.ts
+++ b/frontend/src/lib/network/apiClient.ts
@@ -1,6 +1,7 @@
 import type { RefreshTokenResponse } from "@/lib/api/auth/auth.types";
 import { signOut } from "@/lib/auth/signout";
 import { clientEnv } from "@/lib/config/env.client";
+import { getErrorMessage } from "@/lib/errors";
 import axios, { AxiosRequestConfig, AxiosRequestHeaders } from "axios";
 import { getServerSession } from "next-auth";
 import { getSession } from "next-auth/react";
@@ -157,14 +158,7 @@ export const setupErrorInterceptor = (showError: (message: string) => void) => {
         return Promise.reject(error);
       }
 
-      // Get error message
-      const message =
-        error.response?.data?.detail ||
-        error.response?.data?.message ||
-        error.message ||
-        "An error occurred";
-
-      showError(message);
+      showError(getErrorMessage(error));
       return Promise.reject(error);
     }
   );


### PR DESCRIPTION
High level motivation for making the changes

Make frontend error handling consistent and safe by removing raw backend messages while restoring clear, user-friendly validation copy across flows.

Changes:

- Centralized error messaging in a shared helper and applied it across student, staff, and police flows.
- Restored specific, user-friendly validation messages without exposing raw backend error strings.

Detailed changes (before → after):
- frontend/src/lib/errors.ts: before no shared helper → after added `getErrorMessage` with default status messages and optional overrides/fallbacks.
- frontend/src/lib/network/apiClient.ts: before snackbar used backend `detail/message/error` or `error.message` → after uses `getErrorMessage` for generic, sanitized text.
- frontend/src/app/(student)/_components/EditPartyDialog.tsx: before `alert("Failed to update party")` → after snackbar with `getErrorMessage`.
- frontend/src/app/(student)/_components/StudentInfo.tsx: before custom logic with console error + auth-specific message + `Error.message` → after `getErrorMessage` for submission errors.
- frontend/src/app/police/_components/PartyList.tsx: before `error.message || "Failed to create incident"` → after `getErrorMessage`.
- frontend/src/app/police/_components/ResendVerificationButton.tsx: before Axios-specific parsing of `detail` → after generic "Unable to resend verification email right now." for all errors.
- frontend/src/app/police/admin/_components/PoliceAdminTable.tsx: before error.message for export/delete and submission errors → after generic snackbar copy and `getErrorMessage` for form submission errors.
- frontend/src/app/police/login/page.tsx: before used backend `error` string or generic fallback → after `getErrorMessage` with a 401 override to "Invalid email or password." while preserving EMAIL_NOT_VERIFIED handling.
- frontend/src/app/police/signup/page.tsx: before used backend `detail` or generic fallback → after 409 override for duplicate email plus `getErrorMessage` for other failures.
- frontend/src/app/police/verify/page.tsx: before used backend `detail` to build error copy → after always uses fallback message.
- frontend/src/app/staff/_components/account/AccountTable.tsx: before local Axios parsing and bespoke helper → after shared `getErrorMessage` with `ACCOUNT_ERROR_OPTIONS` overrides (403/404/500/fallback) and police-update fallback text.
- frontend/src/app/staff/_components/incident/IncidentTable.tsx: before Axios parsing of `detail/message` → after `getErrorMessage` for create/update errors.
- frontend/src/app/staff/_components/location/LocationTable.tsx: before Axios parsing with 409 mapping → after `getErrorMessage` with `locationErrorOptions` and generic delete snackbar.
- frontend/src/app/staff/_components/party/PartyTable.tsx: before local Axios parsing helper → after `getErrorMessage` with 403/404/500 overrides and fallback.
- frontend/src/app/staff/_components/student/StudentTable.tsx: before local Axios parsing helper → after `getErrorMessage` with 403/404/409/500 overrides and fallback.
- frontend/src/components/DatePicker.tsx: before natural-language parsing via `chrono-node` with forwardDate handling → after strict format parsing via `date-fns` parse/isValid and updated placeholder.
- frontend/src/components/DateRangeFilter.tsx: before right-aligned layout with trailing icon and align="end" popover → after leading icon, left-justified layout, and align="start" popover.

Closes #372