### PR TITLE
refactor: SQLAlchemy IntegrityError-based conflict handling

### DIFF
--- a/backend/src/modules/account/account_entity.py
+++ b/backend/src/modules/account/account_entity.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 from src.core.database import EntityBase
 from src.core.types import UTCDateTime
 from src.modules.account.account_model import AccountData, AccountDto, AccountRole
+from src.modules.student.student_model import StudentDto
 
 
 class AccountEntity(MappedAsDataclass, EntityBase):
@@ -34,7 +35,7 @@ class AccountEntity(MappedAsDataclass, EntityBase):
     created_at: Mapped[datetime] = mapped_column(UTCDateTime, server_default=func.now(), init=False)
 
     @classmethod
-    def from_data(cls, data: "AccountData") -> Self:
+    def from_data(cls, data: AccountData) -> Self:
         return cls(
             email=data.email,
             first_name=data.first_name,
@@ -44,7 +45,7 @@ class AccountEntity(MappedAsDataclass, EntityBase):
             role=AccountRole(data.role),
         )
 
-    def to_dto(self) -> "AccountDto":
+    def to_dto(self) -> AccountDto:
         return AccountDto(
             id=self.id,
             email=self.email,
@@ -53,4 +54,18 @@ class AccountEntity(MappedAsDataclass, EntityBase):
             pid=self.pid,
             onyen=self.onyen,
             role=self.role,
+        )
+
+    def to_student_dto(self) -> StudentDto:
+        return StudentDto(
+            id=self.id,
+            pid=self.pid,
+            email=self.email,
+            first_name=self.first_name,
+            last_name=self.last_name,
+            onyen=self.onyen,
+            phone_number=None,
+            contact_preference=None,
+            last_registered=None,
+            residence=None,
         )

--- a/backend/src/modules/account/account_service.py
+++ b/backend/src/modules/account/account_service.py
@@ -134,7 +134,7 @@ class AccountService:
         self.email_service = email_service
         self.query_service = query_service
 
-    async def _get_account_entity_by(self, **fields: Unpack[AccountUniqueFields]) -> AccountEntity:
+    async def get_account_entity_by(self, **fields: Unpack[AccountUniqueFields]) -> AccountEntity:
         clause_builders = {
             "id": lambda v: AccountEntity.id == v,
             "email": lambda v: AccountEntity.email.ilike(v),
@@ -225,7 +225,7 @@ class AccountService:
         return [account.to_dto() for account in accounts]
 
     async def get_account_by(self, **fields: Unpack[AccountUniqueFields]) -> AccountDto:
-        account_entity = await self._get_account_entity_by(**fields)
+        account_entity = await self.get_account_entity_by(**fields)
         return account_entity.to_dto()
 
     async def create_account(self, data: AccountData) -> AccountDto:
@@ -243,7 +243,7 @@ class AccountService:
         return new_account.to_dto()
 
     async def update_account(self, account_id: int, data: AccountUpdateData) -> AccountDto:
-        account_entity = await self._get_account_entity_by(id=account_id)
+        account_entity = await self.get_account_entity_by(id=account_id)
         account_entity.role = data.role
         self.session.add(account_entity)
         await self.session.commit()
@@ -251,7 +251,7 @@ class AccountService:
         return account_entity.to_dto()
 
     async def delete_account(self, account_id: int) -> AccountDto:
-        account_entity = await self._get_account_entity_by(id=account_id)
+        account_entity = await self.get_account_entity_by(id=account_id)
         account = account_entity.to_dto()
         await self.session.delete(account_entity)
         await self.session.commit()
@@ -282,7 +282,7 @@ class AccountService:
 
     async def upsert_idp_account(self, data: AccountData) -> AccountDto:
         try:
-            account_entity = await self._get_account_entity_by(onyen=data.onyen)
+            account_entity = await self.get_account_entity_by(onyen=data.onyen)
         except AccountNotFoundException as e:
             if data.role != AccountRole.STUDENT:
                 raise ForbiddenException(detail="No matching account found") from e
@@ -302,7 +302,7 @@ class AccountService:
 
     async def create_invite(self, data: CreateInviteDto) -> None:
         try:
-            await self._get_account_entity_by(email=data.email)
+            await self.get_account_entity_by(email=data.email)
             raise InviteConflictException(data.email)
         except AccountNotFoundException:
             pass
@@ -342,7 +342,7 @@ class AccountService:
 
     async def provision_staff_account(self, data: AccountData) -> AccountDto:
         try:
-            account_entity = await self._get_account_entity_by(pid=data.pid)
+            account_entity = await self.get_account_entity_by(pid=data.pid)
         except AccountNotFoundException:
             account_entity = None
 

--- a/backend/src/modules/auth/auth_router.py
+++ b/backend/src/modules/auth/auth_router.py
@@ -70,7 +70,7 @@ async def exchange_account_data_for_tokens(
         await student_service.ensure_student_entity_exists(account.id)
     else:
         account = await account_service.provision_staff_account(data)
-    return await auth_service.exchange_account_for_tokens(account)
+    return await auth_service.exchange_for_tokens(account)
 
 
 @router.post("/police/signup", status_code=status.HTTP_204_NO_CONTENT)
@@ -124,7 +124,7 @@ async def police_login(
     police = await police_service.verify_police_credentials(credentials.email, credentials.password)
 
     # Generate token pair
-    return await auth_service.exchange_police_for_tokens(police)
+    return await auth_service.exchange_for_tokens(police)
 
 
 @router.post("/refresh")

--- a/backend/src/modules/auth/auth_service.py
+++ b/backend/src/modules/auth/auth_service.py
@@ -1,11 +1,12 @@
 import hashlib
 from datetime import UTC, datetime, timedelta
+from typing import Literal
 from uuid import uuid4
 
 import jwt
 from fastapi import Depends
 from pydantic import TypeAdapter
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.core.config import env
@@ -55,29 +56,13 @@ class AuthService:
         return hashlib.sha256(jti.encode()).hexdigest()
 
     # JWT Operations (instance methods)
-    def create_account_access_token(self, account: AccountDto) -> tuple[str, datetime]:
-        """Create a JWT access token for a university account."""
+    def create_access_token(self, account: AccountDto | PoliceAccountDto) -> tuple[str, datetime]:
         expires_delta = timedelta(minutes=env.ACCESS_TOKEN_EXPIRE_MINUTES)
         expires_at = datetime.now(UTC) + expires_delta
 
         payload = AccessTokenPayload(
             sub=str(account.id),
             role=account.role.value,
-            exp=expires_at,
-            iat=datetime.now(UTC),
-        )
-
-        token = jwt.encode(payload.model_dump(), env.JWT_SECRET_KEY, algorithm=env.JWT_ALGORITHM)
-        return token, expires_at
-
-    def create_police_access_token(self, police: PoliceAccountDto) -> tuple[str, datetime]:
-        """Create a JWT access token for a police account."""
-        expires_delta = timedelta(minutes=env.ACCESS_TOKEN_EXPIRE_MINUTES)
-        expires_at = datetime.now(UTC) + expires_delta
-
-        payload = AccessTokenPayload(
-            sub=str(police.id),
-            role=police.role.value,
             exp=expires_at,
             iat=datetime.now(UTC),
         )
@@ -94,10 +79,6 @@ class AuthService:
                 algorithms=[env.JWT_ALGORITHM],
             )
             return TypeAdapter(AccessTokenPayload).validate_python(payload)
-        except jwt.ExpiredSignatureError as e:
-            raise CredentialsException() from e
-        except jwt.InvalidTokenError as e:
-            raise CredentialsException() from e
         except Exception as e:
             raise CredentialsException() from e
 
@@ -148,7 +129,43 @@ class AuthService:
 
         return token, expires_at
 
-    async def validate_refresh_token(self, token: str) -> tuple[int, str]:
+    async def revoke_refresh_token(self, token: str) -> None:
+        """Revoke a refresh token by removing it from the database allow-list."""
+        try:
+            payload = jwt.decode(
+                token,
+                env.REFRESH_TOKEN_SECRET_KEY,
+                algorithms=[env.JWT_ALGORITHM],
+                options={"verify_exp": False},
+            )
+            jti = payload.get("jti")
+            if jti:
+                token_hash = self._hash_token_id(jti)
+                await self.session.execute(
+                    delete(RefreshTokenEntity).where(RefreshTokenEntity.token_hash == token_hash)
+                )
+                await self.session.commit()
+        except jwt.InvalidTokenError:
+            pass
+
+    # High-Level Operations
+    async def exchange_for_tokens(self, account: AccountDto | PoliceAccountDto) -> TokensDto:
+        access_token, access_expires = self.create_access_token(account)
+        kwargs = (
+            {"police_id": account.id}
+            if isinstance(account, PoliceAccountDto)
+            else {"account_id": account.id}
+        )
+        refresh_token, refresh_expires = await self.create_refresh_token(**kwargs)
+
+        return TokensDto(
+            access_token=access_token,
+            access_token_expires=access_expires,
+            refresh_token=refresh_token,
+            refresh_token_expires=refresh_expires,
+        )
+
+    async def validate_refresh_token(self, token: str) -> tuple[int, Literal["account", "police"]]:
         """
         Validate a refresh token against the database allow-list.
 
@@ -162,9 +179,7 @@ class AuthService:
             payload = jwt.decode(
                 token, env.REFRESH_TOKEN_SECRET_KEY, algorithms=[env.JWT_ALGORITHM]
             )
-        except jwt.ExpiredSignatureError as e:
-            raise InvalidRefreshTokenException() from e
-        except jwt.InvalidTokenError as e:
+        except (jwt.ExpiredSignatureError, jwt.InvalidTokenError) as e:
             raise InvalidRefreshTokenException() from e
 
         jti = payload.get("jti")
@@ -191,62 +206,15 @@ class AuthService:
             return refresh_token_entity.account_id, "account"
         raise InvalidRefreshTokenException()
 
-    async def revoke_refresh_token(self, token: str) -> None:
-        """Revoke a refresh token by removing it from the database allow-list."""
-        try:
-            payload = jwt.decode(
-                token,
-                env.REFRESH_TOKEN_SECRET_KEY,
-                algorithms=[env.JWT_ALGORITHM],
-                options={"verify_exp": False},
-            )
-            jti = payload.get("jti")
-            if jti:
-                token_hash = self._hash_token_id(jti)
-                result = await self.session.execute(
-                    select(RefreshTokenEntity).where(RefreshTokenEntity.token_hash == token_hash)
-                )
-                refresh_token_entity = result.scalar_one_or_none()
-                if refresh_token_entity:
-                    await self.session.delete(refresh_token_entity)
-                    await self.session.commit()
-        except jwt.InvalidTokenError:
-            pass
-
-    # High-Level Operations
-    async def exchange_account_for_tokens(self, account: AccountDto) -> TokensDto:
-        """Exchange an account for a token pair (access + refresh)."""
-        access_token, access_expires = self.create_account_access_token(account)
-        refresh_token, refresh_expires = await self.create_refresh_token(account_id=account.id)
-
-        return TokensDto(
-            access_token=access_token,
-            access_token_expires=access_expires,
-            refresh_token=refresh_token,
-            refresh_token_expires=refresh_expires,
-        )
-
-    async def exchange_police_for_tokens(self, police: PoliceAccountDto) -> TokensDto:
-        """Exchange a police account for a token pair (access + refresh)."""
-        access_token, access_expires = self.create_police_access_token(police)
-        refresh_token, refresh_expires = await self.create_refresh_token(police_id=police.id)
-
-        return TokensDto(
-            access_token=access_token,
-            access_token_expires=access_expires,
-            refresh_token=refresh_token,
-            refresh_token_expires=refresh_expires,
-        )
-
     async def refresh_access_token(self, refresh_token: str) -> AccessTokenDto:
         """Refresh an access token using a valid refresh token."""
         token_id, role = await self.validate_refresh_token(refresh_token)
 
         if role == "police":
             police = await self.police_service.get_police_by_id(token_id)
-            access_token, access_expires = self.create_police_access_token(police)
+            access_token, access_expires = self.create_access_token(police)
         else:
             account = await self.account_service.get_account_by(id=token_id)
-            access_token, access_expires = self.create_account_access_token(account)
+            access_token, access_expires = self.create_access_token(account)
 
         return AccessTokenDto(access_token=access_token, access_token_expires=access_expires)

--- a/backend/src/modules/incident/incident_entity.py
+++ b/backend/src/modules/incident/incident_entity.py
@@ -42,6 +42,13 @@ class IncidentEntity(MappedAsDataclass, EntityBase):
             reference_id=data.reference_id,
         )
 
+    def set_from_data(self, data: IncidentData) -> None:
+        self.location_id = data.location_id
+        self.incident_datetime = data.incident_datetime
+        self.severity = data.severity
+        self.description = data.description
+        self.reference_id = data.reference_id
+
     def to_dto(self) -> IncidentDto:
         """Convert entity to model."""
         # Ensure incident_datetime is timezone-aware

--- a/backend/src/modules/incident/incident_service.py
+++ b/backend/src/modules/incident/incident_service.py
@@ -182,11 +182,15 @@ class IncidentService:
         """Update an existing incident's datetime, description, and severity."""
         incident_entity = await self._get_incident_entity_by_id(incident_id)
         location = await self.location_service.get_or_create_location(data.location_place_id)
-        incident_entity.location_id = location.id
-        incident_entity.incident_datetime = data.incident_datetime
-        incident_entity.description = data.description
-        incident_entity.severity = data.severity
-        incident_entity.reference_id = data.reference_id
+        incident_entity.set_from_data(
+            IncidentData(
+                location_id=location.id,
+                incident_datetime=data.incident_datetime,
+                description=data.description,
+                severity=data.severity,
+                reference_id=data.reference_id,
+            )
+        )
         self.session.add(incident_entity)
         await self.session.commit()
         await self.session.refresh(incident_entity)

--- a/backend/src/modules/location/location_model.py
+++ b/backend/src/modules/location/location_model.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import Self
 
 from pydantic import AwareDatetime, BaseModel
@@ -56,6 +57,11 @@ class LocationData(AddressData):
             zip_code=address.zip_code,
             hold_expiration=hold_expiration,
         )
+
+    def has_active_hold(self) -> bool:
+        """Check if the location currently has an active hold."""
+        now = datetime.now(UTC)
+        return self.hold_expiration is not None and self.hold_expiration > now
 
 
 class LocationDto(LocationData):

--- a/backend/src/modules/location/location_service.py
+++ b/backend/src/modules/location/location_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import ClassVar
 
@@ -40,6 +41,22 @@ from .location_model import (
 class GoogleMapsAPIException(InternalServerException):
     def __init__(self, detail: str):
         super().__init__(f"Google Maps API error: {detail}")
+
+
+@contextmanager
+def _googlemaps_error_handler(fallback_msg: str):
+    try:
+        yield
+    except (PlaceNotFoundException, InvalidPlaceIdException, GoogleMapsAPIException):
+        raise
+    except googlemaps.exceptions.Timeout as e:
+        raise GoogleMapsAPIException(f"Request timed out: {e!s}") from e
+    except googlemaps.exceptions.HTTPError as e:
+        raise GoogleMapsAPIException(f"HTTP error: {e!s}") from e
+    except googlemaps.exceptions.TransportError as e:
+        raise GoogleMapsAPIException(f"Transport error: {e!s}") from e
+    except Exception as e:
+        raise GoogleMapsAPIException(f"{fallback_msg}: {e!s}") from e
 
 
 class PlaceNotFoundException(NotFoundException):
@@ -145,22 +162,14 @@ class LocationService:
             raise LocationNotFoundException(location_id)
         return location_entity
 
-    async def _get_location_entity_by_place_id(self, google_place_id: str) -> LocationEntity | None:
+    async def _get_location_entity_by_place_id(self, google_place_id: str) -> LocationEntity:
         result = await self.session.execute(
             select(LocationEntity).where(LocationEntity.google_place_id == google_place_id)
         )
-        return result.scalar_one_or_none()
-
-    @staticmethod
-    def assert_valid_location_hold(location: LocationDto) -> None:
-        """Validate that location does not have an active hold."""
-        if location.hold_expiration is not None and location.hold_expiration > datetime.now(UTC):
-            raise LocationHoldActiveException(location.id, location.hold_expiration)
-
-    async def get_locations(self) -> list[LocationDto]:
-        result = await self.session.execute(select(LocationEntity))
-        locations = result.scalars().all()
-        return [location.to_dto() for location in locations]
+        location_entity = result.scalar_one_or_none()
+        if location_entity is None:
+            raise LocationNotFoundException(google_place_id=google_place_id)
+        return location_entity
 
     async def get_locations_paginated(self, params: ListQueryParams) -> "PaginatedLocationResponse":
         """
@@ -191,24 +200,24 @@ class LocationService:
         exporter.set_headers(
             ["Address", "Remote Warning Count", "In-Person Warning Count", "Citation Count"]
         )
+
         for location in locations_response.items:
-            complaint_count = sum(
-                1
-                for incident in location.incidents
-                if incident.severity == IncidentSeverity.REMOTE_WARNING
-            )
-            warning_count = sum(
-                1
-                for incident in location.incidents
-                if incident.severity == IncidentSeverity.IN_PERSON_WARNING
-            )
-            citation_count = sum(
-                1
-                for incident in location.incidents
-                if incident.severity == IncidentSeverity.CITATION
-            )
+            remote_warning_count, in_person_warning_count, citation_count = 0, 0, 0
+            for incident in location.incidents:
+                match incident.severity:
+                    case IncidentSeverity.REMOTE_WARNING:
+                        remote_warning_count += 1
+                    case IncidentSeverity.IN_PERSON_WARNING:
+                        in_person_warning_count += 1
+                    case IncidentSeverity.CITATION:
+                        citation_count += 1
             exporter.add_row(
-                [location.formatted_address, complaint_count, warning_count, citation_count]
+                [
+                    location.formatted_address,
+                    remote_warning_count,
+                    in_person_warning_count,
+                    citation_count,
+                ]
             )
         return exporter.to_bytes()
 
@@ -218,53 +227,36 @@ class LocationService:
 
     async def get_location_by_place_id(self, google_place_id: str) -> LocationDto:
         location_entity = await self._get_location_entity_by_place_id(google_place_id)
-        if location_entity is None:
-            raise LocationNotFoundException(google_place_id=google_place_id)
         return location_entity.to_dto()
 
-    async def assert_location_exists(self, location_id: int) -> None:
-        await self._get_location_entity_by_id(location_id)
-
     async def create_location(self, data: LocationData) -> LocationDto:
-        if await self._get_location_entity_by_place_id(data.google_place_id):
-            raise LocationConflictException(data.google_place_id)
-
         new_location = LocationEntity.from_data(data)
         try:
             self.session.add(new_location)
             await self.session.commit()
         except IntegrityError as e:
-            # handle race condition where another session inserted the same google_place_id
+            await self.session.rollback()
             raise LocationConflictException(data.google_place_id) from e
         await self.session.refresh(new_location)
         return new_location.to_dto()
 
-    async def create_location_from_address(self, address_data: AddressData) -> LocationDto:
-        location_data = LocationData.from_address(address_data)
-        return await self.create_location(location_data)
-
     async def create_location_from_place_id(self, place_id: str) -> LocationDto:
         address_data = await self.get_place_details(place_id)
-        return await self.create_location_from_address(address_data)
+        location_data = LocationData.from_address(address_data)
+        return await self.create_location(location_data)
 
     async def get_or_create_location(self, place_id: str) -> LocationDto:
         """Get existing location by place_id, or create it if it doesn't exist."""
         # Try to get existing location
         try:
             location = await self.get_location_by_place_id(place_id)
-            return location
         except LocationNotFoundException:
             location = await self.create_location_from_place_id(place_id)
-            return location
+
+        return location
 
     async def update_location(self, location_id: int, data: LocationData) -> LocationDto:
         location_entity = await self._get_location_entity_by_id(location_id)
-
-        if (
-            data.google_place_id != location_entity.google_place_id
-            and await self._get_location_entity_by_place_id(data.google_place_id)
-        ):
-            raise LocationConflictException(data.google_place_id)
 
         for key, value in data.model_dump().items():
             if key == "id":
@@ -276,6 +268,7 @@ class LocationService:
             self.session.add(location_entity)
             await self.session.commit()
         except IntegrityError as e:
+            await self.session.rollback()
             raise LocationConflictException(data.google_place_id) from e
         await self.session.refresh(location_entity)
         return location_entity.to_dto()
@@ -289,16 +282,19 @@ class LocationService:
 
     async def autocomplete_address(self, input_text: str) -> list[AutocompleteResult]:
         # Autocomplete an address using Google Maps Places API. Biased towards Chapel Hill, NC area
-        try:
-            autocomplete_result = await asyncio.to_thread(
-                places.places_autocomplete,
-                self.gmaps_client,
-                input_text=input_text,
-                types="address",
-                language="en",
-                location=(35.9132, -79.0558),  # Chapel Hill, NC coordinates
-                radius=50000,  # 50km radius around Chapel Hill
-            )
+        with _googlemaps_error_handler("Failed to autocomplete address"):
+            try:
+                autocomplete_result = await asyncio.to_thread(
+                    places.places_autocomplete,
+                    self.gmaps_client,
+                    input_text=input_text,
+                    types="address",
+                    language="en",
+                    location=(35.9132, -79.0558),  # Chapel Hill, NC coordinates
+                    radius=50000,  # 50km radius around Chapel Hill
+                )
+            except googlemaps.exceptions.ApiError as e:
+                raise GoogleMapsAPIException(f"API error ({e.status}): {e!s}") from e
 
             suggestions = []
             for prediction in autocomplete_result:
@@ -310,19 +306,6 @@ class LocationService:
 
             return suggestions
 
-        except GoogleMapsAPIException:
-            raise
-        except googlemaps.exceptions.ApiError as e:
-            raise GoogleMapsAPIException(f"API error ({e.status}): {e!s}") from e
-        except googlemaps.exceptions.Timeout as e:
-            raise GoogleMapsAPIException(f"Request timed out: {e!s}") from e
-        except googlemaps.exceptions.HTTPError as e:
-            raise GoogleMapsAPIException(f"HTTP error: {e!s}") from e
-        except googlemaps.exceptions.TransportError as e:
-            raise GoogleMapsAPIException(f"Transport error: {e!s}") from e
-        except Exception as e:
-            raise GoogleMapsAPIException(f"Failed to autocomplete address: {e!s}") from e
-
     async def get_place_details(self, place_id: str) -> AddressData:
         """
         Get detailed location data for a Google Maps place ID
@@ -330,13 +313,21 @@ class LocationService:
         Raises InvalidPlaceIdException if the place ID format is invalid
         Raises GoogleMapsAPIException for other API errors
         """
-        try:
-            place_result = await asyncio.to_thread(
-                places.place,
-                self.gmaps_client,
-                place_id=place_id,
-                fields=["formatted_address", "geometry", "address_component"],
-            )
+        with _googlemaps_error_handler("Failed to get place details"):
+            try:
+                place_result = await asyncio.to_thread(
+                    places.place,
+                    self.gmaps_client,
+                    place_id=place_id,
+                    fields=["formatted_address", "geometry", "address_component"],
+                )
+            except googlemaps.exceptions.ApiError as e:
+                if e.status == "NOT_FOUND":
+                    raise PlaceNotFoundException(place_id) from e
+                elif e.status == "INVALID_REQUEST":
+                    raise InvalidPlaceIdException(place_id) from e
+                else:
+                    raise GoogleMapsAPIException(f"API error ({e.status}): {e!s}") from e
 
             if "result" not in place_result:
                 raise PlaceNotFoundException(place_id)
@@ -391,26 +382,3 @@ class LocationService:
                 country=country,
                 zip_code=zip_code,
             )
-
-        except (
-            PlaceNotFoundException,
-            InvalidPlaceIdException,
-            GoogleMapsAPIException,
-        ):
-            raise
-        except googlemaps.exceptions.ApiError as e:
-            # Map Google Maps API error statuses to appropriate exceptions
-            if e.status == "NOT_FOUND":
-                raise PlaceNotFoundException(place_id) from e
-            elif e.status == "INVALID_REQUEST":
-                raise InvalidPlaceIdException(place_id) from e
-            else:
-                raise GoogleMapsAPIException(f"API error ({e.status}): {e!s}") from e
-        except googlemaps.exceptions.Timeout as e:
-            raise GoogleMapsAPIException(f"Request timed out: {e!s}") from e
-        except googlemaps.exceptions.HTTPError as e:
-            raise GoogleMapsAPIException(f"HTTP error: {e!s}") from e
-        except googlemaps.exceptions.TransportError as e:
-            raise GoogleMapsAPIException(f"Transport error: {e!s}") from e
-        except Exception as e:
-            raise GoogleMapsAPIException(f"Failed to get place details: {e!s}") from e

--- a/backend/src/modules/party/party_service.py
+++ b/backend/src/modules/party/party_service.py
@@ -120,9 +120,7 @@ class PartyRule(enum.Enum):
     LOCATION_HOLD_ACTIVE = (
         "LOCATION_HOLD_ACTIVE",
         "Location has an active hold and cannot host a party right now",
-        lambda d: d.location is not None
-        and d.location.hold_expiration is not None
-        and d.location.hold_expiration > datetime.now(UTC),
+        lambda d: d.location is not None and d.location.has_active_hold(),
     )
     CONTACT_TWO_EMAIL_MATCHES_CONTACT_ONE = (
         "CONTACT_TWO_EMAIL_MATCHES_CONTACT_ONE",

--- a/backend/src/modules/police/police_service.py
+++ b/backend/src/modules/police/police_service.py
@@ -75,7 +75,7 @@ class PoliceService:
             raise PoliceNotFoundException(police_id)
         return police
 
-    async def _get_police_entity_by_email(self, email: str) -> PoliceEntity | None:
+    async def _find_police_entity_by_email(self, email: str) -> PoliceEntity | None:
         result = await self.session.execute(
             select(PoliceEntity).where(func.lower(PoliceEntity.email) == email.lower())
         )
@@ -125,7 +125,7 @@ class PoliceService:
             await self.session.commit()
         except IntegrityError as e:
             await self.session.rollback()
-            existing = await self._get_police_entity_by_email(email)
+            existing = await self._find_police_entity_by_email(email)
             if existing is None or existing.is_verified:
                 raise PoliceConflictException(email) from e
             existing.hashed_password = hashed_password
@@ -136,7 +136,7 @@ class PoliceService:
         await self.send_verification_email(email, token)
 
     async def retry_verification(self, email: str) -> None:
-        police = await self._get_police_entity_by_email(email)
+        police = await self._find_police_entity_by_email(email)
         if police is None or police.is_verified:
             # To prevent user enumeration, we return success even if the email doesn't exist or is
             # already verified.
@@ -198,7 +198,7 @@ class PoliceService:
         police = await self._get_police_entity_by_id(police_id)
 
         if email.lower() != police.email.lower():
-            existing = await self._get_police_entity_by_email(email)
+            existing = await self._find_police_entity_by_email(email)
             if existing is not None:
                 raise PoliceConflictException(email)
 
@@ -225,7 +225,7 @@ class PoliceService:
 
     async def verify_police_credentials(self, email: str, password: str) -> PoliceAccountDto:
         """Verify police credentials. Never reveals whether the account exists."""
-        police = await self._get_police_entity_by_email(email)
+        police = await self._find_police_entity_by_email(email)
         if police is None or not verify_password(password, police.hashed_password):
             raise CredentialsException()
         if not police.is_verified:

--- a/backend/src/modules/student/student_service.py
+++ b/backend/src/modules/student/student_service.py
@@ -19,6 +19,7 @@ from src.core.utils.query_utils import (
     SortParam,
 )
 from src.modules.account.account_entity import AccountEntity
+from src.modules.account.account_service import AccountService
 from src.modules.location.location_entity import LocationEntity
 from src.modules.location.location_model import LocationDto
 from src.modules.location.location_service import LocationService
@@ -49,21 +50,11 @@ class StudentConflictException(ConflictException):
         super().__init__(f"Student with phone number {phone_number} already exists")
 
 
-class AccountNotFoundException(NotFoundException):
-    def __init__(self, account_id: int):
-        super().__init__(f"Account with ID {account_id} not found")
-
-
 class ResidenceAlreadyChosenException(BadRequestException):
     def __init__(self):
         super().__init__(
             "Student has already chosen a residence for this academic year and cannot change it"
         )
-
-
-class StudentInfoNotProvidedException(BadRequestException):
-    def __init__(self):
-        super().__init__("Student must provide contact information before registering a party")
 
 
 _IS_REGISTERED_EXPR = case(
@@ -110,12 +101,25 @@ class StudentService:
     def __init__(
         self,
         session: AsyncSession = Depends(get_session),
+        account_service: AccountService = Depends(),
         location_service: LocationService = Depends(),
         query_service: QueryService = Depends(),
     ):
         self.session = session
+        self.account_service = account_service
         self.location_service = location_service
         self.query_service = query_service
+
+    async def _save_student(self, student_entity: StudentEntity) -> StudentDto:
+        phone_number = student_entity.phone_number
+        try:
+            self.session.add(student_entity)
+            await self.session.commit()
+        except IntegrityError as e:
+            await self.session.rollback()
+            raise StudentConflictException(phone_number or "") from e
+        await self.session.refresh(student_entity, ["account", "residence"])
+        return student_entity.to_dto()
 
     async def _get_student_entity_by_account_id(self, account_id: int) -> StudentEntity:
         result = await self.session.execute(
@@ -127,50 +131,6 @@ class StudentService:
         if student_entity is None:
             raise StudentNotFoundException(account_id)
         return student_entity
-
-    async def _get_student_entity_by_phone(self, phone_number: str) -> StudentEntity | None:
-        result = await self.session.execute(
-            select(StudentEntity).where(StudentEntity.phone_number == phone_number)
-        )
-        return result.scalar_one_or_none()
-
-    @staticmethod
-    def _build_dto_from_account(account: AccountEntity) -> StudentDto:
-        """Build a partial StudentDto from an Account that has no Student entity yet."""
-        return StudentDto(
-            id=account.id,
-            pid=account.pid,
-            email=account.email,
-            first_name=account.first_name,
-            last_name=account.last_name,
-            onyen=account.onyen,
-            phone_number=None,
-            contact_preference=None,
-            last_registered=None,
-            residence=None,
-        )
-
-    async def _get_account_entity_by_id(self, account_id: int) -> AccountEntity:
-        result = await self.session.execute(
-            select(AccountEntity).where(AccountEntity.id == account_id)
-        )
-        account = result.scalar_one_or_none()
-        if account is None:
-            raise AccountNotFoundException(account_id)
-        return account
-
-    async def get_students(self, skip: int = 0, limit: int | None = None) -> list[StudentDto]:
-        query = (
-            select(StudentEntity)
-            .options(selectinload(StudentEntity.account), selectinload(StudentEntity.residence))
-            .order_by(StudentEntity.account_id)
-            .offset(skip)
-        )
-        if limit is not None:
-            query = query.limit(limit)
-        result = await self.session.execute(query)
-        students = result.scalars().all()
-        return [student.to_dto() for student in students]
 
     async def get_students_paginated(self, params: ListQueryParams) -> PaginatedStudentsResponse:
         """
@@ -246,28 +206,9 @@ class StudentService:
             )
         return exporter.to_bytes()
 
-    async def get_student_count(self) -> int:
-        count_query = select(func.count(StudentEntity.account_id))
-        count_result = await self.session.execute(count_query)
-        return count_result.scalar_one()
-
     async def get_student_by_id(self, account_id: int) -> StudentDto:
         student_entity = await self._get_student_entity_by_account_id(account_id)
         return student_entity.to_dto()
-
-    async def assert_student_exists(self, account_id: int) -> None:
-        """Assert that a student with the given account ID exists."""
-        await self._get_student_entity_by_account_id(account_id)
-
-    async def assert_student_entity_exists(self, account_id: int) -> None:
-        """Assert that a Student entity exists with contact info for this account.
-        Used before party creation to ensure student has provided phone and contact preference."""
-        result = await self.session.execute(
-            select(StudentEntity).where(StudentEntity.account_id == account_id)
-        )
-        entity = result.scalar_one_or_none()
-        if entity is None or entity.phone_number is None or entity.contact_preference is None:
-            raise StudentInfoNotProvidedException()
 
     async def ensure_student_entity_exists(self, account_id: int) -> None:
         """Ensure a StudentEntity exists for this account, creating one with null
@@ -289,25 +230,15 @@ class StudentService:
         Get StudentDto for the authenticated student. Returns a partial DTO (null phone/preference)
         if the Student entity does not exist yet — i.e., the student has not yet provided info.
         """
-        result = await self.session.execute(
-            select(StudentEntity)
-            .where(StudentEntity.account_id == account_id)
-            .options(selectinload(StudentEntity.account), selectinload(StudentEntity.residence))
-        )
-        student_entity = result.scalar_one_or_none()
-        if student_entity is not None:
+        try:
+            student_entity = await self._get_student_entity_by_account_id(account_id)
             return student_entity.to_dto()
-        account = await self._get_account_entity_by_id(account_id)
-        return self._build_dto_from_account(account)
+        except StudentNotFoundException:
+            account = await self.account_service.get_account_entity_by(id=account_id)
+            return account.to_student_dto()
 
     async def update_student(self, account_id: int, data: StudentUpdateDto) -> StudentDto:
         student_entity = await self._get_student_entity_by_account_id(account_id)
-
-        if (
-            data.phone_number != student_entity.phone_number
-            and await self._get_student_entity_by_phone(data.phone_number)
-        ):
-            raise StudentConflictException(data.phone_number)
 
         # Handle residence_place_id for admin updates
         # Admins can update residence at any time, bypassing academic year restrictions
@@ -322,15 +253,7 @@ class StudentService:
         student_entity.last_registered = data.last_registered
         student_entity.phone_number = data.phone_number
 
-        try:
-            self.session.add(student_entity)
-            await self.session.commit()
-        except IntegrityError as e:
-            await self.session.rollback()
-            raise StudentConflictException(data.phone_number) from e
-
-        await self.session.refresh(student_entity, ["account", "residence"])
-        return student_entity.to_dto()
+        return await self._save_student(student_entity)
 
     async def update_student_self(self, account_id: int, data: SelfUpdateStudentDto) -> StudentDto:
         result = await self.session.execute(
@@ -342,41 +265,18 @@ class StudentService:
 
         if student_entity is None:
             # Upsert: create Student entity for the first time
-            await self._get_account_entity_by_id(account_id)
-            if await self._get_student_entity_by_phone(data.phone_number):
-                raise StudentConflictException(data.phone_number)
+            await self.account_service.get_account_entity_by(id=account_id)
             student_data = StudentData(
                 contact_preference=data.contact_preference,
                 phone_number=data.phone_number,
             )
             student_entity = StudentEntity.from_data(student_data, account_id)
-            try:
-                self.session.add(student_entity)
-                await self.session.commit()
-            except IntegrityError as e:
-                await self.session.rollback()
-                raise StudentConflictException(data.phone_number) from e
-            await self.session.refresh(student_entity, ["account", "residence"])
-            return student_entity.to_dto()
-
-        if (
-            data.phone_number != student_entity.phone_number
-            and await self._get_student_entity_by_phone(data.phone_number)
-        ):
-            raise StudentConflictException(data.phone_number)
+            return await self._save_student(student_entity)
 
         student_entity.contact_preference = data.contact_preference
         student_entity.phone_number = data.phone_number
 
-        try:
-            self.session.add(student_entity)
-            await self.session.commit()
-        except IntegrityError as e:
-            await self.session.rollback()
-            raise StudentConflictException(data.phone_number) from e
-
-        await self.session.refresh(student_entity, ["account", "residence"])
-        return student_entity.to_dto()
+        return await self._save_student(student_entity)
 
     async def update_residence(self, account_id: int, residence_place_id: str) -> LocationDto:
         """Update student's residence. Can only be done once per academic year."""
@@ -395,10 +295,21 @@ class StudentService:
         student_entity.residence_id = location.id
         student_entity.residence_chosen_date = datetime.now(UTC)
 
-        self.session.add(student_entity)
-        await self.session.commit()
+        await self._save_student(student_entity)
 
         return location
+
+    async def update_is_registered(self, account_id: int, is_registered: bool) -> StudentDto:
+        """
+        Update the registration status of a student.
+        If is_registered is True, sets last_registered to current datetime.
+        If is_registered is False, sets last_registered to None.
+        """
+        student_entity = await self._get_student_entity_by_account_id(account_id)
+
+        student_entity.last_registered = datetime.now(UTC) if is_registered else None
+
+        return await self._save_student(student_entity)
 
     async def delete_student(self, account_id: int) -> StudentDto:
         student_entity = await self._get_student_entity_by_account_id(account_id)
@@ -472,21 +383,3 @@ class StudentService:
             )
 
         return suggestions
-
-    async def update_is_registered(self, account_id: int, is_registered: bool) -> StudentDto:
-        """
-        Update the registration status of a student.
-        If is_registered is True, sets last_registered to current datetime.
-        If is_registered is False, sets last_registered to None.
-        """
-        student_entity = await self._get_student_entity_by_account_id(account_id)
-
-        if is_registered:
-            student_entity.last_registered = datetime.now(UTC)
-        else:
-            student_entity.last_registered = None
-
-        self.session.add(student_entity)
-        await self.session.commit()
-        await self.session.refresh(student_entity, ["account", "residence"])
-        return student_entity.to_dto()

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -130,10 +130,10 @@ async def create_test_client(
                 role=PoliceRole(role),
                 is_verified=True,
             )
-            token, _ = auth_service.create_police_access_token(police)
+            token, _ = auth_service.create_access_token(police)
         elif role in ("admin", "staff", "student"):
             entity = AccountTestUtils.build_client_account_entity(AccountRole(role))
-            token, _ = auth_service.create_account_access_token(entity.to_dto())
+            token, _ = auth_service.create_access_token(entity.to_dto())
         else:
             token = None
 
@@ -245,9 +245,14 @@ def auth_service(
 
 
 @pytest.fixture()
-def student_service(test_session: AsyncSession, location_service: LocationService):
+def student_service(
+    test_session: AsyncSession,
+    account_service: AccountService,
+    location_service: LocationService,
+):
     return StudentService(
         session=test_session,
+        account_service=account_service,
         location_service=location_service,
         query_service=QueryService(test_session),
     )

--- a/backend/test/modules/auth/auth_router_test.py
+++ b/backend/test/modules/auth/auth_router_test.py
@@ -495,7 +495,7 @@ class TestAuthRouter:
         account_entity = await account_utils.create_one()
         account = account_entity.to_dto()
 
-        tokens = await auth_service.exchange_account_for_tokens(account)
+        tokens = await auth_service.exchange_for_tokens(account)
 
         headers = {"Authorization": f"Bearer {tokens.access_token}"}
 
@@ -569,7 +569,7 @@ class TestAuthMiddleware:
         account_entity = await account_utils.create_one()
         account = account_entity.to_dto()
 
-        tokens = await self.auth_service.exchange_account_for_tokens(account)
+        tokens = await self.auth_service.exchange_for_tokens(account)
 
         response = await self.unauthenticated_client.post(
             "/api/auth/logout",
@@ -585,7 +585,7 @@ class TestAuthMiddleware:
         police_entity = await police_utils.create_one()
         police_dto = police_entity.to_dto()
 
-        tokens = await self.auth_service.exchange_police_for_tokens(police_dto)
+        tokens = await self.auth_service.exchange_for_tokens(police_dto)
 
         response = await self.unauthenticated_client.post(
             "/api/auth/logout",
@@ -635,7 +635,7 @@ class TestAuthMiddleware:
     async def test_wrong_role_returns_403(self, account_utils: AccountTestUtils) -> None:
         """Student token on admin/staff-only route returns 403."""
         account_entity = await account_utils.create_one(role="student")
-        token, _ = self.auth_service.create_account_access_token(account_entity.to_dto())
+        token, _ = self.auth_service.create_access_token(account_entity.to_dto())
 
         response = await self.unauthenticated_client.get(
             "/api/parties/1",
@@ -651,7 +651,7 @@ class TestAuthMiddleware:
         """Middleware correctly uses sub as the account id when looking up the student."""
         account_entity = await account_utils.create_one(role="student")
         await self.student_utils.create_one(account_id=account_entity.id)
-        token, _ = self.auth_service.create_account_access_token(account_entity.to_dto())
+        token, _ = self.auth_service.create_access_token(account_entity.to_dto())
 
         response = await self.unauthenticated_client.get(
             "/api/students/me",

--- a/backend/test/modules/auth/auth_service_test.py
+++ b/backend/test/modules/auth/auth_service_test.py
@@ -31,24 +31,24 @@ class TestAuthService:
     # ========================= JWT Creation Tests =========================
 
     @pytest.mark.asyncio
-    async def test_create_account_access_token(self, account_utils: AccountTestUtils) -> None:
+    async def test_create_access_token_account(self, account_utils: AccountTestUtils) -> None:
         """Test creating access token for account."""
         account_entity = await account_utils.create_one()
         account = account_entity.to_dto()
 
-        token, expires_at = self.auth_service.create_account_access_token(account)
+        token, expires_at = self.auth_service.create_access_token(account)
 
         payload = self.auth_utils.decode_token(token)
         self.auth_utils.assert_account_token_payload(payload, account)
         self.auth_utils.assert_expiration_approx(expires_at, env.ACCESS_TOKEN_EXPIRE_MINUTES * 60)
 
     @pytest.mark.asyncio
-    async def test_create_police_access_token(self, police_utils: PoliceTestUtils) -> None:
+    async def test_create_access_token_police(self, police_utils: PoliceTestUtils) -> None:
         """Test creating access token for police includes police id as sub."""
         police_entity = await police_utils.create_one()
         police = police_entity.to_dto()
 
-        token, expires_at = self.auth_service.create_police_access_token(police)
+        token, expires_at = self.auth_service.create_access_token(police)
 
         payload = self.auth_utils.decode_token(token)
         self.auth_utils.assert_police_token_payload(payload, police)
@@ -281,12 +281,12 @@ class TestAuthService:
     # ========================= High-Level Operations Tests =========================
 
     @pytest.mark.asyncio
-    async def test_exchange_account_for_tokens(self, account_utils: AccountTestUtils) -> None:
+    async def test_exchange_for_tokens_account(self, account_utils: AccountTestUtils) -> None:
         """Test exchanging account for token pair."""
         account_entity = await account_utils.create_one()
         account = account_entity.to_dto()
 
-        tokens = await self.auth_service.exchange_account_for_tokens(account)
+        tokens = await self.auth_service.exchange_for_tokens(account)
 
         access_payload = self.auth_utils.decode_token(tokens.access_token)
         self.auth_utils.assert_account_token_payload(access_payload, account)
@@ -297,12 +297,12 @@ class TestAuthService:
         assert refresh_payload["sub"] == str(account.id)
 
     @pytest.mark.asyncio
-    async def test_exchange_police_for_tokens(self, police_utils: PoliceTestUtils) -> None:
+    async def test_exchange_for_tokens_police(self, police_utils: PoliceTestUtils) -> None:
         """Test exchanging police account for token pair includes police id as sub."""
         police_entity = await police_utils.create_one()
         police = police_entity.to_dto()
 
-        tokens = await self.auth_service.exchange_police_for_tokens(police)
+        tokens = await self.auth_service.exchange_for_tokens(police)
 
         access_payload = self.auth_utils.decode_token(tokens.access_token)
         self.auth_utils.assert_police_token_payload(access_payload, police)

--- a/backend/test/modules/location/location_router_test.py
+++ b/backend/test/modules/location/location_router_test.py
@@ -335,7 +335,7 @@ class TestLocationCRUDRouter:
         )
 
         response = await self.admin_client.post("/api/locations", json=request_data)
-        assert_res_failure(response, LocationConflictException(location.google_place_id))
+        assert_res_failure(response, LocationConflictException(location_data.google_place_id))
 
     @pytest.mark.asyncio
     async def test_update_location_success(self):
@@ -388,7 +388,7 @@ class TestLocationCRUDRouter:
         response = await self.admin_client.put(
             f"/api/locations/{locations[1].id}", json=request_data
         )
-        assert_res_failure(response, LocationConflictException(locations[0].google_place_id))
+        assert_res_failure(response, LocationConflictException(update_data.google_place_id))
 
     @pytest.mark.asyncio
     async def test_delete_location_success(self):

--- a/backend/test/modules/location/location_service_test.py
+++ b/backend/test/modules/location/location_service_test.py
@@ -31,12 +31,6 @@ class TestLocationServiceCRUD:
         self.location_service = location_service
 
     @pytest.mark.asyncio
-    async def test_get_locations_empty(self):
-        """Test getting all locations when none exist"""
-        locations = await self.location_service.get_locations()
-        assert locations == []
-
-    @pytest.mark.asyncio
     async def test_create_location(self):
         """Test creating a new location"""
         data = await self.location_utils.next_data()
@@ -65,17 +59,6 @@ class TestLocationServiceCRUD:
 
         with pytest.raises(LocationConflictException):
             await self.location_service.create_location(data)
-
-    @pytest.mark.asyncio
-    async def test_get_locations(self):
-        """Test getting all locations"""
-        locations = await self.location_utils.create_many(i=3)
-
-        fetched = await self.location_service.get_locations()
-
-        assert len(fetched) == 3
-        for loc, f in zip(locations, fetched, strict=False):
-            self.location_utils.assert_matches(loc, f)
 
     @pytest.mark.asyncio
     async def test_get_location_by_id(self):
@@ -303,32 +286,6 @@ class TestLocationServiceWithIncidents:
         # Verify incidents are retained
         assert len(updated.incidents) == 1
         self.incident_utils.assert_matches(updated.incidents[0], incident)
-
-    @pytest.mark.asyncio
-    async def test_get_locations_includes_incidents(self):
-        """Test that getting all locations includes their incidents."""
-        location1, location2 = await self.location_utils.create_many(i=2)
-
-        # Add incidents to both locations
-        incident1 = await self.incident_utils.create_one(location_id=location1.id)
-        incident2 = await self.incident_utils.create_one(location_id=location2.id)
-
-        # Fetch all locations
-        fetched_locations = await self.location_service.get_locations()
-
-        # Find the locations by id
-        loc1 = next((loc for loc in fetched_locations if loc.id == location1.id), None)
-        loc2 = next((loc for loc in fetched_locations if loc.id == location2.id), None)
-
-        assert loc1 is not None
-        assert loc2 is not None
-
-        # Verify incidents are included
-        assert len(loc1.incidents) == 1
-        self.incident_utils.assert_matches(loc1.incidents[0], incident1)
-
-        assert len(loc2.incidents) == 1
-        self.incident_utils.assert_matches(loc2.incidents[0], incident2)
 
 
 class TestLocationServiceGoogleMapsAutocomplete:

--- a/backend/test/modules/student/student_router_test.py
+++ b/backend/test/modules/student/student_router_test.py
@@ -353,7 +353,7 @@ class TestStudentCRUDRouter:
             f"/api/students/{students[1].account_id}",
             json=updated_data.model_dump(mode="json"),
         )
-        assert_res_failure(response, StudentConflictException(students[0].phone_number))
+        assert_res_failure(response, StudentConflictException(updated_data.phone_number or ""))
 
     @pytest.mark.asyncio
     async def test_delete_student_success(self):
@@ -773,7 +773,7 @@ class TestStudentMeRouter:
             "/api/students/me",
             json=updated_data.model_dump(mode="json"),
         )
-        assert_res_failure(response, StudentConflictException(other_student.phone_number))
+        assert_res_failure(response, StudentConflictException(updated_data.phone_number or ""))
 
     @pytest.mark.asyncio
     async def test_get_me_parties_empty(self, current_student: StudentEntity):

--- a/backend/test/modules/student/student_service_test.py
+++ b/backend/test/modules/student/student_service_test.py
@@ -10,7 +10,6 @@ from src.modules.student.student_model import ContactPreference, SelfUpdateStude
 from src.modules.student.student_service import (
     ResidenceAlreadyChosenException,
     StudentConflictException,
-    StudentInfoNotProvidedException,
     StudentNotFoundException,
     StudentService,
 )
@@ -36,11 +35,6 @@ class TestStudentService:
         self.student_service = student_service
 
     @pytest.mark.asyncio
-    async def test_get_students_empty(self):
-        students = await self.student_service.get_students()
-        assert len(students) == 0
-
-    @pytest.mark.asyncio
     async def test_multiple_null_phone_numbers_do_not_conflict(self) -> None:
         """MySQL allows multiple NULLs in a UNIQUE index natively — no filtered index needed.
         Multiple unonboarded students (null phone_number) must coexist without conflict."""
@@ -54,16 +48,6 @@ class TestStudentService:
         student2 = await self.student_service.get_student_by_id(account2.id)
         assert student1.phone_number is None
         assert student2.phone_number is None
-
-    @pytest.mark.asyncio
-    async def test_get_students(self):
-        students = await self.student_utils.create_many(i=3)
-
-        fetched = await self.student_service.get_students()
-        assert len(fetched) == 3
-
-        for s, f in zip(students, fetched, strict=False):
-            self.student_utils.assert_matches(s, f)
 
     @pytest.mark.asyncio
     async def test_get_student_by_id(self):
@@ -251,35 +235,6 @@ class TestStudentService:
         updated = await self.student_service.update_student(student_entity.account_id, update_data)
 
         self.student_utils.assert_matches(updated, update_data)
-
-    @pytest.mark.asyncio
-    async def test_assert_student_entity_exists_raises_when_no_entity(self):
-        """assert_student_entity_exists raises StudentInfoNotProvidedException when no entity."""
-        account = await self.account_utils.create_one(role=AccountRole.STUDENT.value)
-
-        with pytest.raises(StudentInfoNotProvidedException):
-            await self.student_service.assert_student_entity_exists(account.id)
-
-    @pytest.mark.asyncio
-    async def test_assert_student_entity_exists_passes_when_entity_present(self):
-        """assert_student_entity_exists does not raise when Student entity exists."""
-        student_entity = await self.student_utils.create_one()
-
-        # Should not raise
-        await self.student_service.assert_student_entity_exists(student_entity.account_id)
-
-    @pytest.mark.asyncio
-    async def test_assert_student_entity_exists_raises_when_null_info(
-        self, test_session: AsyncSession
-    ):
-        """assert_student_entity_exists raises when entity exists but phone/preference are null."""
-        account = await self.account_utils.create_one(role=AccountRole.STUDENT.value)
-        entity = StudentEntity(account_id=account.id)
-        test_session.add(entity)
-        await test_session.commit()
-
-        with pytest.raises(StudentInfoNotProvidedException):
-            await self.student_service.assert_student_entity_exists(account.id)
 
     @pytest.mark.asyncio
     async def test_ensure_student_entity_exists_creates_entity(self, test_session: AsyncSession):


### PR DESCRIPTION
Services previously did a SELECT before every INSERT/UPDATE to check for conflicts, issuing an unnecessary round-trip and duplicating guard logic that the DB unique constraint already enforces. This refactor removes those preemptive checks and lets `IntegrityError` be the single source of truth, with explicit `rollback()` after each caught error to restore the session to a clean state.

Changes:

- Removed SELECT-before-write conflict guards from `LocationService`, `StudentService`, and `PoliceService`
- Added `await session.rollback()` inside every `except IntegrityError` block so the session is usable again after a conflict (avoids `PendingRollbackError` / `MissingGreenlet` in subsequent operations)
- Captured entity attributes (e.g. `phone_number`) before the `try` block to avoid expired-attribute lazy-load errors after rollback
- Added `_save_student` helper in `StudentService` to deduplicate the commit → rollback-on-conflict → refresh → return-DTO pattern across four update methods
- Renamed `_get_police_entity_by_email` → `_find_police_entity_by_email` to signal it returns `None` instead of raising
- Moved `_build_dto_from_account` static method to `AccountEntity.to_student_dto()` instance method
- Injected `AccountService` into `StudentService` and removed the duplicate `_get_account_entity_by_id` method
- Combined `create_account_access_token` + `create_police_access_token` → `create_access_token`, and `exchange_account_for_tokens` + `exchange_police_for_tokens` → `exchange_for_tokens` in `AuthService`
- Switched `revoke_refresh_token` to a single `DELETE` statement instead of SELECT-then-delete
- Fixed `export_locations_to_excel` incident count variables being initialized outside the location loop (causing counts to accumulate across locations)
- Updated and cleaned up tests to match all of the above

Closes #140