### PR TITLE
feat: incident severity counts in staff table

### DIFF
--- a/backend/src/core/utils/query_utils.py
+++ b/backend/src/core/utils/query_utils.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 from fastapi import Depends, Request
 from fastapi.exceptions import RequestValidationError
@@ -21,21 +21,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import SQLColumnExpression
 from src.core.database import get_session
 from src.core.exceptions import BadRequestException
-
-__all__ = [
-    "FilterOperator",
-    "FilterParam",
-    "ListQueryParams",
-    "PaginatedResponse",
-    "PaginationParams",
-    "QueryFieldSet",
-    "QueryService",
-    "SortOrder",
-    "SortParam",
-    "get_paginated_openapi_params",
-    "parse_export_list_query_params",
-    "parse_list_query_params",
-]
 
 
 class PaginatedResponse[T](BaseModel):
@@ -453,6 +438,26 @@ class QueryService:
             pagination=params.pagination,
             sort=effective_sort,
         )
+
+    def apply_params(
+        self,
+        base_query: Select,
+        params: ListQueryParams,
+        field_set: QueryFieldSet,
+        *,
+        only: set[Literal["filter", "sort", "search", "pagination"]] | None = None,
+    ) -> Select:
+        query = base_query
+        if not only or "filter" in only:
+            query = self._apply_filters(query, params.filters, field_set)
+        if not only or "sort" in only:
+            effective_sort = params.sort or field_set.default_sort
+            query = self._apply_sorting(query, effective_sort, field_set)
+        if not only or "search" in only:
+            query = self._apply_search(query, params.search, field_set)
+        if not only or "pagination" in only:
+            query = self._apply_pagination(query, params.pagination)
+        return query
 
     def _apply_filters(
         self, query: Select, filters: list[FilterParam], field_set: QueryFieldSet

--- a/backend/src/core/utils/query_utils.py
+++ b/backend/src/core/utils/query_utils.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any, Literal, Self
+from typing import Any, Self
 
 from fastapi import Depends, Request
 from fastapi.exceptions import RequestValidationError
@@ -420,12 +420,12 @@ class QueryService:
         use_mappings: bool = False,
     ) -> PaginatedResponse[ModelType]:
         effective_sort = params.sort or field_set.default_sort
-        query = self._apply_filters(base_query, params.filters, field_set)
-        query = self._apply_sorting(query, effective_sort, field_set)
-        query = self._apply_search(query, params.search, field_set)
+        query = self.apply_filters(base_query, params.filters, field_set)
+        query = self.apply_sorting(query, effective_sort, field_set)
+        query = self.apply_search(query, params.search, field_set)
 
         total_records = await self._get_total_count(query)
-        query = self._apply_pagination(query, params.pagination)
+        query = self.apply_pagination(query, params.pagination)
 
         result = await self.session.execute(query)
 
@@ -439,27 +439,7 @@ class QueryService:
             sort=effective_sort,
         )
 
-    def apply_params(
-        self,
-        base_query: Select,
-        params: ListQueryParams,
-        field_set: QueryFieldSet,
-        *,
-        only: set[Literal["filter", "sort", "search", "pagination"]] | None = None,
-    ) -> Select:
-        query = base_query
-        if not only or "filter" in only:
-            query = self._apply_filters(query, params.filters, field_set)
-        if not only or "sort" in only:
-            effective_sort = params.sort or field_set.default_sort
-            query = self._apply_sorting(query, effective_sort, field_set)
-        if not only or "search" in only:
-            query = self._apply_search(query, params.search, field_set)
-        if not only or "pagination" in only:
-            query = self._apply_pagination(query, params.pagination)
-        return query
-
-    def _apply_filters(
+    def apply_filters(
         self, query: Select, filters: list[FilterParam], field_set: QueryFieldSet
     ) -> Select:
         for filter_param in filters:
@@ -472,21 +452,21 @@ class QueryService:
 
         return query
 
-    def _apply_sorting(self, query: Select, sort: SortParam, field_set: QueryFieldSet) -> Select:
+    def apply_sorting(self, query: Select, sort: SortParam, field_set: QueryFieldSet) -> Select:
         if sort.field not in field_set.sortable_set:
             raise BadRequestException(f"Sorting on field '{sort.field}' is not allowed")
         field = field_set.fields[sort.field]
         order_fn = desc if sort.order == SortOrder.DESC else asc
         return query.order_by(order_fn(field))
 
-    def _apply_pagination(self, query: Select, pagination: PaginationParams) -> Select:
+    def apply_pagination(self, query: Select, pagination: PaginationParams) -> Select:
         if pagination.skip > 0:
             query = query.offset(pagination.skip)
         if pagination.page_size is not None:
             query = query.limit(pagination.page_size)
         return query
 
-    def _apply_search(self, query: Select, search: str | None, field_set: QueryFieldSet) -> Select:
+    def apply_search(self, query: Select, search: str | None, field_set: QueryFieldSet) -> Select:
         if not search or not field_set.searchable:
             return query
         pattern = f"%{search}%"

--- a/backend/src/modules/incident/incident_model.py
+++ b/backend/src/modules/incident/incident_model.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Self
 
 from pydantic import AwareDatetime, BaseModel, Field
 from src.core.utils.query_utils import PaginatedResponse
@@ -43,7 +44,23 @@ class IncidentDto(IncidentData):
     id: int
 
 
-class PaginatedIncidentsResponse(PaginatedResponse[IncidentDto]):
-    """Paginated response for incidents."""
+class IncidentSeverityCounts(BaseModel):
+    """Counts of incidents grouped by severity (over the filtered result set)."""
 
-    pass
+    remote_warning: int = 0
+    in_person_warning: int = 0
+    citation: int = 0
+
+    @classmethod
+    def from_counts(cls, counts: dict[IncidentSeverity, int]) -> Self:
+        return cls(
+            remote_warning=counts.get(IncidentSeverity.REMOTE_WARNING, 0),
+            in_person_warning=counts.get(IncidentSeverity.IN_PERSON_WARNING, 0),
+            citation=counts.get(IncidentSeverity.CITATION, 0),
+        )
+
+
+class PaginatedIncidentsResponse(PaginatedResponse[IncidentDto]):
+    """Paginated response for incidents, with counts grouped by severity."""
+
+    severity_counts: IncidentSeverityCounts

--- a/backend/src/modules/incident/incident_service.py
+++ b/backend/src/modules/incident/incident_service.py
@@ -97,9 +97,10 @@ class IncidentService:
     async def _get_severity_counts(
         self, base_query: Select, params: ListQueryParams
     ) -> IncidentSeverityCounts:
-        filtered = self.query_service.apply_params(
-            base_query, params, _INCIDENT_QUERY_FIELDS, only={"filter", "search"}
+        filtered = self.query_service.apply_filters(
+            base_query, params.filters, _INCIDENT_QUERY_FIELDS
         )
+        filtered = self.query_service.apply_search(filtered, params.search, _INCIDENT_QUERY_FIELDS)
         subq = filtered.subquery()
         count_query = (
             select(subq.c.severity, func.count()).select_from(subq).group_by(subq.c.severity)

--- a/backend/src/modules/incident/incident_service.py
+++ b/backend/src/modules/incident/incident_service.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 from typing import ClassVar
 
 from fastapi import Depends
-from sqlalchemy import select
+from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from src.core.database import get_session
@@ -23,6 +23,8 @@ from .incident_model import (
     IncidentCreateDto,
     IncidentData,
     IncidentDto,
+    IncidentSeverity,
+    IncidentSeverityCounts,
     IncidentUpdateDto,
     PaginatedIncidentsResponse,
 )
@@ -86,7 +88,27 @@ class IncidentService:
             base_query=base_query,
             field_set=_INCIDENT_QUERY_FIELDS,
         )
-        return PaginatedIncidentsResponse(**result.model_dump())
+        severity_counts = await self._get_severity_counts(base_query, params)
+        return PaginatedIncidentsResponse(
+            **result.model_dump(),
+            severity_counts=severity_counts,
+        )
+
+    async def _get_severity_counts(
+        self, base_query: Select, params: ListQueryParams
+    ) -> IncidentSeverityCounts:
+        filtered = self.query_service.apply_params(
+            base_query, params, _INCIDENT_QUERY_FIELDS, only={"filter", "search"}
+        )
+        subq = filtered.subquery()
+        count_query = (
+            select(subq.c.severity, func.count()).select_from(subq).group_by(subq.c.severity)
+        )
+        result = await self.session.execute(count_query)
+        counts: dict[IncidentSeverity, int] = dict.fromkeys(IncidentSeverity, 0)
+        for severity, count in result.all():
+            counts[severity] = count
+        return IncidentSeverityCounts.from_counts(counts)
 
     async def get_incidents_with_addresses(
         self, params: ListQueryParams

--- a/backend/test/modules/incident/incident_list_features_test.py
+++ b/backend/test/modules/incident/incident_list_features_test.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from httpx import AsyncClient
 from src.modules.incident.incident_model import IncidentDto, IncidentSeverity
-from test.modules.incident.incident_utils import IncidentTestUtils
+from test.modules.incident.incident_utils import IncidentTestUtils, assert_severity_counts
 from test.utils.http.assertions import assert_res_paginated
 from test.utils.http.test_templates import generate_filter_sort_tests, generate_search_tests
 
@@ -281,3 +281,84 @@ class TestIncidentListSearch:
         response = await self.admin_client.get("/api/incidents?search=5555")
         paginated = assert_res_paginated(response, IncidentDto, total_records=1)
         self.incident_utils.assert_matches(paginated.items[0], incident1.to_dto())
+
+
+class TestIncidentListSeverityCounts:
+    """Tests for severity_counts field on GET /api/incidents endpoint."""
+
+    admin_client: AsyncClient
+    incident_utils: IncidentTestUtils
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, incident_utils: IncidentTestUtils, admin_client: AsyncClient):
+        self.incident_utils = incident_utils
+        self.admin_client = admin_client
+
+    @pytest.mark.asyncio
+    async def test_severity_counts_empty(self):
+        """Severity counts should be all zero when there are no incidents."""
+        response = await self.admin_client.get("/api/incidents")
+        assert_res_paginated(response, IncidentDto, total_records=0)
+        assert_severity_counts(response.json())
+
+    @pytest.mark.asyncio
+    async def test_severity_counts_unfiltered(self):
+        """Severity counts should reflect every incident when no filter is applied."""
+        await self.incident_utils.create_many(i=2, severity="remote_warning")
+        await self.incident_utils.create_many(i=3, severity="in_person_warning")
+        await self.incident_utils.create_many(i=1, severity="citation")
+
+        response = await self.admin_client.get("/api/incidents")
+        assert_res_paginated(response, IncidentDto, total_records=6)
+        assert_severity_counts(
+            response.json(), remote_warning=2, in_person_warning=3, citation=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_severity_counts_ignore_pagination(self):
+        """Severity counts should reflect the full filtered set, not just the current page."""
+        await self.incident_utils.create_many(i=4, severity="remote_warning")
+        await self.incident_utils.create_many(i=2, severity="citation")
+
+        response = await self.admin_client.get("/api/incidents?page_number=1&page_size=2")
+        paginated = assert_res_paginated(
+            response, IncidentDto, total_records=6, page_size=2, total_pages=3
+        )
+        assert len(paginated.items) == 2
+        assert_severity_counts(response.json(), remote_warning=4, citation=2)
+
+    @pytest.mark.asyncio
+    async def test_severity_counts_respect_filters(self):
+        """Severity counts should reflect filters applied to the list query."""
+        await self.incident_utils.create_many(i=2, severity="remote_warning", reference_id="A")
+        await self.incident_utils.create_many(i=1, severity="in_person_warning", reference_id="A")
+        await self.incident_utils.create_many(i=3, severity="citation", reference_id="B")
+
+        response = await self.admin_client.get("/api/incidents?reference_id_eq=A")
+        assert_res_paginated(response, IncidentDto, total_records=3)
+        assert_severity_counts(
+            response.json(), remote_warning=2, in_person_warning=1, citation=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_severity_counts_respect_search(self):
+        """Severity counts should reflect search applied to the list query."""
+        await self.incident_utils.create_one(severity="remote_warning", reference_id="MATCH-1")
+        await self.incident_utils.create_one(severity="citation", reference_id="MATCH-2")
+        await self.incident_utils.create_one(severity="in_person_warning", reference_id="OTHER")
+
+        response = await self.admin_client.get("/api/incidents?search=MATCH")
+        assert_res_paginated(response, IncidentDto, total_records=2)
+        assert_severity_counts(response.json(), remote_warning=1, citation=1)
+
+    @pytest.mark.asyncio
+    async def test_severity_counts_consistent_with_self_filter(self):
+        """Filtering by severity should leave only that bucket non-zero."""
+        await self.incident_utils.create_many(i=2, severity="remote_warning")
+        await self.incident_utils.create_many(i=3, severity="in_person_warning")
+
+        response = await self.admin_client.get(
+            "/api/incidents?severity_eq=in_person_warning"
+        )
+        assert_res_paginated(response, IncidentDto, total_records=3)
+        assert_severity_counts(response.json(), in_person_warning=3)

--- a/backend/test/modules/incident/incident_list_features_test.py
+++ b/backend/test/modules/incident/incident_list_features_test.py
@@ -310,9 +310,7 @@ class TestIncidentListSeverityCounts:
 
         response = await self.admin_client.get("/api/incidents")
         assert_res_paginated(response, IncidentDto, total_records=6)
-        assert_severity_counts(
-            response.json(), remote_warning=2, in_person_warning=3, citation=1
-        )
+        assert_severity_counts(response.json(), remote_warning=2, in_person_warning=3, citation=1)
 
     @pytest.mark.asyncio
     async def test_severity_counts_ignore_pagination(self):
@@ -336,9 +334,7 @@ class TestIncidentListSeverityCounts:
 
         response = await self.admin_client.get("/api/incidents?reference_id_eq=A")
         assert_res_paginated(response, IncidentDto, total_records=3)
-        assert_severity_counts(
-            response.json(), remote_warning=2, in_person_warning=1, citation=0
-        )
+        assert_severity_counts(response.json(), remote_warning=2, in_person_warning=1, citation=0)
 
     @pytest.mark.asyncio
     async def test_severity_counts_respect_search(self):
@@ -357,8 +353,6 @@ class TestIncidentListSeverityCounts:
         await self.incident_utils.create_many(i=2, severity="remote_warning")
         await self.incident_utils.create_many(i=3, severity="in_person_warning")
 
-        response = await self.admin_client.get(
-            "/api/incidents?severity_eq=in_person_warning"
-        )
+        response = await self.admin_client.get("/api/incidents?severity_eq=in_person_warning")
         assert_res_paginated(response, IncidentDto, total_records=3)
         assert_severity_counts(response.json(), in_person_warning=3)

--- a/backend/test/modules/incident/incident_utils.py
+++ b/backend/test/modules/incident/incident_utils.py
@@ -125,3 +125,21 @@ class IncidentTestUtils(
     @override
     async def create_one(self, **overrides: Unpack[IncidentOverrides]) -> IncidentEntity:
         return await super().create_one(**overrides)
+
+
+def assert_severity_counts(
+    response_json: dict,
+    *,
+    remote_warning: int = 0,
+    in_person_warning: int = 0,
+    citation: int = 0,
+) -> None:
+    """Assert that the paginated incidents response includes the expected severity counts."""
+    counts = response_json.get("severity_counts")
+    assert counts is not None, f"Expected severity_counts in response, got: {response_json}"
+    expected = {
+        "remote_warning": remote_warning,
+        "in_person_warning": in_person_warning,
+        "citation": citation,
+    }
+    assert counts == expected, f"Expected severity_counts {expected}, got {counts}"

--- a/frontend/src/app/police/_components/AdvancedPartySearch.tsx
+++ b/frontend/src/app/police/_components/AdvancedPartySearch.tsx
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { INCIDENT_SEVERITY_LABELS } from "@/lib/api/incident/incident.types";
 import { IncidentSeverity } from "@/lib/api/location/location.types";
 import { ContactPreference } from "@/lib/api/student/student.types";
 import { X } from "lucide-react";
@@ -205,11 +206,15 @@ export default function AdvancedPartySearch({
                 )}
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="remote_warning">Remote Warning</SelectItem>
-                <SelectItem value="in_person_warning">
-                  In-Person Warning
+                <SelectItem value="remote_warning">
+                  {INCIDENT_SEVERITY_LABELS.remote_warning}
                 </SelectItem>
-                <SelectItem value="citation">Citation</SelectItem>
+                <SelectItem value="in_person_warning">
+                  {INCIDENT_SEVERITY_LABELS.in_person_warning}
+                </SelectItem>
+                <SelectItem value="citation">
+                  {INCIDENT_SEVERITY_LABELS.citation}
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
@@ -1,15 +1,10 @@
 import IncidentFlag from "@/components/icons/IncidentFlag";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
-  IncidentSeverity,
+  INCIDENT_SEVERITIES,
+  INCIDENT_SEVERITY_LABELS,
   IncidentSeverityCounts,
 } from "@/lib/api/incident/incident.types";
-
-const SEVERITY_DISPLAY: { severity: IncidentSeverity; label: string }[] = [
-  { severity: "remote_warning", label: "Remote Warnings" },
-  { severity: "in_person_warning", label: "In-Person Warnings" },
-  { severity: "citation", label: "Citations" },
-];
 
 export function IncidentSeverityCountsHeader({
   counts,
@@ -20,13 +15,15 @@ export function IncidentSeverityCountsHeader({
 }) {
   return (
     <div className="flex items-center gap-6 flex-wrap">
-      {SEVERITY_DISPLAY.map(({ severity, label }) => (
+      {INCIDENT_SEVERITIES.map((severity) => (
         <div
           key={severity}
           className="flex items-center gap-2 text-sm whitespace-nowrap"
         >
           <IncidentFlag type={severity} />
-          <span className="text-muted-foreground">{label}</span>
+          <span className="text-muted-foreground">
+            {INCIDENT_SEVERITY_LABELS[severity]}s
+          </span>
           {isLoading || !counts ? (
             <Skeleton className="h-4 w-6" />
           ) : (

--- a/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
@@ -14,14 +14,14 @@ export function IncidentSeverityCountsHeader({
   isLoading?: boolean;
 }) {
   return (
-    <div className="flex items-center gap-6 flex-wrap">
+    <div className="@container w-full flex items-center gap-6">
       {INCIDENT_SEVERITIES.map((severity) => (
         <div
           key={severity}
           className="flex items-center gap-2 text-sm whitespace-nowrap"
         >
           <IncidentFlag type={severity} />
-          <span className="text-text">
+          <span className="hidden @md:inline">
             {INCIDENT_SEVERITY_LABELS[severity]}s
           </span>
           {isLoading || !counts ? (

--- a/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
@@ -21,7 +21,7 @@ export function IncidentSeverityCountsHeader({
           className="flex items-center gap-2 text-sm whitespace-nowrap"
         >
           <IncidentFlag type={severity} />
-          <span className="text-muted-foreground">
+          <span className="text-text">
             {INCIDENT_SEVERITY_LABELS[severity]}s
           </span>
           {isLoading || !counts ? (

--- a/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentSeverityCountsHeader.tsx
@@ -1,0 +1,39 @@
+import IncidentFlag from "@/components/icons/IncidentFlag";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  IncidentSeverity,
+  IncidentSeverityCounts,
+} from "@/lib/api/incident/incident.types";
+
+const SEVERITY_DISPLAY: { severity: IncidentSeverity; label: string }[] = [
+  { severity: "remote_warning", label: "Remote Warnings" },
+  { severity: "in_person_warning", label: "In-Person Warnings" },
+  { severity: "citation", label: "Citations" },
+];
+
+export function IncidentSeverityCountsHeader({
+  counts,
+  isLoading,
+}: {
+  counts?: IncidentSeverityCounts;
+  isLoading?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-6 flex-wrap">
+      {SEVERITY_DISPLAY.map(({ severity, label }) => (
+        <div
+          key={severity}
+          className="flex items-center gap-2 text-sm whitespace-nowrap"
+        >
+          <IncidentFlag type={severity} />
+          <span className="text-muted-foreground">{label}</span>
+          {isLoading || !counts ? (
+            <Skeleton className="h-4 w-6" />
+          ) : (
+            <span className="font-medium tabular-nums">{counts[severity]}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -10,9 +10,9 @@ import {
   useIncidents,
 } from "@/lib/api/incident/incident.queries";
 import {
+  INCIDENT_SEVERITY_LABELS,
   IncidentCreateDto,
   IncidentDto,
-  IncidentSeverity,
 } from "@/lib/api/incident/incident.types";
 import {
   useLocations,
@@ -55,12 +55,6 @@ const hasIncidentChanged = (
     original.reference_id !== updated.reference_id
   );
 };
-
-function severityLabel(severity: IncidentSeverity): string {
-  if (severity === "remote_warning") return "Remote Warning";
-  if (severity === "in_person_warning") return "In-Person Warning";
-  return "Citation";
-}
 
 function truncateDescription(
   description: string | undefined,
@@ -297,13 +291,7 @@ export const IncidentTable = () => {
       cell: ({ row }) => (
         <div className="flex items-center gap-2">
           <IncidentFlag type={row.original.severity} />
-          {/* <Image
-            src={getSeverityFlag(row.original.severity)}
-            alt={row.original.severity}
-            width={16}
-            height={16}
-          /> */}
-          {severityLabel(row.original.severity)}
+          {INCIDENT_SEVERITY_LABELS[row.original.severity]}
         </div>
       ),
     },

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -33,6 +33,7 @@ import LocationInfoChipDetails from "../party/details/LocationInfoChipDetails";
 import { InfoChip } from "../shared/sidebar/InfoChip";
 import { TableTemplate } from "../shared/table/TableTemplate";
 import IncidentDescriptionChipDetails from "./IncidentDescriptionChipDetails";
+import { IncidentSeverityCountsHeader } from "./IncidentSeverityCountsHeader";
 import IncidentTableForm from "./IncidentTableForm";
 
 const hasIncidentChanged = (
@@ -382,6 +383,12 @@ export const IncidentTable = () => {
         onStateChange={setServerParams}
         onExportCsv={exportCsv}
         isExporting={isExporting}
+        headerSlot={
+          <IncidentSeverityCountsHeader
+            counts={incidentsQuery.data?.severity_counts}
+            isLoading={incidentsQuery.isLoading || incidentsQuery.isFetching}
+          />
+        }
       />
     </div>
   );

--- a/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  INCIDENT_SEVERITY_LABELS,
   IncidentCreateDto,
   IncidentDto,
   IncidentSeverity,
@@ -58,12 +59,6 @@ interface IncidentTableFormProps {
   allLocations: LocationDto[];
   editData?: IncidentDto;
   submissionError?: string | null;
-}
-
-function severityLabel(severity: IncidentSeverity): string {
-  if (severity === "remote_warning") return "Remote Warning";
-  if (severity === "in_person_warning") return "In-Person Warning";
-  return "Citation";
 }
 
 export default function IncidentTableForm({
@@ -243,7 +238,7 @@ export default function IncidentTableForm({
               <SelectContent>
                 {incidentSeverityValues.map((severity) => (
                   <SelectItem key={severity} value={severity}>
-                    {severityLabel(severity)}
+                    {INCIDENT_SEVERITY_LABELS[severity]}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
+++ b/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
@@ -16,7 +16,10 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import { IncidentDto } from "@/lib/api/incident/incident.types";
+import {
+  INCIDENT_SEVERITY_LABELS,
+  IncidentDto,
+} from "@/lib/api/incident/incident.types";
 import { formatTime } from "@/lib/utils";
 import { ChevronDown, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useSession } from "next-auth/react";
@@ -59,13 +62,7 @@ export default function IncidentSidebarCard({
                       <IncidentFlag type={incidents.severity} />
                     </HoverCardTrigger>
                     <HoverCardContent>
-                      <p>
-                        {incidents.severity === "remote_warning" &&
-                          "Remote Warning"}
-                        {incidents.severity === "in_person_warning" &&
-                          "In-Person Warning"}
-                        {incidents.severity === "citation" && "Citation"}
-                      </p>
+                      <p>{INCIDENT_SEVERITY_LABELS[incidents.severity]}</p>
                     </HoverCardContent>
                   </HoverCard>
                 </div>

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -106,6 +106,7 @@ export type TableProps<T> = {
   onStateChange?: (params: ServerTableParams) => void;
   onExportCsv?: (params: ListQueryParams) => void;
   isExporting?: boolean;
+  headerSlot?: ReactNode;
   canManageRows?: boolean;
   canEditRow?: (row: T) => boolean;
   canDeleteRow?: (row: T) => boolean;
@@ -140,6 +141,7 @@ export function TableTemplate<T extends object>({
   onStateChange,
   onExportCsv,
   isExporting,
+  headerSlot,
   canManageRows,
   canEditRow,
   canDeleteRow,
@@ -548,6 +550,11 @@ export function TableTemplate<T extends object>({
                 className="p-2 pl-3 h-9 rounded-md"
               />
             </div>
+            {headerSlot && (
+              <div className="hidden md:flex items-center min-w-0">
+                {headerSlot}
+              </div>
+            )}
             <div className="shrink-0 ml-auto flex items-center gap-2">
               {onExportCsv && (
                 <Button

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -551,7 +551,7 @@ export function TableTemplate<T extends object>({
               />
             </div>
             {headerSlot && (
-              <div className="hidden md:flex items-center min-w-0">
+              <div className="hidden lg:flex flex-1 items-center justify-center min-w-0 ml-1">
                 {headerSlot}
               </div>
             )}
@@ -593,6 +593,7 @@ export function TableTemplate<T extends object>({
           </div>
         </div>
       )}
+      {headerSlot && <div className="lg:hidden">{headerSlot}</div>}
 
       <div className="flex min-h-0 h-full flex-col justify-between overflow-hidden">
         <Card className="flex-1 min-h-0 py-2 px-4 overflow-hidden rounded-sm w-full max-w-none mx-0">

--- a/frontend/src/components/IncidentDialog.tsx
+++ b/frontend/src/components/IncidentDialog.tsx
@@ -20,6 +20,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import {
   INCIDENT_SEVERITIES,
+  INCIDENT_SEVERITY_LABELS,
   IncidentCreateDto,
   IncidentDto,
   IncidentSeverity,
@@ -39,12 +40,6 @@ const incidentSchema = z.object({
 });
 
 type IncidentFormValues = z.infer<typeof incidentSchema>;
-
-const SEVERITY_LABELS: Record<IncidentSeverity, string> = {
-  remote_warning: "Remote Warning",
-  in_person_warning: "In-Person Warning",
-  citation: "Citation",
-};
 
 export interface IncidentDialogProps {
   open: boolean;
@@ -167,7 +162,7 @@ export default function IncidentDialog({
                 <SelectContent>
                   {INCIDENT_SEVERITIES.map((s) => (
                     <SelectItem key={s} value={s}>
-                      {SEVERITY_LABELS[s]}
+                      {INCIDENT_SEVERITY_LABELS[s]}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/lib/api/incident/incident.queries.ts
+++ b/frontend/src/lib/api/incident/incident.queries.ts
@@ -2,7 +2,7 @@ import {
   ListQueryParams,
   ServerTableParams,
 } from "@/lib/api/shared/query-params";
-import { OptimisticMutationOptions, PaginatedResponse } from "@/lib/shared";
+import { OptimisticMutationOptions } from "@/lib/shared";
 import {
   UseQueryOptions,
   keepPreviousData,
@@ -12,7 +12,11 @@ import {
 } from "@tanstack/react-query";
 import { useRef } from "react";
 import { IncidentService } from "./incident.service";
-import { IncidentCreateDto, IncidentDto } from "./incident.types";
+import {
+  IncidentCreateDto,
+  IncidentDto,
+  PaginatedIncidentsResponse,
+} from "./incident.types";
 
 const incidentService = new IncidentService();
 
@@ -25,7 +29,7 @@ export type UpdateIncidentVars = {
 
 export function useIncidents(
   params?: ServerTableParams,
-  options?: UseQueryOptions<PaginatedResponse<IncidentDto>>
+  options?: UseQueryOptions<PaginatedIncidentsResponse>
 ) {
   return useQuery({
     queryKey: [...INCIDENTS_KEY, params ?? "all"],
@@ -130,7 +134,7 @@ export function useDeleteIncident<TContext = unknown>(
   const queryClient = useQueryClient();
   const previousQueriesRef = useRef<
     ReturnType<
-      typeof queryClient.getQueriesData<PaginatedResponse<IncidentDto>>
+      typeof queryClient.getQueriesData<PaginatedIncidentsResponse>
     >
   >([]);
 
@@ -142,10 +146,10 @@ export function useDeleteIncident<TContext = unknown>(
       await queryClient.cancelQueries({ queryKey: INCIDENTS_KEY });
 
       previousQueriesRef.current = queryClient.getQueriesData<
-        PaginatedResponse<IncidentDto>
+        PaginatedIncidentsResponse
       >({ queryKey: INCIDENTS_KEY });
 
-      queryClient.setQueriesData<PaginatedResponse<IncidentDto>>(
+      queryClient.setQueriesData<PaginatedIncidentsResponse>(
         { queryKey: INCIDENTS_KEY },
         (old) =>
           old ? { ...old, items: old.items.filter((i) => i.id !== id) } : old

--- a/frontend/src/lib/api/incident/incident.queries.ts
+++ b/frontend/src/lib/api/incident/incident.queries.ts
@@ -133,9 +133,7 @@ export function useDeleteIncident<TContext = unknown>(
 ) {
   const queryClient = useQueryClient();
   const previousQueriesRef = useRef<
-    ReturnType<
-      typeof queryClient.getQueriesData<PaginatedIncidentsResponse>
-    >
+    ReturnType<typeof queryClient.getQueriesData<PaginatedIncidentsResponse>>
   >([]);
 
   return useMutation<void, Error, number, TContext>({
@@ -145,9 +143,10 @@ export function useDeleteIncident<TContext = unknown>(
     onMutate: async (id, context) => {
       await queryClient.cancelQueries({ queryKey: INCIDENTS_KEY });
 
-      previousQueriesRef.current = queryClient.getQueriesData<
-        PaginatedIncidentsResponse
-      >({ queryKey: INCIDENTS_KEY });
+      previousQueriesRef.current =
+        queryClient.getQueriesData<PaginatedIncidentsResponse>({
+          queryKey: INCIDENTS_KEY,
+        });
 
       queryClient.setQueriesData<PaginatedIncidentsResponse>(
         { queryKey: INCIDENTS_KEY },

--- a/frontend/src/lib/api/incident/incident.service.ts
+++ b/frontend/src/lib/api/incident/incident.service.ts
@@ -1,12 +1,13 @@
 import { downloadExcelFile } from "@/lib/api/shared/download-file";
 import { ListQueryParams, toAxiosParams } from "@/lib/api/shared/query-params";
 import apiClient from "@/lib/network/apiClient";
-import { PaginatedResponse } from "@/lib/shared";
 import { AxiosInstance } from "axios";
 import {
   IncidentCreateDto,
   IncidentDto,
   IncidentDtoBackend,
+  PaginatedIncidentsResponse,
+  PaginatedIncidentsResponseBackend,
   convertIncident,
 } from "./incident.types";
 
@@ -27,12 +28,13 @@ export class IncidentService {
    */
   async listIncidents(
     params?: ListQueryParams
-  ): Promise<PaginatedResponse<IncidentDto>> {
-    const response = await this.client.get<
-      PaginatedResponse<IncidentDtoBackend>
-    >("/incidents", {
-      params: params ? toAxiosParams(params) : undefined,
-    });
+  ): Promise<PaginatedIncidentsResponse> {
+    const response = await this.client.get<PaginatedIncidentsResponseBackend>(
+      "/incidents",
+      {
+        params: params ? toAxiosParams(params) : undefined,
+      }
+    );
     return {
       ...response.data,
       items: response.data.items.map(convertIncident),

--- a/frontend/src/lib/api/incident/incident.types.ts
+++ b/frontend/src/lib/api/incident/incident.types.ts
@@ -8,6 +8,12 @@ const INCIDENT_SEVERITIES = [
 
 type IncidentSeverity = (typeof INCIDENT_SEVERITIES)[number];
 
+const INCIDENT_SEVERITY_LABELS: Record<IncidentSeverity, string> = {
+  remote_warning: "Remote Warning",
+  in_person_warning: "In-Person Warning",
+  citation: "Citation",
+};
+
 type IncidentCreateDto = {
   location_place_id: string;
   incident_datetime: Date;
@@ -35,9 +41,10 @@ type PaginatedIncidentsResponse = PaginatedResponse<IncidentDto> & {
   severity_counts: IncidentSeverityCounts;
 };
 
-type PaginatedIncidentsResponseBackend = PaginatedResponse<IncidentDtoBackend> & {
-  severity_counts: IncidentSeverityCounts;
-};
+type PaginatedIncidentsResponseBackend =
+  PaginatedResponse<IncidentDtoBackend> & {
+    severity_counts: IncidentSeverityCounts;
+  };
 
 function convertIncident(backend: IncidentDtoBackend): IncidentDto {
   return {
@@ -56,4 +63,4 @@ export type {
   PaginatedIncidentsResponseBackend,
 };
 
-export { convertIncident, INCIDENT_SEVERITIES };
+export { convertIncident, INCIDENT_SEVERITIES, INCIDENT_SEVERITY_LABELS };

--- a/frontend/src/lib/api/incident/incident.types.ts
+++ b/frontend/src/lib/api/incident/incident.types.ts
@@ -1,3 +1,5 @@
+import { PaginatedResponse } from "@/lib/shared";
+
 const INCIDENT_SEVERITIES = [
   "remote_warning",
   "in_person_warning",
@@ -27,6 +29,16 @@ type IncidentDtoBackend = Omit<IncidentDto, "incident_datetime"> & {
   incident_datetime: string;
 };
 
+type IncidentSeverityCounts = Record<IncidentSeverity, number>;
+
+type PaginatedIncidentsResponse = PaginatedResponse<IncidentDto> & {
+  severity_counts: IncidentSeverityCounts;
+};
+
+type PaginatedIncidentsResponseBackend = PaginatedResponse<IncidentDtoBackend> & {
+  severity_counts: IncidentSeverityCounts;
+};
+
 function convertIncident(backend: IncidentDtoBackend): IncidentDto {
   return {
     ...backend,
@@ -39,6 +51,9 @@ export type {
   IncidentDto,
   IncidentDtoBackend,
   IncidentSeverity,
+  IncidentSeverityCounts,
+  PaginatedIncidentsResponse,
+  PaginatedIncidentsResponseBackend,
 };
 
 export { convertIncident, INCIDENT_SEVERITIES };


### PR DESCRIPTION
## Summary
- Extend `GET /api/incidents` to return `severity_counts` alongside the paginated list, computed over the same filtered+searched query (ignores pagination).
- Add an `IncidentSeverityCountsHeader` rendered in a new generic `headerSlot` prop on `TableTemplate` — shows flag + label + count per severity, with skeletons while loading.
- Container-query based responsive labels (hide on narrow widths) plus a mobile-only row below the search bar.
- Consolidate the repeated `severity → label` mapping (4+ duplicates) into a single `INCIDENT_SEVERITY_LABELS` in `incident.types.ts`.

## Test plan
- [ ] Counts reflect the full filtered set, not just the current page
- [ ] Counts update when filters change
- [ ] Counts update when search changes
- [ ] Loading skeletons appear on initial load and refetch
- [ ] On narrow widths labels hide, leaving just flag + count
- [ ] On mobile (<md) the counts row appears below the search bar
- [ ] All existing incident table flows (create / edit / delete / filter / sort / search / export) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #395 