### PR TITLE
ui: table layout polish and dynamic filler rows

### DIFF
--- a/frontend/src/app/staff/_components/shared/table/ColumnHeader.tsx
+++ b/frontend/src/app/staff/_components/shared/table/ColumnHeader.tsx
@@ -37,13 +37,13 @@ export function ColumnHeader<T>({
   const canFilter = column.getCanFilter();
 
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex h-full items-start">
       <DropdownMenu open={open} onOpenChange={setOpen}>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="-ml-3 h-8 data-[state=open]:bg-accent"
+            className="-mx-4 -mt-2 h-12 justify-start rounded-none px-4 pt-2 data-[state=open]:bg-accent"
           >
             <span>{title}</span>
             {isFiltered && (

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -66,7 +66,14 @@ import {
   Trash2,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
-import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { DeleteConfirmDialog } from "../dialog/DeleteConfirmDialog";
 import { useSidebar } from "../sidebar/SidebarContext";
 import { ColumnHeader } from "./ColumnHeader";
@@ -182,6 +189,13 @@ export function TableTemplate<T extends object>({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [itemToDelete, setItemToDelete] = useState<T | null>(null);
   const [globalFilter, setGlobalFilter] = useState<string>("");
+  const [fillerMetrics, setFillerMetrics] = useState({
+    fullRows: 0,
+    partialRowHeight: 0,
+  });
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const tableHeaderRef = useRef<HTMLTableSectionElement | null>(null);
+  const sampleRowRef = useRef<HTMLTableRowElement | null>(null);
 
   // Refs to avoid stale closures in debounced effects
   const paginationRef = useRef(pagination);
@@ -510,11 +524,54 @@ export function TableTemplate<T extends object>({
   });
 
   const visibleRows = table.getRowModel().rows;
-  const renderedDataRowCount = visibleRows.length > 0 ? visibleRows.length : 1;
-  const fillerRowCount = Math.max(
-    pagination.pageSize - renderedDataRowCount,
-    0
-  );
+  useLayoutEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    const tableHeader = tableHeaderRef.current;
+
+    if (!scrollContainer || !tableHeader) return;
+
+    const updateVisibleRowCapacity = () => {
+      const availableBodyHeight =
+        scrollContainer.clientHeight -
+        tableHeader.getBoundingClientRect().height;
+      const measuredRowHeight =
+        sampleRowRef.current?.getBoundingClientRect().height ?? 49;
+
+      if (availableBodyHeight <= 0 || measuredRowHeight <= 0) {
+        setFillerMetrics({ fullRows: 0, partialRowHeight: 0 });
+        return;
+      }
+
+      const remainingHeight = Math.max(
+        availableBodyHeight - visibleRows.length * measuredRowHeight,
+        0
+      );
+      const fullRows = Math.floor(remainingHeight / measuredRowHeight);
+      const partialRowHeight = remainingHeight - fullRows * measuredRowHeight;
+
+      setFillerMetrics({
+        fullRows,
+        partialRowHeight: partialRowHeight > 1 ? partialRowHeight : 0,
+      });
+    };
+
+    updateVisibleRowCapacity();
+
+    const resizeObserver = new ResizeObserver(updateVisibleRowCapacity);
+    resizeObserver.observe(scrollContainer);
+    resizeObserver.observe(tableHeader);
+    if (sampleRowRef.current) {
+      resizeObserver.observe(sampleRowRef.current);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [visibleRows.length, columnsWithActions.length]);
+
+  const fillerRowCount = visibleRows.length > 0 ? fillerMetrics.fullRows : 0;
+  const partialFillerRowHeight =
+    visibleRows.length > 0 ? fillerMetrics.partialRowHeight : 0;
   const activePage = table.getState().pagination.pageIndex;
   const activePageSize = table.getState().pagination.pageSize;
   const filteredRowCount = isServerMode
@@ -605,13 +662,14 @@ export function TableTemplate<T extends object>({
 
           {!error && (
             <div
+              ref={scrollContainerRef}
               className={cn(
                 "h-full overflow-y-auto",
                 (isFetching || isLoading) && "opacity-60 pointer-events-none"
               )}
             >
               <Table className="bg-card rounded-sm">
-                <TableHeader>
+                <TableHeader ref={tableHeaderRef}>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <TableRow key={headerGroup.id}>
                       {headerGroup.headers.map((header) => (
@@ -690,6 +748,9 @@ export function TableTemplate<T extends object>({
                       {visibleRows.map((row) => (
                         <TableRow
                           key={row.id}
+                          ref={
+                            row.id === visibleRows[0]?.id ? sampleRowRef : null
+                          }
                           className={cn(
                             row.getIsSelected() &&
                               "bg-accent hover:bg-secondary"
@@ -725,6 +786,18 @@ export function TableTemplate<T extends object>({
                             />
                           </TableRow>
                         )
+                      )}
+                      {partialFillerRowHeight > 0 && (
+                        <TableRow
+                          key="filler-row-partial"
+                          className="pointer-events-none"
+                          style={{ height: partialFillerRowHeight }}
+                        >
+                          <TableCell
+                            colSpan={columnsWithActions.length}
+                            className="p-0"
+                          />
+                        </TableRow>
                       )}
                     </>
                   ) : (

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -596,7 +596,7 @@ export function TableTemplate<T extends object>({
       {headerSlot && <div className="lg:hidden">{headerSlot}</div>}
 
       <div className="flex min-h-0 h-full flex-col justify-between overflow-hidden">
-        <Card className="flex-1 min-h-0 py-2 px-4 overflow-hidden rounded-sm w-full max-w-none mx-0">
+        <Card className="flex-1 min-h-0 overflow-hidden rounded-sm w-full max-w-none mx-0">
           {error && (
             <span className="text-center py-8 text-destructive">
               <p>Error: {error.message}</p>
@@ -619,12 +619,12 @@ export function TableTemplate<T extends object>({
                           key={header.id}
                           className={
                             header.column.id === "actions"
-                              ? "w-0 text-right"
-                              : ""
+                              ? "h-12 w-0 pr-4 pt-2 align-top text-right"
+                              : "h-12 pt-2 align-top first:pl-6 last:pr-6"
                           }
                         >
-                          {header.isPlaceholder ? null : header.column.id ===
-                            "actions" ? null : (
+                          {header.isPlaceholder ||
+                          header.column.id === "actions" ? null : (
                             <ColumnHeader
                               column={header.column}
                               title={
@@ -667,6 +667,11 @@ export function TableTemplate<T extends object>({
                           {table.getVisibleLeafColumns().map((column) => (
                             <TableCell
                               key={`loading-cell-${rowIndex}-${column.id}`}
+                              className={
+                                column.id === "actions"
+                                  ? "pr-4"
+                                  : "first:pl-6 last:pr-6"
+                              }
                             >
                               <Skeleton
                                 className={
@@ -693,9 +698,12 @@ export function TableTemplate<T extends object>({
                           {row.getVisibleCells().map((cell) => (
                             <TableCell
                               key={cell.id}
-                              className={
-                                cell.column.getIsFiltered() ? "bg-card" : ""
-                              }
+                              className={cn(
+                                cell.column.getIsFiltered() && "bg-card",
+                                cell.column.id === "actions"
+                                  ? "pr-4"
+                                  : "first:pl-6 last:pr-6"
+                              )}
                             >
                               {flexRender(
                                 cell.column.columnDef.cell,
@@ -713,7 +721,7 @@ export function TableTemplate<T extends object>({
                           >
                             <TableCell
                               colSpan={columnsWithActions.length}
-                              className="h-12.25"
+                              className="h-12.25 px-4"
                             />
                           </TableRow>
                         )
@@ -723,7 +731,7 @@ export function TableTemplate<T extends object>({
                     <TableRow>
                       <TableCell
                         colSpan={columnsWithActions.length}
-                        className="h-12 text-center"
+                        className="h-12 px-4 text-center"
                       >
                         No results.
                       </TableCell>

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -128,6 +128,14 @@ export type TableProps<T> = {
 
 const serverFilterPassthrough = () => true;
 
+function areSortingStatesEqual(a: SortingState, b: SortingState) {
+  if (a.length !== b.length) return false;
+
+  return a.every(
+    (sort, index) => sort.id === b[index]?.id && sort.desc === b[index]?.desc
+  );
+}
+
 export function TableTemplate<T extends object>({
   data,
   columns,
@@ -276,16 +284,15 @@ export function TableTemplate<T extends object>({
       ([, config]) => config.backendField === serverMeta.sortBy
     )?.[0];
     if (!columnId) return;
-    const desc = serverMeta.sortOrder === "desc";
-    if (
-      sorting.length !== 1 ||
-      sorting[0].id !== columnId ||
-      sorting[0].desc !== desc
-    ) {
-      setSorting([{ id: columnId, desc }]);
-    }
+    const nextSorting = [
+      { id: columnId, desc: serverMeta.sortOrder === "desc" },
+    ];
+
+    setSorting((prev) =>
+      areSortingStatesEqual(prev, nextSorting) ? prev : nextSorting
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [serverMeta?.sortBy, serverMeta?.sortOrder, sorting.length]);
+  }, [serverMeta?.sortBy, serverMeta?.sortOrder]);
 
   // Server mode: debounced callback on search (globalFilter) change
   useEffect(() => {
@@ -760,7 +767,6 @@ export function TableTemplate<T extends object>({
                             <TableCell
                               key={cell.id}
                               className={cn(
-                                cell.column.getIsFiltered() && "bg-card",
                                 cell.column.id === "actions"
                                   ? "pr-4"
                                   : "first:pl-6 last:pr-6"


### PR DESCRIPTION
Tighten up the staff table styling so headers, padding, and placeholder rows behave consistently across page sizes and viewport heights.

Changes:

- Measure available body height and render an exact number of full filler rows plus a partial filler row, so the table never shows a gap or overflows past the page-size capacity
- Removed the fixed padding on the table `Card` and moved horizontal padding onto cells (`first:pl-6 last:pr-6`, `pr-4` on the actions column) so column headers align with their cells and filtered-column backgrounds extend to the edge
- Reworked `ColumnHeader` trigger to fill the full header cell height for a larger click target and cleaner hover state
- Replaced the inline sorting-sync logic with `areSortingStatesEqual` to avoid redundant `setSorting` calls when only `sorting.length` changed
- Applied consistent cell padding to skeleton, filler, and "No results" rows

Closes #367
Closes #393 