### PR TITLE
feat: add info hover cards for last registered and hold expiration

### DIFF
--- a/frontend/src/app/staff/_components/location/LocationTableForm.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTableForm.tsx
@@ -11,9 +11,15 @@ import {
   FieldLabel,
   FieldSet,
 } from "@/components/ui/field";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
+import { Info } from "lucide-react";
 import { useState } from "react";
 import * as z from "zod";
 
@@ -130,7 +136,22 @@ export default function LocationTableForm({
           </Field>
 
           <Field data-invalid={!!errors.holdExpiration}>
-            <FieldLabel htmlFor="hold-expiration">Hold Expiration</FieldLabel>
+            <FieldLabel
+              htmlFor="hold-expiration"
+              className="flex items-center gap-1"
+            >
+              Hold Expiration
+              <HoverCard>
+                <HoverCardTrigger asChild>
+                  <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
+                </HoverCardTrigger>
+                <HoverCardContent className="max-w-64">
+                  A location has an active hold when a hold expiration date is
+                  set and has not yet passed. An active hold prevents students
+                  from registering parties at this location.
+                </HoverCardContent>
+              </HoverCard>
+            </FieldLabel>
             <DatePicker
               id="hold-expiration"
               value={formData.holdExpiration}

--- a/frontend/src/app/staff/_components/student/StudentTableForm.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTableForm.tsx
@@ -11,6 +11,11 @@ import {
   FieldLabel,
   FieldSet,
 } from "@/components/ui/field";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -23,6 +28,7 @@ import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { ResidenceDto } from "@/lib/api/student/student.types";
 import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
+import { Info } from "lucide-react";
 import { useState } from "react";
 import * as z from "zod";
 
@@ -274,7 +280,21 @@ export default function StudentTableForm({
           </Field>
 
           <Field data-invalid={!!errors.last_registered}>
-            <FieldLabel htmlFor="party-date">Last registered</FieldLabel>
+            <FieldLabel
+              htmlFor="party-date"
+              className="flex items-center gap-1"
+            >
+              Last Registered
+              <HoverCard>
+                <HoverCardTrigger asChild>
+                  <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
+                </HoverCardTrigger>
+                <HoverCardContent className="max-w-64">
+                  A student is considered registered if they have a last
+                  registered date within the current academic year.
+                </HoverCardContent>
+              </HoverCard>
+            </FieldLabel>
             <DatePicker
               id="last-registered"
               value={formData.last_registered}

--- a/frontend/src/components/ui/hover-card.tsx
+++ b/frontend/src/components/ui/hover-card.tsx
@@ -5,9 +5,18 @@ import { HoverCard as HoverCardPrimitive } from "radix-ui";
 import * as React from "react";
 
 function HoverCard({
+  openDelay = 0,
+  closeDelay = 0,
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
-  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+  return (
+    <HoverCardPrimitive.Root
+      data-slot="hover-card"
+      openDelay={openDelay}
+      closeDelay={closeDelay}
+      {...props}
+    />
+  );
 }
 
 function HoverCardTrigger({


### PR DESCRIPTION
Add informational hover cards to the Last Registered and Hold Expiration fields in the student and location forms, explaining the business rules behind each field.

Changes:

- Added Info icon with HoverCard to the Last Registered label in `StudentTableForm`, explaining that a student is considered registered if their last registered date falls within the current academic year
- Added Info icon with HoverCard to the Hold Expiration label in `LocationTableForm`, explaining that an active hold occurs when a hold expiration date is set and has not yet passed, and that it prevents students from registering parties at that location
- Set default `openDelay` and `closeDelay` to `0` in the shared `HoverCard` component for instant feedback

Closes #239