### PR TITLE
feat: cancel/restore parties with idempotent endpoints

### DIFF
--- a/backend/script/reset_dev.py
+++ b/backend/script/reset_dev.py
@@ -202,6 +202,7 @@ async def reset_dev():
                 contact_two_contact_preference=ContactPreference(
                     party_data["contact_two"]["contact_preference"]
                 ),
+                status=party_data.get("status", "confirmed"),
             )
             session.add(party)
 

--- a/backend/script/reset_dev.py
+++ b/backend/script/reset_dev.py
@@ -202,7 +202,7 @@ async def reset_dev():
                 contact_two_contact_preference=ContactPreference(
                     party_data["contact_two"]["contact_preference"]
                 ),
-                status=party_data.get("status", "confirmed"),
+                status=party_data.get("status", "confirmed").upper(),
             )
             session.add(party)
 

--- a/backend/src/modules/party/party_entity.py
+++ b/backend/src/modules/party/party_entity.py
@@ -37,7 +37,6 @@ class PartyEntity(MappedAsDataclass, EntityBase):
     status: Mapped[PartyStatus] = mapped_column(
         Enum(PartyStatus, native_enum=False, length=20),
         nullable=False,
-        default=PartyStatus.CONFIRMED,
     )
 
     # Relationships
@@ -59,6 +58,7 @@ class PartyEntity(MappedAsDataclass, EntityBase):
             contact_two_last_name=data.contact_two.last_name,
             contact_two_phone_number=data.contact_two.phone_number,
             contact_two_contact_preference=data.contact_two.contact_preference,
+            status=data.status,
         )
 
     def to_dto(self) -> PartyDto:

--- a/backend/src/modules/party/party_model.py
+++ b/backend/src/modules/party/party_model.py
@@ -18,6 +18,7 @@ class PartyData(BaseModel):
     location_id: int = Field(..., description="ID of the location where the party is held")
     contact_one_id: int = Field(..., description="ID of the first contact student")
     contact_two: "ContactDto" = Field(..., description="Contact information for the second contact")
+    status: PartyStatus = PartyStatus.CONFIRMED
 
 
 class ContactDto(BaseModel):

--- a/backend/src/modules/party/party_router.py
+++ b/backend/src/modules/party/party_router.py
@@ -295,17 +295,26 @@ async def get_party(
     return await party_service.get_party_by_id(party_id)
 
 
-@party_router.delete("/{party_id}")
-async def delete_party(
+@party_router.post("/{party_id}/cancel")
+async def cancel_party(
     party_id: int,
     party_service: PartyService = Depends(),
     user: AuthPrincipal = Depends(authenticate_by_role("student", "staff", "admin")),
 ) -> PartyDto:
     """
-    Deletes a party registration by ID.
+    Cancels a party registration by ID.
 
-    Admins hard-delete any party. Students and staff cancel parties they own.
+    Admins can cancel any party. Students and staff can only cancel parties they own.
+    Idempotent: cancelling an already-cancelled party is a no-op.
     """
-    if user.role == AccountRole.ADMIN:
-        return await party_service.delete_party(party_id)
-    return await party_service.cancel_party_as_student(party_id, user.id)
+    student_id = user.id if user.role in (AccountRole.STUDENT, AccountRole.STAFF) else None
+    return await party_service.cancel_party(party_id, student_id)
+
+
+@party_router.post("/{party_id}/restore")
+async def restore_party(
+    party_id: int,
+    party_service: PartyService = Depends(),
+    _=Depends(authenticate_by_role("admin")),
+) -> PartyDto:
+    return await party_service.restore_party(party_id)

--- a/backend/src/modules/party/party_service.py
+++ b/backend/src/modules/party/party_service.py
@@ -574,16 +574,35 @@ class PartyService:
 
         return await party_entity.load_dto(self.session)
 
-    async def cancel_party_as_student(self, party_id: int, student_account_id: int) -> PartyDto:
-        """Cancel a party as a student. Only the party owner can cancel their party."""
+    async def cancel_party(self, party_id: int, student_id: int | None) -> PartyDto:
+        """Cancel a party. If student_id is given, only the owner can cancel.
+        Idempotent: cancelling an already-cancelled party is a no-op."""
         party_entity = await self._get_party_entity_by_id(party_id)
 
-        # Validate ownership, status, and timing
-        self._validate_party_belongs_to_student(party_entity, student_account_id)
-        self._validate_party_not_cancelled(party_entity)
-        self._validate_party_in_future(party_entity)
+        if student_id:
+            self._validate_party_belongs_to_student(party_entity, student_id)
+
+        if party_entity.status == PartyStatus.CANCELLED:
+            return party_entity.to_dto()
+
+        if student_id:
+            self._validate_party_in_future(party_entity)
 
         party_entity.status = PartyStatus.CANCELLED
+        self.session.add(party_entity)
+        await self.session.commit()
+
+        return party_entity.to_dto()
+
+    async def restore_party(self, party_id: int) -> PartyDto:
+        """Restore a cancelled party to CONFIRMED. Admin-only at the router level.
+        Idempotent: restoring an already-confirmed party is a no-op."""
+        party_entity = await self._get_party_entity_by_id(party_id)
+
+        if party_entity.status == PartyStatus.CONFIRMED:
+            return party_entity.to_dto()
+
+        party_entity.status = PartyStatus.CONFIRMED
         self.session.add(party_entity)
         await self.session.commit()
 

--- a/backend/test/modules/party/party_router_test.py
+++ b/backend/test/modules/party/party_router_test.py
@@ -36,7 +36,8 @@ test_party_authentication = generate_auth_required_tests(
     ({"admin", "staff", "officer", "police_admin"}, "GET", "/api/parties", None),
     ({"admin", "staff", "officer", "police_admin"}, "GET", "/api/parties/csv", None),
     ({"admin", "staff"}, "GET", "/api/parties/1", None),
-    ({"student", "staff", "admin"}, "DELETE", "/api/parties/1", None),
+    ({"student", "staff", "admin"}, "POST", "/api/parties/1/cancel", None),
+    ({"admin"}, "POST", "/api/parties/1/restore", None),
     (
         {"admin", "officer", "police_admin"},
         "GET",
@@ -240,7 +241,7 @@ class TestPartyGetRouter:
 
 
 class TestPartyDeleteRouter:
-    """Tests for DELETE /api/parties/{id} endpoint."""
+    """Tests for DELETE /api/parties/{id} endpoint (admin)."""
 
     admin_client: AsyncClient
     party_utils: PartyTestUtils
@@ -251,23 +252,74 @@ class TestPartyDeleteRouter:
         self.admin_client = admin_client
 
     @pytest.mark.asyncio
-    async def test_delete_party_success(self):
-        """Test successfully deleting a party."""
+    async def test_admin_delete_party_cancels(self):
+        """Admin DELETE cancels the party (no hard-delete) and does not check ownership."""
         party = await self.party_utils.create_one()
 
-        response = await self.admin_client.delete(f"/api/parties/{party.id}")
+        response = await self.admin_client.post(f"/api/parties/{party.id}/cancel")
+        data = assert_res_success(response, PartyDto)
+
+        party.status = PartyStatus.CANCELLED
+        self.party_utils.assert_matches(party, data)
+
+        # Party still exists in the DB, just cancelled
+        all_parties = await self.party_utils.get_all()
+        assert party.id in [p.id for p in all_parties]
+
+    @pytest.mark.asyncio
+    async def test_admin_delete_cancelled_party_idempotent(self):
+        """Cancelling an already-cancelled party is a no-op (no error)."""
+        party = await self.party_utils.create_one()
+
+        await self.admin_client.post(f"/api/parties/{party.id}/cancel")
+
+        response = await self.admin_client.post(f"/api/parties/{party.id}/cancel")
+        data = assert_res_success(response, PartyDto)
+        party.status = PartyStatus.CANCELLED
+        self.party_utils.assert_matches(party, data)
+
+    @pytest.mark.asyncio
+    async def test_delete_party_not_found(self):
+        """Test cancelling a non-existent party."""
+        response = await self.admin_client.post("/api/parties/999/cancel")
+        assert_res_failure(response, PartyNotFoundException(999))
+
+
+class TestPartyRestoreRouter:
+    """Tests for POST /api/parties/{id}/restore endpoint (admin only)."""
+
+    admin_client: AsyncClient
+    party_utils: PartyTestUtils
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, party_utils: PartyTestUtils, admin_client: AsyncClient):
+        self.party_utils = party_utils
+        self.admin_client = admin_client
+
+    @pytest.mark.asyncio
+    async def test_admin_restore_cancelled_party(self):
+        """Admin can restore a cancelled party back to CONFIRMED."""
+        party = await self.party_utils.create_one()
+        await self.admin_client.post(f"/api/parties/{party.id}/cancel")
+
+        response = await self.admin_client.post(f"/api/parties/{party.id}/restore")
         data = assert_res_success(response, PartyDto)
 
         self.party_utils.assert_matches(party, data)
 
-        # Verify deletion
-        all_parties = await self.party_utils.get_all()
-        assert party.id not in [p.id for p in all_parties]
+    @pytest.mark.asyncio
+    async def test_admin_restore_confirmed_party_idempotent(self):
+        """Restoring an already-confirmed party is a no-op."""
+        party = await self.party_utils.create_one()
+
+        response = await self.admin_client.post(f"/api/parties/{party.id}/restore")
+        data = assert_res_success(response, PartyDto)
+
+        self.party_utils.assert_matches(party, data)
 
     @pytest.mark.asyncio
-    async def test_delete_party_not_found(self):
-        """Test deleting a non-existent party."""
-        response = await self.admin_client.delete("/api/parties/999")
+    async def test_restore_party_not_found(self):
+        response = await self.admin_client.post("/api/parties/999/restore")
         assert_res_failure(response, PartyNotFoundException(999))
 
 
@@ -1519,28 +1571,30 @@ class TestStudentPartyDeleteRouter:
         """Test that student deleting a party cancels it (status=cancelled)."""
         party = await self.party_utils.create_one(contact_one_id=current_student.account_id)
 
-        response = await self.student_client.delete(f"/api/parties/{party.id}")
+        response = await self.student_client.post(f"/api/parties/{party.id}/cancel")
         data = assert_res_success(response, PartyDto)
 
-        assert data.status == PartyStatus.CANCELLED
-        assert data.id == party.id
+        party.status = PartyStatus.CANCELLED
+        self.party_utils.assert_matches(party, data)
 
     @pytest.mark.asyncio
-    async def test_student_delete_cancelled_party_fails(self, current_student: StudentEntity):
-        """Test that student cannot cancel an already-cancelled party."""
+    async def test_student_delete_cancelled_party_idempotent(self, current_student: StudentEntity):
+        """Cancelling an already-cancelled party is a no-op for the owner."""
         party = await self.party_utils.create_one(contact_one_id=current_student.account_id)
 
-        await self.student_client.delete(f"/api/parties/{party.id}")
+        await self.student_client.post(f"/api/parties/{party.id}/cancel")
 
-        response = await self.student_client.delete(f"/api/parties/{party.id}")
-        assert_res_failure(response, PartyCancelledException(party.id))
+        response = await self.student_client.post(f"/api/parties/{party.id}/cancel")
+        data = assert_res_success(response, PartyDto)
+        party.status = PartyStatus.CANCELLED
+        self.party_utils.assert_matches(party, data)
 
     @pytest.mark.asyncio
     async def test_student_delete_others_party_fails(self):
         """Test that student cannot cancel a party that belongs to another student."""
         party = await self.party_utils.create_one()
 
-        response = await self.student_client.delete(f"/api/parties/{party.id}")
+        response = await self.student_client.post(f"/api/parties/{party.id}/cancel")
         assert_res_failure(response, PartyNotOwnedByStudentException(party.id))
 
     @pytest.mark.asyncio
@@ -1552,7 +1606,7 @@ class TestStudentPartyDeleteRouter:
             party_datetime=past_datetime,
         )
 
-        response = await self.student_client.delete(f"/api/parties/{party.id}")
+        response = await self.student_client.post(f"/api/parties/{party.id}/cancel")
         assert_res_failure(response, PartyInPastException())
 
 
@@ -1588,7 +1642,7 @@ class TestStudentPartyUpdateValidationRouter:
     async def test_student_update_cancelled_party_fails(self, current_student: StudentEntity):
         """Test that student cannot update a cancelled party."""
         party = await self.party_utils.create_one(contact_one_id=current_student.account_id)
-        await self.student_client.delete(f"/api/parties/{party.id}")
+        await self.student_client.post(f"/api/parties/{party.id}/cancel")
 
         location = await self.location_utils.create_one()
         update_payload = await self.party_utils.next_student_create_dto(
@@ -1664,7 +1718,7 @@ class TestStudentMyPartiesRouter:
         party1 = await self.party_utils.create_one(contact_one_id=current_student.account_id)
         party2 = await self.party_utils.create_one(contact_one_id=current_student.account_id)
 
-        await self.student_client.delete(f"/api/parties/{party2.id}")
+        await self.student_client.post(f"/api/parties/{party2.id}/cancel")
 
         response = await self.student_client.get("/api/students/me/parties")
         parties = assert_res_success(response, list[PartyDto])
@@ -1748,16 +1802,16 @@ class TestPartyAsStaffRouter:
         does not hard-delete (which is admin-only)."""
         party = await self.party_utils.create_one(contact_one_id=current_staff_host.account_id)
 
-        response = await self.staff_client.delete(f"/api/parties/{party.id}")
+        response = await self.staff_client.post(f"/api/parties/{party.id}/cancel")
         data = assert_res_success(response, PartyDto)
 
-        assert data.id == party.id
-        assert data.status == PartyStatus.CANCELLED
+        party.status = PartyStatus.CANCELLED
+        self.party_utils.assert_matches(party, data)
 
     @pytest.mark.asyncio
     async def test_delete_other_users_party_as_staff_fails(self, current_staff_host: StudentEntity):
         """Staff cannot cancel a party they don't own (same rule as students)."""
         party = await self.party_utils.create_one()
 
-        response = await self.staff_client.delete(f"/api/parties/{party.id}")
+        response = await self.staff_client.post(f"/api/parties/{party.id}/cancel")
         assert_res_failure(response, PartyNotOwnedByStudentException(party.id))

--- a/backend/test/modules/party/party_service_test.py
+++ b/backend/test/modules/party/party_service_test.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from src.modules.location.location_service import LocationNotFoundException
-from src.modules.party.party_model import ContactDto, StudentCreatePartyDto
+from src.modules.party.party_model import ContactDto, PartyStatus, StudentCreatePartyDto
 from src.modules.party.party_service import (
     ContactTwoMatchesContactOneException,
     PartyNotFoundException,
@@ -167,6 +167,61 @@ class TestPartyServiceCRUD:
         """Test deleting a non-existent party."""
         with pytest.raises(PartyNotFoundException):
             await self.party_service.delete_party(999)
+
+    @pytest.mark.asyncio
+    async def test_cancel_party_as_admin(self):
+        """Admin cancellation flips status to CANCELLED without ownership check."""
+        party_entity = await self.party_utils.create_one()
+
+        cancelled = await self.party_service.cancel_party(party_entity.id, student_id=None)
+
+        party_entity.status = PartyStatus.CANCELLED
+        self.party_utils.assert_matches(party_entity, cancelled)
+
+        # Party still exists in the DB
+        fetched = await self.party_service.get_party_by_id(party_entity.id)
+        self.party_utils.assert_matches(party_entity, fetched)
+
+    @pytest.mark.asyncio
+    async def test_cancel_party_as_admin_not_found(self):
+        with pytest.raises(PartyNotFoundException):
+            await self.party_service.cancel_party(999, student_id=None)
+
+    @pytest.mark.asyncio
+    async def test_cancel_party_idempotent(self):
+        """Cancelling an already-cancelled party is a no-op (no error)."""
+        party_entity = await self.party_utils.create_one()
+        await self.party_service.cancel_party(party_entity.id, student_id=None)
+
+        result = await self.party_service.cancel_party(party_entity.id, student_id=None)
+        party_entity.status = PartyStatus.CANCELLED
+        self.party_utils.assert_matches(party_entity, result)
+
+    @pytest.mark.asyncio
+    async def test_restore_party(self):
+        """Restoring a cancelled party flips status back to CONFIRMED."""
+        party_entity = await self.party_utils.create_one()
+        await self.party_service.cancel_party(party_entity.id, student_id=None)
+
+        restored = await self.party_service.restore_party(party_entity.id)
+
+        self.party_utils.assert_matches(party_entity, restored)
+
+        fetched = await self.party_service.get_party_by_id(party_entity.id)
+        self.party_utils.assert_matches(party_entity, fetched)
+
+    @pytest.mark.asyncio
+    async def test_restore_party_idempotent(self):
+        """Restoring an already-confirmed party is a no-op."""
+        party_entity = await self.party_utils.create_one()
+
+        result = await self.party_service.restore_party(party_entity.id)
+        self.party_utils.assert_matches(party_entity, result)
+
+    @pytest.mark.asyncio
+    async def test_restore_party_not_found(self):
+        with pytest.raises(PartyNotFoundException):
+            await self.party_service.restore_party(999)
 
     @pytest.mark.asyncio
     async def test_party_exists(self):

--- a/frontend/shared/mock_data.json
+++ b/frontend/shared/mock_data.json
@@ -937,7 +937,8 @@
         "last_name": "Griffin",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 2,
@@ -950,7 +951,8 @@
         "last_name": "Johnson",
         "phone_number": "9132229878",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 3,
@@ -963,7 +965,8 @@
         "last_name": "Griffin",
         "phone_number": "4298137870",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 4,
@@ -976,7 +979,8 @@
         "last_name": "Griffin",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 5,
@@ -989,7 +993,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 6,
@@ -1002,7 +1007,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 7,
@@ -1015,7 +1021,8 @@
         "last_name": "Garza",
         "phone_number": "8807336024",
         "contact_preference": "call"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 8,
@@ -1028,7 +1035,8 @@
         "last_name": "Griffin",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 9,
@@ -1041,7 +1049,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 10,
@@ -1054,7 +1063,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 11,
@@ -1067,7 +1077,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 12,
@@ -1080,7 +1091,8 @@
         "last_name": "Casey",
         "phone_number": "6900922391",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 13,
@@ -1093,7 +1105,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 14,
@@ -1106,7 +1119,8 @@
         "last_name": "Williams",
         "phone_number": "3553147977",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 15,
@@ -1119,7 +1133,8 @@
         "last_name": "Delacruz",
         "phone_number": "4006249809",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 16,
@@ -1132,7 +1147,8 @@
         "last_name": "Griffin",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 17,
@@ -1145,7 +1161,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 18,
@@ -1158,7 +1175,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 19,
@@ -1171,7 +1189,8 @@
         "last_name": "Garza",
         "phone_number": "8807336024",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 20,
@@ -1184,7 +1203,8 @@
         "last_name": "Hill",
         "phone_number": "6306652657",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 21,
@@ -1197,7 +1217,8 @@
         "last_name": "Griffin",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 22,
@@ -1210,7 +1231,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 23,
@@ -1223,7 +1245,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 24,
@@ -1236,7 +1259,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 25,
@@ -1249,7 +1273,8 @@
         "last_name": "Nash",
         "phone_number": "6666817217",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 26,
@@ -1262,7 +1287,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 27,
@@ -1275,7 +1301,8 @@
         "last_name": "Padilla",
         "phone_number": "1946724564",
         "contact_preference": "text"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 28,
@@ -1288,7 +1315,8 @@
         "last_name": "Hill",
         "phone_number": "6306652657",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 29,
@@ -1301,7 +1329,8 @@
         "last_name": "Huang",
         "phone_number": "9128438423",
         "contact_preference": "call"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 31,
@@ -1314,7 +1343,8 @@
         "last_name": "Pugh",
         "phone_number": "6511999184",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 32,
@@ -1327,7 +1357,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 33,
@@ -1340,7 +1371,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 34,
@@ -1353,7 +1385,8 @@
         "last_name": "Griffin",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 35,
@@ -1366,7 +1399,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 36,
@@ -1379,7 +1413,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 37,
@@ -1392,7 +1427,8 @@
         "last_name": "Reynolds",
         "phone_number": "2485867231",
         "contact_preference": "call"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 38,
@@ -1405,7 +1441,8 @@
         "last_name": "Hill",
         "phone_number": "6306652657",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 40,
@@ -1418,7 +1455,8 @@
         "last_name": "Griffin",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 41,
@@ -1431,7 +1469,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 43,
@@ -1444,7 +1483,8 @@
         "last_name": "Delacruz",
         "phone_number": "4006249809",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 44,
@@ -1457,7 +1497,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 45,
@@ -1470,7 +1511,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 46,
@@ -1483,7 +1525,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 47,
@@ -1496,7 +1539,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 48,
@@ -1509,7 +1553,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 49,
@@ -1522,7 +1567,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 50,
@@ -1535,7 +1581,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 51,
@@ -1548,7 +1595,8 @@
         "last_name": "Reynolds",
         "phone_number": "2485867231",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 52,
@@ -1561,7 +1609,8 @@
         "last_name": "Gentry",
         "phone_number": "2806602428",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 53,
@@ -1574,7 +1623,8 @@
         "last_name": "Garza",
         "phone_number": "7533119675",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 54,
@@ -1587,7 +1637,8 @@
         "last_name": "Meyer",
         "phone_number": "8512913775",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 55,
@@ -1600,7 +1651,8 @@
         "last_name": "Garza",
         "phone_number": "7533119675",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 56,
@@ -1613,7 +1665,8 @@
         "last_name": "Jones",
         "phone_number": "7656611880",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 57,
@@ -1626,7 +1679,8 @@
         "last_name": "Young",
         "phone_number": "6697432221",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 58,
@@ -1639,7 +1693,8 @@
         "last_name": "Burke",
         "phone_number": "8693868085",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 59,
@@ -1652,7 +1707,8 @@
         "last_name": "Wheeler",
         "phone_number": "3223027851",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 60,
@@ -1665,7 +1721,8 @@
         "last_name": "Jones",
         "phone_number": "7656611880",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 61,
@@ -1678,7 +1735,8 @@
         "last_name": "Park",
         "phone_number": "4267235992",
         "contact_preference": "text"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 62,
@@ -1691,7 +1749,8 @@
         "last_name": "Sherman",
         "phone_number": "8044158590",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 63,
@@ -1704,7 +1763,8 @@
         "last_name": "Henderson",
         "phone_number": "6838994488",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 64,
@@ -1717,7 +1777,8 @@
         "last_name": "Mcclain",
         "phone_number": "1550193697",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 65,
@@ -1730,7 +1791,8 @@
         "last_name": "Ashley",
         "phone_number": "4517753838",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 66,
@@ -1743,7 +1805,8 @@
         "last_name": "Ramirez",
         "phone_number": "7276907707",
         "contact_preference": "text"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 67,
@@ -1756,7 +1819,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 68,
@@ -1769,7 +1833,8 @@
         "last_name": "Jones",
         "phone_number": "9551203032",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 69,
@@ -1782,7 +1847,8 @@
         "last_name": "Jones",
         "phone_number": "9551203032",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 70,
@@ -1795,7 +1861,8 @@
         "last_name": "Nunez",
         "phone_number": "8435149530",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 71,
@@ -1808,7 +1875,8 @@
         "last_name": "Jones",
         "phone_number": "9551203032",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 72,
@@ -1821,7 +1889,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 73,
@@ -1834,7 +1903,8 @@
         "last_name": "Spencer",
         "phone_number": "1441449651",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 74,
@@ -1847,7 +1917,8 @@
         "last_name": "Spencer",
         "phone_number": "1441449651",
         "contact_preference": "text"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 75,
@@ -1860,7 +1931,8 @@
         "last_name": "Howard",
         "phone_number": "3291879776",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 76,
@@ -1873,7 +1945,8 @@
         "last_name": "King",
         "phone_number": "5171131884",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 77,
@@ -1886,7 +1959,8 @@
         "last_name": "Hill",
         "phone_number": "9531893411",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 78,
@@ -1899,7 +1973,8 @@
         "last_name": "Hill",
         "phone_number": "6306652657",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 79,
@@ -1912,7 +1987,8 @@
         "last_name": "Simmons",
         "phone_number": "5353976161",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 80,
@@ -1925,7 +2001,8 @@
         "last_name": "Abbott",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 81,
@@ -1938,7 +2015,8 @@
         "last_name": "Oliver",
         "phone_number": "6708441824",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 82,
@@ -1951,7 +2029,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 83,
@@ -1964,7 +2043,8 @@
         "last_name": "Richardson",
         "phone_number": "5981747695",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 84,
@@ -1977,7 +2057,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 85,
@@ -1990,7 +2071,8 @@
         "last_name": "Hill",
         "phone_number": "0714862591",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 86,
@@ -2003,7 +2085,8 @@
         "last_name": "Hayden",
         "phone_number": "9673085639",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 87,
@@ -2016,7 +2099,8 @@
         "last_name": "Rivera",
         "phone_number": "7435414311",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 88,
@@ -2029,7 +2113,8 @@
         "last_name": "Benson",
         "phone_number": "0347041827",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 89,
@@ -2042,7 +2127,8 @@
         "last_name": "Goodwin",
         "phone_number": "2419191469",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 90,
@@ -2055,7 +2141,8 @@
         "last_name": "Richmond",
         "phone_number": "4329188319",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 91,
@@ -2068,7 +2155,8 @@
         "last_name": "Sanchez",
         "phone_number": "2450216261",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 93,
@@ -2081,7 +2169,8 @@
         "last_name": "Hill",
         "phone_number": "6306652657",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 94,
@@ -2094,7 +2183,8 @@
         "last_name": "Watson",
         "phone_number": "0233776931",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 95,
@@ -2107,7 +2197,8 @@
         "last_name": "Molina",
         "phone_number": "2670721838",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 96,
@@ -2120,7 +2211,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 97,
@@ -2133,7 +2225,8 @@
         "last_name": "Larson",
         "phone_number": "4544001370",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 98,
@@ -2146,7 +2239,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 99,
@@ -2159,7 +2253,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 100,
@@ -2172,7 +2267,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 101,
@@ -2185,7 +2281,8 @@
         "last_name": "Nunez",
         "phone_number": "8435149530",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 102,
@@ -2198,7 +2295,8 @@
         "last_name": "Delacruz",
         "phone_number": "4006249809",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 103,
@@ -2211,7 +2309,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 104,
@@ -2224,7 +2323,8 @@
         "last_name": "Nunez",
         "phone_number": "8435149530",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 105,
@@ -2237,7 +2337,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 106,
@@ -2250,7 +2351,8 @@
         "last_name": "Taylor",
         "phone_number": "1072159144",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 107,
@@ -2263,7 +2365,8 @@
         "last_name": "Harris",
         "phone_number": "9890632700",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 108,
@@ -2276,7 +2379,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 109,
@@ -2289,7 +2393,8 @@
         "last_name": "Simmons",
         "phone_number": "5353976161",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 110,
@@ -2302,7 +2407,8 @@
         "last_name": "Thornton",
         "phone_number": "0159542565",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 111,
@@ -2315,7 +2421,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 112,
@@ -2328,7 +2435,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 113,
@@ -2341,7 +2449,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 115,
@@ -2354,7 +2463,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 116,
@@ -2367,7 +2477,8 @@
         "last_name": "Hill",
         "phone_number": "6306652657",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 117,
@@ -2380,7 +2491,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 118,
@@ -2393,7 +2505,8 @@
         "last_name": "Malone",
         "phone_number": "7247664088",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 119,
@@ -2406,7 +2519,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 120,
@@ -2419,7 +2533,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 121,
@@ -2432,7 +2547,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 122,
@@ -2445,7 +2561,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 124,
@@ -2458,7 +2575,8 @@
         "last_name": "Campbell",
         "phone_number": "7365405204",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 125,
@@ -2471,7 +2589,8 @@
         "last_name": "Thomas",
         "phone_number": "0365674922",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 126,
@@ -2484,7 +2603,8 @@
         "last_name": "Parker",
         "phone_number": "5172316581",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 127,
@@ -2497,7 +2617,8 @@
         "last_name": "Smith",
         "phone_number": "3836791316",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 128,
@@ -2510,7 +2631,8 @@
         "last_name": "Nunez",
         "phone_number": "8435149530",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 129,
@@ -2523,7 +2645,8 @@
         "last_name": "Burke",
         "phone_number": "8693868085",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 130,
@@ -2536,7 +2659,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 131,
@@ -2549,7 +2673,8 @@
         "last_name": "Brady",
         "phone_number": "3214404320",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 132,
@@ -2562,7 +2687,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 133,
@@ -2575,7 +2701,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 134,
@@ -2588,7 +2715,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 135,
@@ -2601,7 +2729,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 136,
@@ -2614,7 +2743,8 @@
         "last_name": "Gardner",
         "phone_number": "3168698828",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 137,
@@ -2627,7 +2757,8 @@
         "last_name": "Hill",
         "phone_number": "6306652657",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 138,
@@ -2640,7 +2771,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 139,
@@ -2653,7 +2785,8 @@
         "last_name": "Villarreal",
         "phone_number": "9890632700",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 140,
@@ -2666,7 +2799,8 @@
         "last_name": "Hill",
         "phone_number": "9531893411",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 141,
@@ -2679,7 +2813,8 @@
         "last_name": "Freeman",
         "phone_number": "9146517058",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 142,
@@ -2692,7 +2827,8 @@
         "last_name": "Johnson",
         "phone_number": "2140441694",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 143,
@@ -2705,7 +2841,8 @@
         "last_name": "Horne",
         "phone_number": "1739556546",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 144,
@@ -2718,7 +2855,8 @@
         "last_name": "Cardenas",
         "phone_number": "8334908909",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 145,
@@ -2731,7 +2869,8 @@
         "last_name": "Garcia",
         "phone_number": "6428191988",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 146,
@@ -2744,7 +2883,8 @@
         "last_name": "Aguilar",
         "phone_number": "5343930452",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 147,
@@ -2757,7 +2897,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 148,
@@ -2770,7 +2911,8 @@
         "last_name": "Cardenas",
         "phone_number": "8334908909",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 149,
@@ -2783,7 +2925,8 @@
         "last_name": "Quinn",
         "phone_number": "8047677277",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 150,
@@ -2796,7 +2939,8 @@
         "last_name": "Simmons",
         "phone_number": "5353976161",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 151,
@@ -2809,7 +2953,8 @@
         "last_name": "Hayden",
         "phone_number": "9673085639",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 152,
@@ -2822,7 +2967,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 153,
@@ -2835,7 +2981,8 @@
         "last_name": "Andersen",
         "phone_number": "9042516249",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 154,
@@ -2848,7 +2995,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 155,
@@ -2861,7 +3009,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 156,
@@ -2874,7 +3023,8 @@
         "last_name": "Stewart",
         "phone_number": "6063986944",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 157,
@@ -2887,7 +3037,8 @@
         "last_name": "Brady",
         "phone_number": "3214404320",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 158,
@@ -2900,7 +3051,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 159,
@@ -2913,7 +3065,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 160,
@@ -2926,7 +3079,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 161,
@@ -2939,7 +3093,8 @@
         "last_name": "Simmons",
         "phone_number": "5353976161",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 162,
@@ -2952,7 +3107,8 @@
         "last_name": "Stephens",
         "phone_number": "7451359721",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 163,
@@ -2965,7 +3121,8 @@
         "last_name": "Reynolds",
         "phone_number": "2485867231",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 164,
@@ -2978,7 +3135,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 165,
@@ -2991,7 +3149,8 @@
         "last_name": "Jones",
         "phone_number": "9551203032",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 166,
@@ -3004,7 +3163,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 167,
@@ -3017,7 +3177,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 168,
@@ -3030,7 +3191,8 @@
         "last_name": "Hale",
         "phone_number": "2866159363",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 169,
@@ -3043,7 +3205,8 @@
         "last_name": "Martin",
         "phone_number": "7742014292",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 170,
@@ -3056,7 +3219,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 171,
@@ -3069,7 +3233,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 172,
@@ -3082,7 +3247,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 173,
@@ -3095,7 +3261,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 174,
@@ -3108,7 +3275,8 @@
         "last_name": "Mueller",
         "phone_number": "2486599169",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 175,
@@ -3121,7 +3289,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 176,
@@ -3134,7 +3303,8 @@
         "last_name": "Burch",
         "phone_number": "3475330617",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 177,
@@ -3147,7 +3317,8 @@
         "last_name": "Griffin",
         "phone_number": "2607135634",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 178,
@@ -3160,7 +3331,8 @@
         "last_name": "Booth",
         "phone_number": "7055471558",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 179,
@@ -3173,7 +3345,8 @@
         "last_name": "Boone",
         "phone_number": "6738853178",
         "contact_preference": "call"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 180,
@@ -3186,7 +3359,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "cancelled"
     },
     {
       "id": 181,
@@ -3199,7 +3373,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 182,
@@ -3212,7 +3387,8 @@
         "last_name": "Aguilar",
         "phone_number": "5343930452",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 183,
@@ -3225,7 +3401,8 @@
         "last_name": "Gonzalez",
         "phone_number": "8790458763",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 184,
@@ -3238,7 +3415,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 185,
@@ -3251,7 +3429,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 186,
@@ -3264,7 +3443,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 187,
@@ -3277,7 +3457,8 @@
         "last_name": "Ellis",
         "phone_number": "5040599133",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     },
     {
       "id": 188,
@@ -3290,7 +3471,8 @@
         "last_name": "Hall",
         "phone_number": "0750818732",
         "contact_preference": "text"
-      }
+      },
+      "status": "confirmed"
     }
   ],
   "locations": [

--- a/frontend/src/app/(student)/_components/DeletePartyDialog.tsx
+++ b/frontend/src/app/(student)/_components/DeletePartyDialog.tsx
@@ -28,12 +28,12 @@ export function DeletePartyDialog({
   const { openSnackbar } = useSnackbar();
   const deletePartyMutation = useDeleteParty();
 
-  const handleDelete = async () => {
+  const handleCancel = async () => {
     try {
       await deletePartyMutation.mutateAsync(party.id);
       onOpenChange(false);
     } catch {
-      openSnackbar("Failed to delete party", "error");
+      openSnackbar("Failed to cancel party", "error");
     }
   };
 
@@ -41,11 +41,11 @@ export function DeletePartyDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete Party</DialogTitle>
+          <DialogTitle>Cancel Party</DialogTitle>
           <DialogDescription>
-            Are you sure you want to delete the party on{" "}
+            Are you sure you want to cancel the party on{" "}
             {format(party.party_datetime, "PPP")} at{" "}
-            {format(party.party_datetime, "p")}? This action cannot be undone.
+            {format(party.party_datetime, "p")}?
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -54,14 +54,14 @@ export function DeletePartyDialog({
             onClick={() => onOpenChange(false)}
             disabled={deletePartyMutation.isPending}
           >
-            Cancel
+            Back
           </Button>
           <Button
             variant="destructive"
-            onClick={handleDelete}
+            onClick={handleCancel}
             disabled={deletePartyMutation.isPending}
           >
-            {deletePartyMutation.isPending ? "Deleting..." : "Delete"}
+            {deletePartyMutation.isPending ? "Cancelling..." : "Cancel Party"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/app/(student)/_components/RegistrationTracker.tsx
+++ b/frontend/src/app/(student)/_components/RegistrationTracker.tsx
@@ -24,7 +24,7 @@ import {
   isFromThisSchoolYear,
 } from "@/lib/utils";
 import { format } from "date-fns";
-import { MoreVertical, Pencil, Plus, Trash2 } from "lucide-react";
+import { Ban, MoreVertical, Pencil, Plus } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 
@@ -151,8 +151,8 @@ export default function RegistrationTracker(): React.JSX.Element {
                   variant="destructive"
                   onClick={() => setDeleteParty(party)}
                 >
-                  <Trash2 className="h-4 w-4" />
-                  Delete
+                  <Ban className="h-4 w-4" />
+                  Cancel
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -294,7 +294,7 @@ export default function RegistrationTracker(): React.JSX.Element {
                   <SkeletonText className="max-w-full" />
                 </div>
               ) : activeParties.length === 0 ? (
-                <p className="flex h-full items-center justify-center px-4 text-center content-sub !text-base">
+                <p className="flex h-full items-center justify-center px-4 text-center content-sub text-base!">
                   {showPartySmartPrompt
                     ? "Schedule and attend the Party Smart course below to register your first party!"
                     : "No active registrations"}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -26,6 +26,7 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
+  --color-muted-background: var(--muted-background);
   --color-muted: var(--muted);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-secondary: var(--secondary);
@@ -34,7 +35,9 @@
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
+  --color-card-shadow: var(--card-shadow);
   --color-card: var(--card);
+  --color-input-shadow: var(--input-shadow);
   --color-sub-text: var(--sub-text);
   --color-text: var(--text);
   --radius-sm: calc(var(--radius) - 4px);
@@ -96,42 +99,6 @@
   --sidebar-ring: oklch(0.708 0 0);
   --sub-text: oklch(0.281 0.0773 254.77 / 0.7);
   --text: oklch(0.281 0.0773 254.77);
-  --modal-overlay: oklch(0 0 0 / 0.5);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: var(--primary);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
   --modal-overlay: oklch(0 0 0 / 0.5);
 }
 

--- a/frontend/src/app/police/_components/PartyCard.tsx
+++ b/frontend/src/app/police/_components/PartyCard.tsx
@@ -161,12 +161,12 @@ export default function PartyCard({
         {data.hasParty && (
           <div className="grid grid-rows-2 gap-y-2 mb-2 mr-4">
             <div className="flex flex-row justify-between gap-x-0.5">
-              <p className="content text-secondary self-end mb-[-6px]">
+              <p className="content text-secondary self-end -mb-1.5">
                 {data.party.contact_one.first_name}{" "}
                 {data.party.contact_one.last_name}
               </p>
-              <span className="flex-1 h-[2px] bg-[radial-gradient(circle,currentColor_1px,transparent_1px)] bg-[length:6px_2px] bg-repeat-x self-end text-[var(--secondary)]" />
-              <div className="flex flex-row gap-x-1 mb-[-6px]">
+              <span className="flex-1 h-0.5 bg-[radial-gradient(circle,currentColor_1px,transparent_1px)] bg-size-[6px_2px] bg-repeat-x self-end text-secondary" />
+              <div className="flex flex-row gap-x-1 -mb-1.5">
                 <PhoneLink
                   phoneNumber={data.party.contact_one.phone_number ?? "—"}
                   contactPreference={data.party.contact_one.contact_preference}
@@ -181,12 +181,12 @@ export default function PartyCard({
               </div>
             </div>
             <div className="flex flex-row justify-between gap-x-0.5">
-              <p className="content text-secondary self-end mb-[-6px]">
+              <p className="content text-secondary self-end -mb-1.5">
                 {data.party.contact_two.first_name}{" "}
                 {data.party.contact_two.last_name}
               </p>
-              <span className="flex-1 h-[2px] bg-[radial-gradient(circle,currentColor_1px,transparent_1px)] bg-[length:6px_2px] bg-repeat-x self-end text-[var(--secondary)]" />
-              <div className="flex flex-row gap-x-1 mb-[-6px]">
+              <span className="flex-1 h-0.5 bg-[radial-gradient(circle,currentColor_1px,transparent_1px)] bg-size-[6px_2px] bg-repeat-x self-end text-secondary" />
+              <div className="flex flex-row gap-x-1 -mb-1.5">
                 <PhoneLink
                   phoneNumber={data.party.contact_two.phone_number}
                   contactPreference={data.party.contact_two.contact_preference}

--- a/frontend/src/app/police/_components/PartyList.tsx
+++ b/frontend/src/app/police/_components/PartyList.tsx
@@ -95,7 +95,7 @@ const PartyList = ({
   return (
     <>
       <div className="flex flex-col min-h-0 flex-1">
-        <div className="flex-1 min-h-0 w-full overflow-y-auto [scroll-behavior:smooth]">
+        <div className="flex-1 min-h-0 w-full overflow-y-auto scroll-smooth">
           {exactMatchData && (
             <section>
               <h2 className="px-4 pt-4 subhead-content">Exact Match:</h2>

--- a/frontend/src/app/staff/_components/party/PartyTable.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTable.tsx
@@ -1,14 +1,24 @@
 "use client";
 
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { useSnackbar } from "@/contexts/SnackbarContext";
 import {
   useAdminParties,
+  useCancelAdminParty,
   useCreateAdminParty,
-  useDeleteAdminParty,
+  useRestoreAdminParty,
   useUpdateAdminParty,
 } from "@/lib/api/party/admin-party.queries";
 import { useDownloadPartiesCsv } from "@/lib/api/party/party.queries";
-import { AdminCreatePartyDto, PartyDto } from "@/lib/api/party/party.types";
+import {
+  AdminCreatePartyDto,
+  PartyDto,
+  PartyStatus,
+} from "@/lib/api/party/party.types";
 import {
   DEFAULT_TABLE_PARAMS,
   ServerTableParams,
@@ -17,7 +27,9 @@ import { getErrorMessage } from "@/lib/errors";
 import { formatTime } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { format } from "date-fns";
+import { Ban, Check, Undo2, X } from "lucide-react";
 import { useState } from "react";
+import { DeleteConfirmDialog } from "../shared/dialog/DeleteConfirmDialog";
 import { InfoChip } from "../shared/sidebar/InfoChip";
 import { useSidebar } from "../shared/sidebar/SidebarContext";
 import { TableTemplate } from "../shared/table/TableTemplate";
@@ -125,20 +137,33 @@ export const PartyTable = () => {
     },
   });
 
-  const deleteMutation = useDeleteAdminParty({
+  const cancelMutation = useCancelAdminParty({
     onError: (error: Error) => {
       const message = getErrorMessage(error, {
         status: {
-          403: "You do not have permission to perform this action.",
           404: "Party not found.",
-          500: "Server error. Please try again later.",
         },
         fallback: "Operation failed.",
       });
-      console.error("Failed to delete party:", message);
+      openSnackbar(message, "error");
     },
     onSuccess: () => {
-      openSnackbar("Party deleted successfully", "success");
+      openSnackbar("Party cancelled successfully", "success");
+    },
+  });
+
+  const restoreMutation = useRestoreAdminParty({
+    onError: (error: Error) => {
+      const message = getErrorMessage(error, {
+        status: {
+          404: "Party not found.",
+        },
+        fallback: "Operation failed.",
+      });
+      openSnackbar(message, "error");
+    },
+    onSuccess: () => {
+      openSnackbar("Party restored successfully", "success");
     },
   });
 
@@ -155,9 +180,7 @@ export const PartyTable = () => {
     );
   };
 
-  const handleDelete = (party: PartyDto) => {
-    deleteMutation.mutate(party.id);
-  };
+  const [partyToCancel, setPartyToCancel] = useState<PartyDto | null>(null);
 
   const handleCreate = () => {
     setEditingParty(null);
@@ -338,6 +361,33 @@ export const PartyTable = () => {
         );
       },
     },
+    {
+      id: "status",
+      accessorFn: (row) => row.status,
+      header: "Active",
+      enableColumnFilter: true,
+      meta: {
+        filter: {
+          type: "select",
+          backendField: "status",
+          filterLabel: "Active",
+          selectOptions: [PartyStatus.CONFIRMED, PartyStatus.CANCELLED],
+        },
+      },
+      cell: ({ row }) =>
+        row.original.status === PartyStatus.CANCELLED ? (
+          <HoverCard openDelay={0} closeDelay={0}>
+            <HoverCardTrigger asChild>
+              <X className="size-4 text-destructive cursor-default" />
+            </HoverCardTrigger>
+            <HoverCardContent>
+              This party was cancelled by the host
+            </HoverCardContent>
+          </HoverCard>
+        ) : (
+          <Check className="size-4" />
+        ),
+    },
   ];
 
   return (
@@ -347,17 +397,25 @@ export const PartyTable = () => {
         columns={columns}
         resourceName="Party"
         onEdit={handleEdit}
-        onDelete={handleDelete}
         onCreateNewRow={handleCreate}
         isLoading={partiesQuery.isLoading}
         isFetching={partiesQuery.isFetching}
         error={partiesQuery.error as Error | null}
-        getDeleteDescription={(party: PartyDto) =>
-          `Are you sure you want to delete this party on ${new Date(
-            party.party_datetime
-          ).toLocaleString()}? This action cannot be undone.`
-        }
-        isDeleting={deleteMutation.isPending}
+        rowActions={[
+          {
+            label: "Cancel",
+            icon: <Ban className="mr-2 size-4" />,
+            variant: "destructive",
+            isVisible: (party) => party.status !== PartyStatus.CANCELLED,
+            onClick: (party) => setPartyToCancel(party),
+          },
+          {
+            label: "Restore",
+            icon: <Undo2 className="mr-2 size-4" />,
+            isVisible: (party) => party.status === PartyStatus.CANCELLED,
+            onClick: (party) => restoreMutation.mutate(party.id),
+          },
+        ]}
         serverMeta={
           partiesQuery.data
             ? {
@@ -371,6 +429,28 @@ export const PartyTable = () => {
         onStateChange={setServerParams}
         onExportCsv={exportCsv}
         isExporting={isExporting}
+      />
+      <DeleteConfirmDialog
+        open={partyToCancel !== null}
+        onOpenChange={(open) => {
+          if (!open) setPartyToCancel(null);
+        }}
+        onConfirm={() => {
+          if (partyToCancel) cancelMutation.mutate(partyToCancel.id);
+        }}
+        title="Cancel Party"
+        description={
+          partyToCancel
+            ? `Are you sure you want to cancel this party on ${format(
+                partyToCancel.party_datetime,
+                "PPP 'at' p"
+              )}?`
+            : undefined
+        }
+        isDeleting={cancelMutation.isPending}
+        dismissLabel="Back"
+        confirmLabel="Cancel Party"
+        pendingLabel="Cancelling..."
       />
     </div>
   );

--- a/frontend/src/app/staff/_components/shared/dialog/DeleteConfirmDialog.tsx
+++ b/frontend/src/app/staff/_components/shared/dialog/DeleteConfirmDialog.tsx
@@ -17,6 +17,9 @@ interface DeleteConfirmDialogProps {
   title?: string;
   description?: string;
   isDeleting?: boolean;
+  dismissLabel?: string;
+  confirmLabel?: string;
+  pendingLabel?: string;
 }
 
 export function DeleteConfirmDialog({
@@ -26,6 +29,9 @@ export function DeleteConfirmDialog({
   title = "Delete Item",
   description = "Are you sure you want to delete this item? This action cannot be undone.",
   isDeleting = false,
+  dismissLabel = "Cancel",
+  confirmLabel = "Delete",
+  pendingLabel = "Deleting...",
 }: DeleteConfirmDialogProps) {
   const handleConfirm = () => {
     onConfirm();
@@ -45,14 +51,14 @@ export function DeleteConfirmDialog({
             onClick={() => onOpenChange(false)}
             disabled={isDeleting}
           >
-            Cancel
+            {dismissLabel}
           </Button>
           <Button
             variant="destructive"
             onClick={handleConfirm}
             disabled={isDeleting}
           >
-            {isDeleting ? "Deleting..." : "Delete"}
+            {isDeleting ? pendingLabel : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/app/staff/_components/shared/table/ColumnHeader.tsx
+++ b/frontend/src/app/staff/_components/shared/table/ColumnHeader.tsx
@@ -59,7 +59,11 @@ export function ColumnHeader<T>({
         <DropdownMenuContent align="start">
           <DropdownMenuItem
             onClick={() => {
-              column.toggleSorting(false);
+              if (isSorted === "asc") {
+                column.clearSorting();
+              } else {
+                column.toggleSorting(false);
+              }
               setOpen(false);
             }}
           >
@@ -69,7 +73,11 @@ export function ColumnHeader<T>({
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
-              column.toggleSorting(true);
+              if (isSorted === "desc") {
+                column.clearSorting();
+              } else {
+                column.toggleSorting(true);
+              }
               setOpen(false);
             }}
           >

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -271,7 +271,7 @@ export function TableTemplate<T extends object>({
       setSorting([{ id: columnId, desc }]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [serverMeta?.sortBy, serverMeta?.sortOrder]);
+  }, [serverMeta?.sortBy, serverMeta?.sortOrder, sorting.length]);
 
   // Server mode: debounced callback on search (globalFilter) change
   useEffect(() => {
@@ -685,11 +685,10 @@ export function TableTemplate<T extends object>({
                       {visibleRows.map((row) => (
                         <TableRow
                           key={row.id}
-                          className={
-                            row.getIsSelected()
-                              ? "bg-accent hover:bg-secondary"
-                              : ""
-                          }
+                          className={cn(
+                            row.getIsSelected() &&
+                              "bg-accent hover:bg-secondary"
+                          )}
                         >
                           {row.getVisibleCells().map((cell) => (
                             <TableCell

--- a/frontend/src/lib/api/party/admin-party.queries.ts
+++ b/frontend/src/lib/api/party/admin-party.queries.ts
@@ -7,8 +7,14 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { useRef } from "react";
 import { PartyService } from "./party.service";
-import { AdminCreatePartyDto, PARTIES_KEY, PartyDto } from "./party.types";
+import {
+  AdminCreatePartyDto,
+  PARTIES_KEY,
+  PartyDto,
+  PartyStatus,
+} from "./party.types";
 
 const partyService = new PartyService();
 
@@ -63,14 +69,98 @@ export function useUpdateAdminParty(
   });
 }
 
-export function useDeleteAdminParty(
-  options?: OptimisticMutationOptions<PartyDto, Error, number>
+export function useCancelAdminParty<TContext = unknown>(
+  options?: OptimisticMutationOptions<PartyDto, Error, number, TContext>
 ) {
   const queryClient = useQueryClient();
+  const previousQueriesRef = useRef<
+    ReturnType<typeof queryClient.getQueriesData<PaginatedResponse<PartyDto>>>
+  >([]);
 
-  return useMutation({
+  return useMutation<PartyDto, Error, number, TContext>({
     ...options,
-    mutationFn: (id: number) => partyService.deleteParty(id),
+    mutationFn: (id: number) => partyService.cancelParty(id),
+
+    onMutate: async (id, context) => {
+      await queryClient.cancelQueries({ queryKey: PARTIES_KEY });
+
+      previousQueriesRef.current = queryClient.getQueriesData<
+        PaginatedResponse<PartyDto>
+      >({ queryKey: PARTIES_KEY });
+
+      queryClient.setQueriesData<PaginatedResponse<PartyDto>>(
+        { queryKey: PARTIES_KEY },
+        (old) =>
+          old
+            ? {
+                ...old,
+                items: old.items.map((p) =>
+                  p.id === id ? { ...p, status: PartyStatus.CANCELLED } : p
+                ),
+              }
+            : old
+      );
+
+      options?.onOptimisticUpdate?.(id);
+      return (await options?.onMutate?.(id, context)) as TContext;
+    },
+
+    onError: (error, id, onMutateResult, context) => {
+      previousQueriesRef.current.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      options?.onError?.(error, id, onMutateResult, context);
+    },
+
+    onSuccess: (...params) => {
+      queryClient.invalidateQueries({ queryKey: PARTIES_KEY });
+      options?.onSuccess?.(...params);
+    },
+  });
+}
+
+export function useRestoreAdminParty<TContext = unknown>(
+  options?: OptimisticMutationOptions<PartyDto, Error, number, TContext>
+) {
+  const queryClient = useQueryClient();
+  const previousQueriesRef = useRef<
+    ReturnType<typeof queryClient.getQueriesData<PaginatedResponse<PartyDto>>>
+  >([]);
+
+  return useMutation<PartyDto, Error, number, TContext>({
+    ...options,
+    mutationFn: (id: number) => partyService.restoreParty(id),
+
+    onMutate: async (id, context) => {
+      await queryClient.cancelQueries({ queryKey: PARTIES_KEY });
+
+      previousQueriesRef.current = queryClient.getQueriesData<
+        PaginatedResponse<PartyDto>
+      >({ queryKey: PARTIES_KEY });
+
+      queryClient.setQueriesData<PaginatedResponse<PartyDto>>(
+        { queryKey: PARTIES_KEY },
+        (old) =>
+          old
+            ? {
+                ...old,
+                items: old.items.map((p) =>
+                  p.id === id ? { ...p, status: PartyStatus.CONFIRMED } : p
+                ),
+              }
+            : old
+      );
+
+      options?.onOptimisticUpdate?.(id);
+      return (await options?.onMutate?.(id, context)) as TContext;
+    },
+
+    onError: (error, id, onMutateResult, context) => {
+      previousQueriesRef.current.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      options?.onError?.(error, id, onMutateResult, context);
+    },
 
     onSuccess: (...params) => {
       queryClient.invalidateQueries({ queryKey: PARTIES_KEY });

--- a/frontend/src/lib/api/party/party.queries.ts
+++ b/frontend/src/lib/api/party/party.queries.ts
@@ -88,7 +88,7 @@ export function useDeleteParty() {
   const queryClient = useQueryClient();
 
   return useMutation<PartyDto, Error, number>({
-    mutationFn: (partyId) => partyService.deleteParty(partyId),
+    mutationFn: (partyId) => partyService.cancelParty(partyId),
     onSuccess: () => {
       // Invalidate parties list to refetch after deletion
       queryClient.invalidateQueries({ queryKey: MY_PARTIES_KEY });

--- a/frontend/src/lib/api/party/party.service.ts
+++ b/frontend/src/lib/api/party/party.service.ts
@@ -108,11 +108,21 @@ export class PartyService {
   }
 
   /**
-   * Delete party (DELETE /api/parties/{party_id})
+   * Cancel party (POST /api/parties/{party_id}/cancel)
    */
-  async deleteParty(partyId: number): Promise<PartyDto> {
-    const response = await this.client.delete<PartyDtoBackend>(
-      `/parties/${partyId}`
+  async cancelParty(partyId: number): Promise<PartyDto> {
+    const response = await this.client.post<PartyDtoBackend>(
+      `/parties/${partyId}/cancel`
+    );
+    return convertParty(response.data);
+  }
+
+  /**
+   * Restore a cancelled party (POST /api/parties/{party_id}/restore)
+   */
+  async restoreParty(partyId: number): Promise<PartyDto> {
+    const response = await this.client.post<PartyDtoBackend>(
+      `/parties/${partyId}/restore`
     );
     return convertParty(response.data);
   }

--- a/frontend/src/lib/api/party/party.types.ts
+++ b/frontend/src/lib/api/party/party.types.ts
@@ -21,6 +21,13 @@ type ContactDto = {
   contact_preference: ContactPreference;
 };
 
+const PartyStatus = {
+  CONFIRMED: "confirmed",
+  CANCELLED: "cancelled",
+} as const;
+
+type PartyStatus = (typeof PartyStatus)[keyof typeof PartyStatus];
+
 /**
  * Party DTO
  */
@@ -30,6 +37,7 @@ type PartyDto = {
   location: LocationDto;
   contact_one: StudentDto;
   contact_two: ContactDto;
+  status: PartyStatus;
 };
 
 /**
@@ -54,6 +62,7 @@ export function convertParty(backend: PartyDtoBackend): PartyDto {
     location: convertLocation(backend.location),
     contact_one: convertStudent(backend.contact_one),
     contact_two: backend.contact_two,
+    status: backend.status,
   };
 }
 
@@ -148,4 +157,4 @@ export type {
   ProximitySearchResponseBackend,
   StudentCreatePartyDto,
 };
-export { convertProximitySearchResponse };
+export { convertProximitySearchResponse, PartyStatus };

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -149,4 +149,5 @@ export const PARTIES: PartyDto[] = mockData.parties.map((party) => ({
   location: findLocationById(party.location_id),
   contact_one: findStudentById(party.contact_one_id),
   contact_two: parseContactTwo(party.contact_two),
+  status: (party.status as PartyDto["status"]) ?? "confirmed",
 }));


### PR DESCRIPTION
Cancelling a party is a soft-delete (status flips to CANCELLED), but the staff/admin table treated cancelled rows as normal confirmed parties, with no way to filter, surface, or undo them. This PR makes cancellation a first-class state across the API and admin UI.

Changes:

- Replaced `DELETE /api/parties/{id}` with `POST /api/parties/{id}/cancel` and added `POST /api/parties/{id}/restore` (admin-only); both endpoints are idempotent
- Fixed staff bypassing the ownership check on cancel (was treated like admin after a prior consolidation)
- Added an "Active" column to the staff Party table with a check/X icon, hover-card explanation on cancelled rows, and a server-side select filter on `status`
- Added Cancel and Restore row actions with optimistic cache updates, custom dialog labels ("Keep Party" / "Cancel Party"), and `Ban`/`Undo2` icons
- Updated student `RegistrationTracker` and `DeletePartyDialog` to say "Cancel Party" instead of "Delete"
- Added `PartyStatus` to frontend party types as a const-enum and exposed the `--muted-background`, `--card-shadow`, and `--input-shadow` tokens in `@theme inline`
- Updated all affected backend tests (router + service) to assert idempotency via `assert_matches`, plus new tests for restore
- Updated mock data and reset_dev to populate some cancelled parties
- Simplified some tailwind classes 
- Made it so that clicking an already selected sort direction to revert back to default sort

Closes #344