### PR TITLE
feat: proactive hold validation

### DIFF
--- a/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
@@ -27,6 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { PARTY_RULE_MESSAGES } from "@/lib/api/party/party.types";
@@ -274,6 +275,7 @@ export default function PartyRegistrationForm({
   const validResidence = isFromThisSchoolYear(
     student?.residence?.residence_chosen_date
   );
+  const isStudentLoading = student === undefined;
 
   return (
     <form onSubmit={handleSubmit}>
@@ -325,7 +327,12 @@ export default function PartyRegistrationForm({
               </Field>
             </div>
 
-            {!validResidence && (
+            {isStudentLoading ? (
+              <Field>
+                <FieldLabel className="content-bold">Party Address</FieldLabel>
+                <Skeleton className="h-10 w-full" />
+              </Field>
+            ) : !validResidence ? (
               <Field data-invalid={!!errors.address}>
                 <FieldLabel htmlFor="party-address" className="content-bold">
                   Party Address
@@ -345,8 +352,7 @@ export default function PartyRegistrationForm({
                 </FieldDescription>
                 {errors.address && <FieldError>{errors.address}</FieldError>}
               </Field>
-            )}
-            {validResidence && (
+            ) : (
               <Field className="col-span-2 gap-1">
                 <FieldLabel className="content-bold">Party Address</FieldLabel>
                 <p className="content">
@@ -372,18 +378,28 @@ export default function PartyRegistrationForm({
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
               <Field className="gap-1">
                 <FieldLabel className="content-bold">First Name</FieldLabel>
-                <p className="content">{student?.first_name}</p>
+                {isStudentLoading ? (
+                  <Skeleton className="h-6 w-full" />
+                ) : (
+                  <p className="content">{student?.first_name}</p>
+                )}
               </Field>
               <Field className="gap-1">
                 <FieldLabel className="content-bold">Last Name</FieldLabel>
-                <p className="content">{student?.last_name}</p>
+                {isStudentLoading ? (
+                  <Skeleton className="h-6 w-full" />
+                ) : (
+                  <p className="content">{student?.last_name}</p>
+                )}
               </Field>
               <Field
                 className="gap-1"
                 data-invalid={!!errors.studentPhoneNumber}
               >
                 <FieldLabel className="content-bold">Phone Number</FieldLabel>
-                {student?.phone_number != null ? (
+                {isStudentLoading ? (
+                  <Skeleton className="h-6 w-full" />
+                ) : student?.phone_number != null ? (
                   <p className="content">
                     {formatPhoneNumberInput(student.phone_number)}
                   </p>
@@ -418,7 +434,9 @@ export default function PartyRegistrationForm({
                 <FieldLabel className="content-bold">
                   Contact Preference
                 </FieldLabel>
-                {student?.phone_number != null ? (
+                {isStudentLoading ? (
+                  <Skeleton className="h-6 w-full" />
+                ) : student?.phone_number != null ? (
                   <p className="content capitalize">
                     {student.contact_preference}
                   </p>
@@ -453,7 +471,11 @@ export default function PartyRegistrationForm({
               </Field>
               <Field className="gap-1">
                 <FieldLabel className="content-bold">Email</FieldLabel>
-                <p className="content">{student?.email}</p>
+                {isStudentLoading ? (
+                  <Skeleton className="h-6 w-full" />
+                ) : (
+                  <p className="content">{student?.email}</p>
+                )}
               </Field>
             </div>
           </div>

--- a/frontend/src/app/(student)/_components/RegistrationTracker.tsx
+++ b/frontend/src/app/(student)/_components/RegistrationTracker.tsx
@@ -12,7 +12,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton, SkeletonText } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { IncidentDto } from "@/lib/api/incident/incident.types";
+import {
+  INCIDENT_SEVERITY_LABELS,
+  IncidentDto,
+} from "@/lib/api/incident/incident.types";
+import { hasActiveHold } from "@/lib/api/location/location.service";
 import { PartyDto } from "@/lib/api/party/party.types";
 import {
   useCurrentStudent,
@@ -23,7 +27,7 @@ import {
   formatTime,
   isFromThisSchoolYear,
 } from "@/lib/utils";
-import { format } from "date-fns";
+import { format } from "date-fns/format";
 import { Ban, MoreVertical, Pencil, Plus } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
@@ -44,6 +48,13 @@ export default function RegistrationTracker(): React.JSX.Element {
   const courseCompleted = student
     ? isFromThisSchoolYear(student.last_registered)
     : false;
+  const residenceHoldExpiration = student?.residence?.location.hold_expiration;
+  const residenceHasActiveHold = hasActiveHold(residenceHoldExpiration ?? null);
+  const disabledNewPartyTitle = residenceHasActiveHold
+    ? "A party cannot be registered on a residence with an active hold"
+    : !courseCompleted
+      ? "Complete the Party Smart Course to register a party"
+      : undefined;
 
   const { activeParties, pastParties } = useMemo(() => {
     const parties = partiesQuery.data ?? [];
@@ -138,20 +149,20 @@ export default function RegistrationTracker(): React.JSX.Element {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button className="shrink-0 bg-transparent hover:bg-transparent p-0 h-auto">
-                  <MoreVertical className="h-4 w-4 content cursor-pointer" />
+                  <MoreVertical className="size-4 content cursor-pointer" />
                   <p className="sr-only">Party actions</p>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={() => setEditParty(party)}>
-                  <Pencil className="h-4 w-4" />
+                  <Pencil className="size-4" />
                   Edit
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   variant="destructive"
                   onClick={() => setDeleteParty(party)}
                 >
-                  <Ban className="h-4 w-4" />
+                  <Ban className="size-4" />
                   Cancel
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -180,7 +191,7 @@ export default function RegistrationTracker(): React.JSX.Element {
           </div>
 
           {/* Contact Two */}
-          <div className="ml-3 mt-6 sm:ml-0 sm:mt-0 content">
+          <div className="ml-3 mt-3 sm:ml-0 sm:mt-0 content">
             <p>
               {party.contact_two.first_name} {party.contact_two.last_name}
             </p>
@@ -208,17 +219,19 @@ export default function RegistrationTracker(): React.JSX.Element {
     incidents: IncidentDto[];
   }) => (
     <div className="px-4 py-4 border-b border-gray-200 rounded-none">
-      <div className="space-y-2">
+      <div>
         <h2 className="content-bold">{date}</h2>
-        {incidents.map((incident) => (
-          <div key={incident.id} className="mt-3">
-            <p className="content">
-              {formatTime(incident.incident_datetime)} -{" "}
-              <span className="capitalize">{incident.severity}</span>
-            </p>
-            <p className="content ml-3 mt-1">{incident.description}</p>
-          </div>
-        ))}
+        <div className="mt-2 space-y-3">
+          {incidents.map((incident) => (
+            <div key={incident.id}>
+              <p className="content">
+                {formatTime(incident.incident_datetime)} -{" "}
+                <span>{INCIDENT_SEVERITY_LABELS[incident.severity]}</span>
+              </p>
+              <p className="content ml-3 mt-1">{incident.description}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );
@@ -242,7 +255,7 @@ export default function RegistrationTracker(): React.JSX.Element {
           setActiveTab(value as "active" | "past" | "incidents")
         }
       >
-        <div className="flex justify-between items-center mt-2">
+        <div className="mt-2 flex items-end justify-between">
           <TabsList className="w-fit flex gap-4">
             <TabsTrigger
               value="active"
@@ -264,7 +277,7 @@ export default function RegistrationTracker(): React.JSX.Element {
             </TabsTrigger>
           </TabsList>
           <div>
-            {courseCompleted ? (
+            {courseCompleted && !residenceHasActiveHold ? (
               <Link href="/new-party">
                 <Button className="px-4 py-2">
                   <Plus className="size-4 inline-block" />
@@ -272,7 +285,10 @@ export default function RegistrationTracker(): React.JSX.Element {
                 </Button>
               </Link>
             ) : (
-              <span title="Complete the Party Smart Course to register a party">
+              <span
+                className="inline-flex cursor-not-allowed"
+                title={disabledNewPartyTitle}
+              >
                 <Button className="px-4 py-2" disabled>
                   <Plus className="size-4 inline-block" />
                   New Party

--- a/frontend/src/app/(student)/_components/StatusComponent.tsx
+++ b/frontend/src/app/(student)/_components/StatusComponent.tsx
@@ -1,17 +1,21 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { hasActiveHold } from "@/lib/api/location/location.service";
 import { isFromThisSchoolYear } from "@/lib/utils";
+import { format } from "date-fns";
 import { AlertTriangleIcon, CheckCircle, ExternalLink } from "lucide-react";
 import Link from "next/link";
 
 type CompletionCardProps = {
   last_registered: Date | null | undefined;
+  hold_expiration?: Date | null;
   isPending?: boolean;
   error?: Error | null;
 };
 
 export default function StatusComponent({
   last_registered = null,
+  hold_expiration = null,
   isPending = false,
   error = null,
 }: CompletionCardProps) {
@@ -40,14 +44,24 @@ export default function StatusComponent({
   }
 
   const isCompleted = isFromThisSchoolYear(last_registered);
+  const hasResidenceHold = hasActiveHold(hold_expiration);
 
   return (
     <Card className="p-4 rounded-md shadow-sm w-full bg-card">
       <CardContent className="p-0 flex flex-col gap-1 text-sm">
+        {hasResidenceHold && (
+          <div className="flex items-center gap-2 text-base text-destructive">
+            <AlertTriangleIcon className="size-4 shrink-0 mb-0.5" />
+            <p>
+              Residence on hold until{" "}
+              <b>{format(hold_expiration!, "MM/dd/yy")}</b>
+            </p>
+          </div>
+        )}
         {isCompleted ? (
           <>
             <div className="flex items-center gap-2 text-gray-800">
-              <CheckCircle className="w-4 h-4" />
+              <CheckCircle className="size-4 mb-0.5" />
               <p className="content">
                 Completed on{" "}
                 <span className="content-bold">
@@ -59,8 +73,8 @@ export default function StatusComponent({
           </>
         ) : (
           <div className="content">
-            <div className="flex items-center gap-2 mb-1">
-              <AlertTriangleIcon className="w-4 h-4" />
+            <div className="flex items-center gap-2 mb-1 text-destructive">
+              <AlertTriangleIcon className="size-4 mb-0.5" />
               <p>Course not completed</p>
             </div>
             <div className="flex items-center">
@@ -69,8 +83,8 @@ export default function StatusComponent({
               </a>
               <Link href="/">
                 {" "}
-                {/*change*/}
-                <ExternalLink className="w-4 h-4 ml-2" />
+                {/*TODO add link to course information */}
+                <ExternalLink className="size-4 ml-2" />
               </Link>
             </div>
           </div>

--- a/frontend/src/app/(student)/new-party/page.tsx
+++ b/frontend/src/app/(student)/new-party/page.tsx
@@ -5,6 +5,7 @@ import PartyRegistrationForm, {
 } from "@/app/(student)/_components/PartyRegistrationForm";
 import { Card } from "@/components/ui/card";
 import { useSnackbar } from "@/contexts/SnackbarContext";
+import { hasActiveHold } from "@/lib/api/location/location.service";
 import { useRegisterParty } from "@/lib/api/party/party.queries";
 import {
   StudentCreatePartyDto,
@@ -19,7 +20,7 @@ import { isFromThisSchoolYear } from "@/lib/utils";
 import { ArrowLeft, Info } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 export default function RegistrationForm() {
   const registerPartyMutation = useRegisterParty();
@@ -29,6 +30,20 @@ export default function RegistrationForm() {
   const router = useRouter();
   const { openSnackbar } = useSnackbar();
   const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const courseCompleted = studentQuery.data
+    ? isFromThisSchoolYear(studentQuery.data.last_registered)
+    : false;
+  const residenceHasActiveHold = hasActiveHold(
+    studentQuery.data?.residence?.location.hold_expiration ?? null
+  );
+  const canRegisterParty = courseCompleted && !residenceHasActiveHold;
+  const isRedirectingBlockedStudent =
+    !studentQuery.isPending && !!studentQuery.data && !canRegisterParty;
+
+  useEffect(() => {
+    if (!isRedirectingBlockedStudent) return;
+    router.replace("/");
+  }, [isRedirectingBlockedStudent, router]);
 
   /**
    * Get initial values from the student's most recent party (if they have one).
@@ -115,6 +130,10 @@ export default function RegistrationForm() {
       }
     }
   };
+
+  if (isRedirectingBlockedStudent) {
+    return null;
+  }
 
   return (
     <div className="h-full overflow-y-auto">

--- a/frontend/src/app/(student)/page.tsx
+++ b/frontend/src/app/(student)/page.tsx
@@ -16,6 +16,7 @@ export default function StudentDashboard() {
   const validResidence = isFromThisSchoolYear(
     studentQuery?.data?.residence?.residence_chosen_date
   );
+  const location = studentQuery?.data?.residence?.location;
 
   return (
     <div className="flex flex-col items-center pt-6">
@@ -31,9 +32,8 @@ export default function StudentDashboard() {
                   ) : (
                     validResidence && (
                       <p>
-                        {studentQuery?.data?.residence?.location.street_number}{" "}
-                        {studentQuery?.data?.residence?.location.street_name}{" "}
-                        {studentQuery?.data?.residence?.location.unit}
+                        {location?.street_number} {location?.street_name}{" "}
+                        {location?.unit}
                       </p>
                     )
                   )}
@@ -54,6 +54,9 @@ export default function StudentDashboard() {
             </Link>
             <StatusComponent
               last_registered={studentQuery.data?.last_registered}
+              hold_expiration={
+                studentQuery.data?.residence?.location.hold_expiration
+              }
               {...studentQuery}
             />
           </div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -53,7 +53,7 @@
 :root {
   --app-header-height: 4rem;
   --radius: 0.625rem;
-  --background: oklch(0.7349 0.0915 237.35 / 0.1);
+  --background: oklch(0.9723 0.01 238.51);
   --background-gradient: linear-gradient(
     in oklch 161deg,
     #dceef9 0%,
@@ -149,11 +149,12 @@
     @apply border-border outline-ring/50;
   }
 
-  /* Prevent rubber-band overscroll on the page itself.
+  /* Prevent rubber-band overscroll only while a dialog overlay is open.
      Without this, trackpad pull-to-bounce exposes the transparent body bg. */
-  /* html {
+  html:has(body [data-slot="dialog-overlay"][data-state="open"]),
+  body:has([data-slot="dialog-overlay"][data-state="open"]) {
     overscroll-behavior: none;
-  } */
+  }
 
   body {
     @apply bg-background text-foreground;

--- a/frontend/src/app/police/_components/PartyCard.tsx
+++ b/frontend/src/app/police/_components/PartyCard.tsx
@@ -13,7 +13,10 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import type { IncidentSeverity } from "@/lib/api/incident/incident.types";
+import {
+  INCIDENT_SEVERITY_LABELS,
+  type IncidentSeverity,
+} from "@/lib/api/incident/incident.types";
 import {
   LocationDto,
   getCitationCount,
@@ -32,18 +35,18 @@ const INCIDENT_MENU_ITEMS: {
 }[] = [
   {
     severity: "remote_warning",
-    label: "Add remote warning",
-    hoverLabel: "Remote Warnings",
+    label: `Add ${INCIDENT_SEVERITY_LABELS.remote_warning.toLowerCase()}`,
+    hoverLabel: `${INCIDENT_SEVERITY_LABELS.remote_warning}s`,
   },
   {
     severity: "in_person_warning",
-    label: "Add in-person warning",
-    hoverLabel: "In-Person Warnings",
+    label: `Add ${INCIDENT_SEVERITY_LABELS.in_person_warning.toLowerCase()}`,
+    hoverLabel: `${INCIDENT_SEVERITY_LABELS.in_person_warning}s`,
   },
   {
     severity: "citation",
-    label: "Add citation",
-    hoverLabel: "Citations",
+    label: `Add ${INCIDENT_SEVERITY_LABELS.citation.toLowerCase()}`,
+    hoverLabel: `${INCIDENT_SEVERITY_LABELS.citation}s`,
   },
 ];
 

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ function TabsList({
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
-      className={cn("text-muted-foreground rounded-lg", className)}
+      className={cn("text-muted-foreground", className)}
       {...props}
     />
   );
@@ -38,7 +38,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "cursor-pointer data-[state=active]:underline data-[state=active]:underline-offset-4 data-[state=active]:font-semibold dark:data-[state=active]:text-foreground dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md px-4 py-1 text-md font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "cursor-pointer data-[state=active]:underline data-[state=active]:underline-offset-4 data-[state=active]:font-semibold dark:data-[state=active]:text-foreground dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md px-4 text-md font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
Prevent students whose residence is on hold from registering a new party, and surface the hold state on the dashboard so it's clear why registration is blocked. Also tightens up a few loading states and small UI inconsistencies that surfaced while in this area.

Changes:

- Disable the "New Party" button (with explanatory tooltip) when the student's residence has an active hold, and redirect any direct nav to `/new-party` back to the dashboard
- Show a "Residence on hold until {date}" warning in `StatusComponent` when the residence has an active hold
- Render skeletons in `PartyRegistrationForm` for student fields and the party address while the student query is loading, instead of showing empty values
- Use shared `INCIDENT_SEVERITY_LABELS` in `RegistrationTracker` incident rows and the police `PartyCard` menu so severity labels stay consistent
- Replace transparent root background with a solid token, and scope `overscroll-behavior: none` to when a dialog overlay is open so the body background no longer shows through on overscroll
- Minor cleanup: `h-4 w-4` → `size-4`, drop a stale `rounded-lg` on `TabsList`, and route the student dashboard address through a local `location` variable

Closes #404