### PR TITLE
feat: add custom auth error page

### DIFF
--- a/frontend/src/app/api/auth/login/saml/route.ts
+++ b/frontend/src/app/api/auth/login/saml/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: NextRequest) {
   const origin = serverEnv.NEXTAUTH_URL;
   const errorUrl = (msg: string) =>
     NextResponse.redirect(
-      new URL(`/api/auth/error?error=${encodeURIComponent(msg)}`, origin),
+      new URL(`/auth-error?error=${encodeURIComponent(msg)}`, origin),
       { status: 303 }
     );
 

--- a/frontend/src/app/auth-error/page.tsx
+++ b/frontend/src/app/auth-error/page.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@/components/ui/button";
+import { TriangleAlert } from "lucide-react";
+import Link from "next/link";
+
+interface Props {
+  searchParams: Promise<{ error?: string }>;
+}
+
+const ERROR_MESSAGES: Record<string, { title: string; description: string }> = {
+  AccessDenied: {
+    title: "Access Denied",
+    description:
+      "Your account doesn't have permission to access this application. Contact your administrator if you believe this is a mistake.",
+  },
+  MissingRole: {
+    title: "Sign-In Failed",
+    description:
+      "Something went wrong while processing your sign-in request. Please try again.",
+  },
+  SAMLAssertionFailed: {
+    title: "Sign-In Failed",
+    description:
+      "We couldn't verify your identity with the identity provider. Please try again.",
+  },
+  MissingEmail: {
+    title: "Sign-In Failed",
+    description:
+      "Your account is missing a required email address. Contact your administrator for help.",
+  },
+  ExchangeFailed: {
+    title: "Sign-In Failed",
+    description:
+      "An unexpected error occurred while signing you in. Please try again or contact support if the problem persists.",
+  },
+};
+
+const DEFAULT_ERROR = {
+  title: "Sign-In Failed",
+  description:
+    "An unexpected error occurred. Please try again or contact support if the problem persists.",
+};
+
+export default async function AuthErrorPage({ searchParams }: Props) {
+  const { error } = await searchParams;
+  const { title, description } =
+    (error ? ERROR_MESSAGES[error] : undefined) ?? DEFAULT_ERROR;
+  const isPermanent = error === "AccessDenied" || error === "MissingEmail";
+
+  return (
+    <main className="flex h-full items-center justify-center px-4">
+      <div className="flex flex-col items-center text-center max-w-md gap-4">
+        <TriangleAlert className="size-12 text-destructive" />
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold">{title}</h1>
+          <p className="text-muted-foreground">{description}</p>
+        </div>
+        {!isPermanent && (
+          <Button asChild>
+            <Link href="/">Try Again</Link>
+          </Button>
+        )}
+        {isPermanent && (
+          <Button asChild variant="outline">
+            <a href="mailto:offcampus@unc.edu">Contact Support</a>
+          </Button>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/lib/auth/auth-options.ts
+++ b/frontend/src/lib/auth/auth-options.ts
@@ -11,6 +11,9 @@ export const authOptions: NextAuthOptions = {
   session: {
     strategy: "jwt",
   },
+  pages: {
+    error: "/auth-error",
+  },
   callbacks: {
     async session({
       session,


### PR DESCRIPTION
Replace the generic NextAuth boilerplate error screen with a styled, app-native error page that matches the rest of the UI (header, footer, no scroll). The new page surfaces friendly messages per error code and offers contextual CTAs — retry for transient errors, contact support for permanent ones.

Changes:

- Added `frontend/src/app/auth-error/page.tsx` — server component that reads `?error=` and maps known SAML/exchange error codes to user-friendly titles and descriptions
- Updated `frontend/src/lib/auth/auth-options.ts` — set `pages: { error: '/auth-error' }` so all NextAuth error redirects land on the custom page
- Updated `frontend/src/app/api/auth/login/saml/route.ts` — changed `errorUrl` helper to redirect to `/auth-error` instead of `/api/auth/error`

Closes #370