### PR TITLE
refactor: replace ExcelExporter class with typed export_to_excel function

### DIFF
--- a/backend/src/core/utils/excel_utils.py
+++ b/backend/src/core/utils/excel_utils.py
@@ -1,4 +1,7 @@
+from collections.abc import Callable
+from datetime import UTC, datetime
 from io import BytesIO
+from typing import Any
 
 import openpyxl
 from openpyxl.styles import Font
@@ -6,58 +9,38 @@ from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.worksheet import Worksheet
 
 
-class ExcelExporter:
-    """Encapsulates openpyxl mechanics for generating Excel workbooks."""
+def export_to_excel[T](
+    resource_name: str,
+    field_map: dict[str, Callable[[T], Any]],
+    items: list[T],
+) -> bytes:
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    assert isinstance(sheet, Worksheet)
+    sheet.title = f"{resource_name} {datetime.now(UTC).strftime('%Y-%m-%d')}"
 
-    def __init__(self, sheet_title: str = "Sheet") -> None:
-        self._workbook = openpyxl.Workbook()
-        sheet = self._workbook.active
-        assert isinstance(sheet, Worksheet)
-        self._sheet: Worksheet = sheet
-        self._sheet.title = sheet_title
-        self._headers_set: bool = False
+    headers = list(field_map.keys())
+    sheet.append(headers)
+    bold_font = Font(bold=True)
+    for cell in sheet[1]:
+        cell.font = bold_font
 
-    def set_headers(self, headers: list[str]) -> "ExcelExporter":
-        """Append headers as the first row with bold font. Returns self for chaining."""
-        if self._headers_set:
-            raise RuntimeError("Headers have already been set")
-        self._sheet.append(headers)
-        bold_font = Font(bold=True)
-        for cell in self._sheet[1]:
-            cell.font = bold_font
-        self._headers_set = True
-        return self
+    for item in items:
+        sheet.append([fn(item) for fn in field_map.values()])
 
-    def add_row(self, row: list) -> "ExcelExporter":
-        """Append a data row. Returns self for chaining."""
-        self._sheet.append(row)
-        return self
+    for col_idx, column_cells in enumerate(sheet.columns, start=1):
+        max_length = 0
+        for cell in column_cells:
+            try:
+                if cell.value:
+                    cell_length = len(str(cell.value))
+                    if cell_length > max_length:
+                        max_length = cell_length
+            except (AttributeError, TypeError):
+                pass
+        col_letter = get_column_letter(col_idx)
+        sheet.column_dimensions[col_letter].width = min(max_length + 2, 50)
 
-    def to_bytes(self) -> bytes:
-        """Auto-fit column widths (capped at 50 chars), save workbook, return bytes."""
-        for col_idx, column_cells in enumerate(self._sheet.columns, start=1):
-            max_length = 0
-            for cell in column_cells:
-                try:
-                    if cell.value:
-                        cell_length = len(str(cell.value))
-                        if cell_length > max_length:
-                            max_length = cell_length
-                except (AttributeError, TypeError):
-                    pass
-            col_letter = get_column_letter(col_idx)
-            self._sheet.column_dimensions[col_letter].width = min(max_length + 2, 50)
-
-        buffer = BytesIO()
-        self._workbook.save(buffer)
-        return buffer.getvalue()
-
-    @staticmethod
-    def format_phone(phone: str | None) -> str:
-        """Format 10-digit numbers as (XXX) XXX-XXXX; pass through anything else unchanged."""
-        if not phone:
-            return ""
-        digits = "".join(filter(str.isdigit, phone))
-        if digits and len(digits) == 10:
-            return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
-        return phone
+    buffer = BytesIO()
+    workbook.save(buffer)
+    return buffer.getvalue()

--- a/backend/src/core/utils/phone_utils.py
+++ b/backend/src/core/utils/phone_utils.py
@@ -1,2 +1,12 @@
 def digits_only(phone: str) -> str:
     return "".join(filter(str.isdigit, phone))
+
+
+def format_phone(phone: str | None) -> str:
+    """Format 10-digit numbers as (XXX) XXX-XXXX; pass through anything else unchanged."""
+    if not phone:
+        return ""
+    digits = "".join(filter(str.isdigit, phone))
+    if digits and len(digits) == 10:
+        return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
+    return phone

--- a/backend/src/modules/account/account_service.py
+++ b/backend/src/modules/account/account_service.py
@@ -9,7 +9,7 @@ from src.core.config import env
 from src.core.database import get_session
 from src.core.exceptions import ConflictException, ForbiddenException, NotFoundException
 from src.core.utils.email_utils import EmailService
-from src.core.utils.excel_utils import ExcelExporter
+from src.core.utils.excel_utils import export_to_excel
 from src.core.utils.query_utils import (
     ListQueryParams,
     QueryFieldSet,
@@ -175,43 +175,35 @@ class AccountService:
         return PaginatedAccountsResponse(**result.model_dump())
 
     def export_accounts_to_excel(self, accounts_response: PaginatedAccountsResponse) -> bytes:
-        headers = ["Onyen", "Email", "First Name", "Last Name", "PID", "Role"]
-        exporter = ExcelExporter(sheet_title=f"Accounts {datetime.now(UTC).strftime('%Y-%m-%d')}")
-        exporter.set_headers(headers)
-        for account in accounts_response.items:
-            exporter.add_row(
-                [
-                    account.onyen,
-                    account.email,
-                    account.first_name,
-                    account.last_name,
-                    account.pid,
-                    account.role.value.capitalize(),
-                ]
-            )
-        return exporter.to_bytes()
+        return export_to_excel(
+            resource_name="Accounts",
+            field_map={
+                "Onyen": lambda a: a.onyen,
+                "Email": lambda a: a.email,
+                "First Name": lambda a: a.first_name,
+                "Last Name": lambda a: a.last_name,
+                "PID": lambda a: a.pid,
+                "Role": lambda a: a.role.value.capitalize(),
+            },
+            items=accounts_response.items,
+        )
 
     def export_aggregate_accounts_to_excel(
         self, accounts_response: PaginatedAggregateAccountsResponse
     ) -> bytes:
-        headers = ["Email", "First Name", "Last Name", "Onyen", "PID", "Role", "Status"]
-        exporter = ExcelExporter(
-            sheet_title=f"Aggregate Accounts {datetime.now(UTC).strftime('%Y-%m-%d')}"
+        return export_to_excel(
+            resource_name="Aggregate Accounts",
+            field_map={
+                "Email": lambda a: a.email,
+                "First Name": lambda a: a.first_name,
+                "Last Name": lambda a: a.last_name,
+                "Onyen": lambda a: a.onyen,
+                "PID": lambda a: a.pid,
+                "Role": lambda a: a.role.replace("_", " ").title(),
+                "Status": lambda a: a.status.value.capitalize(),
+            },
+            items=accounts_response.items,
         )
-        exporter.set_headers(headers)
-        for account in accounts_response.items:
-            exporter.add_row(
-                [
-                    account.email,
-                    account.first_name,
-                    account.last_name,
-                    account.onyen,
-                    account.pid,
-                    account.role.replace("_", " ").title(),
-                    account.status.value.capitalize(),
-                ]
-            )
-        return exporter.to_bytes()
 
     async def get_accounts_by_roles(
         self, roles: list[AccountRole] | None = None

--- a/backend/src/modules/incident/incident_service.py
+++ b/backend/src/modules/incident/incident_service.py
@@ -1,4 +1,3 @@
-from datetime import UTC, datetime
 from typing import ClassVar
 
 from fastapi import Depends
@@ -7,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from src.core.database import get_session
 from src.core.exceptions import NotFoundException
-from src.core.utils.excel_utils import ExcelExporter
+from src.core.utils.excel_utils import export_to_excel
 from src.core.utils.query_utils import (
     ListQueryParams,
     QueryFieldSet,
@@ -129,22 +128,18 @@ class IncidentService:
         return result.items
 
     def export_incidents_to_excel(self, incident_data: list[tuple[IncidentDto, str]]) -> bytes:
-        headers = ["Severity", "Address", "Date", "Time", "Description", "Reference ID"]
-        exporter = ExcelExporter(
-            sheet_title=f"Incidents {datetime.now(UTC).strftime('%Y-%m-%d')}"
-        ).set_headers(headers)
-        for incident, address in incident_data:
-            exporter.add_row(
-                [
-                    incident.severity.value.replace("_", " ").title(),
-                    address,
-                    incident.incident_datetime.strftime("%Y-%m-%d"),
-                    incident.incident_datetime.strftime("%-I:%M %p"),
-                    incident.description,
-                    incident.reference_id or None,
-                ]
-            )
-        return exporter.to_bytes()
+        return export_to_excel(
+            resource_name="Incidents",
+            field_map={
+                "Severity": lambda x: x[0].severity.value.replace("_", " ").title(),
+                "Address": lambda x: x[1],
+                "Date": lambda x: x[0].incident_datetime.strftime("%Y-%m-%d"),
+                "Time": lambda x: x[0].incident_datetime.strftime("%-I:%M %p"),
+                "Description": lambda x: x[0].description,
+                "Reference ID": lambda x: x[0].reference_id,
+            },
+            items=incident_data,
+        )
 
     async def get_incidents_by_location(self, location_id: int) -> list[IncidentDto]:
         """Get all incidents for a given location, ordered by incident datetime."""

--- a/backend/src/modules/location/location_service.py
+++ b/backend/src/modules/location/location_service.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import ClassVar
 
 import googlemaps
@@ -17,7 +17,7 @@ from src.core.exceptions import (
     InternalServerException,
     NotFoundException,
 )
-from src.core.utils.excel_utils import ExcelExporter
+from src.core.utils.excel_utils import export_to_excel
 from src.core.utils.query_utils import (
     ListQueryParams,
     QueryFieldSet,
@@ -195,31 +195,22 @@ class LocationService:
         return PaginatedLocationResponse(**result.model_dump())
 
     def export_locations_to_excel(self, locations_response: PaginatedLocationResponse) -> bytes:
-        """Export locations to an Excel file."""
-        exporter = ExcelExporter(sheet_title=f"Locations {datetime.now(UTC).strftime('%Y-%m-%d')}")
-        exporter.set_headers(
-            ["Address", "Remote Warning Count", "In-Person Warning Count", "Citation Count"]
+        return export_to_excel(
+            resource_name="Locations",
+            field_map={
+                "Address": lambda loc: loc.formatted_address,
+                "Remote Warning Count": lambda loc: sum(
+                    1 for i in loc.incidents if i.severity == IncidentSeverity.REMOTE_WARNING
+                ),
+                "In-Person Warning Count": lambda loc: sum(
+                    1 for i in loc.incidents if i.severity == IncidentSeverity.IN_PERSON_WARNING
+                ),
+                "Citation Count": lambda loc: sum(
+                    1 for i in loc.incidents if i.severity == IncidentSeverity.CITATION
+                ),
+            },
+            items=locations_response.items,
         )
-
-        for location in locations_response.items:
-            remote_warning_count, in_person_warning_count, citation_count = 0, 0, 0
-            for incident in location.incidents:
-                match incident.severity:
-                    case IncidentSeverity.REMOTE_WARNING:
-                        remote_warning_count += 1
-                    case IncidentSeverity.IN_PERSON_WARNING:
-                        in_person_warning_count += 1
-                    case IncidentSeverity.CITATION:
-                        citation_count += 1
-            exporter.add_row(
-                [
-                    location.formatted_address,
-                    remote_warning_count,
-                    in_person_warning_count,
-                    citation_count,
-                ]
-            )
-        return exporter.to_bytes()
 
     async def get_location_by_id(self, location_id: int) -> LocationDto:
         location_entity = await self._get_location_entity_by_id(location_id)

--- a/backend/src/modules/party/party_service.py
+++ b/backend/src/modules/party/party_service.py
@@ -12,8 +12,8 @@ from src.core.config import env
 from src.core.database import get_session
 from src.core.exceptions import BadRequestException, NotFoundException
 from src.core.utils.date_utils import business_days_ahead, is_same_academic_year
-from src.core.utils.excel_utils import ExcelExporter
-from src.core.utils.phone_utils import digits_only
+from src.core.utils.excel_utils import export_to_excel
+from src.core.utils.phone_utils import digits_only, format_phone
 from src.core.utils.query_utils import (
     ListQueryParams,
     QueryFieldSet,
@@ -479,84 +479,66 @@ class PartyService:
         return c * r
 
     def export_parties_to_excel_police(self, parties_response: PaginatedPartiesResponse) -> bytes:
-        """Police format: 11 columns, full names, no residence."""
-        exporter = ExcelExporter(sheet_title=f"Parties {datetime.now(UTC).strftime('%Y-%m-%d')}")
-        exporter.set_headers(
-            [
-                "Address",
-                "Date of Party",
-                "Time of Party",
-                "Contact One Full Name",
-                "Contact One Email",
-                "Contact One Phone Number",
-                "Contact One Contact Preference",
-                "Contact Two Full Name",
-                "Contact Two Email",
-                "Contact Two Phone Number",
-                "Contact Two Contact Preference",
-            ]
+        return export_to_excel(
+            resource_name="Parties",
+            field_map={
+                "Address": lambda p: p.location.formatted_address,
+                "Date of Party": lambda p: p.party_datetime.strftime("%Y-%m-%d"),
+                "Time of Party": lambda p: p.party_datetime.strftime("%-I:%M %p"),
+                "Contact One Full Name": lambda p: (
+                    f"{p.contact_one.first_name} {p.contact_one.last_name}"
+                ),
+                "Contact One Email": lambda p: p.contact_one.email,
+                "Contact One Phone Number": lambda p: format_phone(
+                    p.contact_one.phone_number or ""
+                ),
+                "Contact One Contact Preference": lambda p: (
+                    p.contact_one.contact_preference.value.capitalize()
+                    if p.contact_one.contact_preference
+                    else None
+                ),
+                "Contact Two Full Name": lambda p: (
+                    f"{p.contact_two.first_name} {p.contact_two.last_name}"
+                ),
+                "Contact Two Email": lambda p: p.contact_two.email,
+                "Contact Two Phone Number": lambda p: format_phone(p.contact_two.phone_number),
+                "Contact Two Contact Preference": lambda p: (
+                    p.contact_two.contact_preference.value.capitalize()
+                ),
+            },
+            items=parties_response.items,
         )
-        for party in parties_response.items:
-            c1 = party.contact_one
-            c2 = party.contact_two
-            exporter.add_row(
-                [
-                    party.location.formatted_address,
-                    party.party_datetime.strftime("%Y-%m-%d"),
-                    party.party_datetime.strftime("%-I:%M %p"),
-                    f"{c1.first_name} {c1.last_name}",
-                    c1.email,
-                    ExcelExporter.format_phone(c1.phone_number or ""),
-                    c1.contact_preference.value.capitalize() if c1.contact_preference else None,
-                    f"{c2.first_name} {c2.last_name}",
-                    c2.email,
-                    ExcelExporter.format_phone(c2.phone_number),
-                    c2.contact_preference.value.capitalize(),
-                ]
-            )
-        return exporter.to_bytes()
 
     def export_parties_to_excel_staff(self, parties_response: PaginatedPartiesResponse) -> bytes:
-        """Staff/admin format: 14 columns, split names, includes residence."""
-        exporter = ExcelExporter(sheet_title=f"Parties {datetime.now(UTC).strftime('%Y-%m-%d')}")
-        exporter.set_headers(
-            [
-                "Address",
-                "Date of Party",
-                "Time of Party",
-                "Contact One First Name",
-                "Contact One Last Name",
-                "Contact One Email",
-                "Contact One Phone Number",
-                "Contact One Contact Preference",
-                "Contact One Residence",
-                "Contact Two First Name",
-                "Contact Two Last Name",
-                "Contact Two Email",
-                "Contact Two Phone Number",
-                "Contact Two Contact Preference",
-            ]
+        return export_to_excel(
+            resource_name="Parties",
+            field_map={
+                "Address": lambda p: p.location.formatted_address,
+                "Date of Party": lambda p: p.party_datetime.strftime("%Y-%m-%d"),
+                "Time of Party": lambda p: p.party_datetime.strftime("%-I:%M %p"),
+                "Contact One First Name": lambda p: p.contact_one.first_name,
+                "Contact One Last Name": lambda p: p.contact_one.last_name,
+                "Contact One Email": lambda p: p.contact_one.email,
+                "Contact One Phone Number": lambda p: format_phone(
+                    p.contact_one.phone_number or ""
+                ),
+                "Contact One Contact Preference": lambda p: (
+                    p.contact_one.contact_preference.value.capitalize()
+                    if p.contact_one.contact_preference
+                    else None
+                ),
+                "Contact One Residence": lambda p: (
+                    p.contact_one.residence.location.formatted_address
+                    if p.contact_one.residence
+                    else ""
+                ),
+                "Contact Two First Name": lambda p: p.contact_two.first_name,
+                "Contact Two Last Name": lambda p: p.contact_two.last_name,
+                "Contact Two Email": lambda p: p.contact_two.email,
+                "Contact Two Phone Number": lambda p: format_phone(p.contact_two.phone_number),
+                "Contact Two Contact Preference": lambda p: (
+                    p.contact_two.contact_preference.value.capitalize()
+                ),
+            },
+            items=parties_response.items,
         )
-        for party in parties_response.items:
-            c1 = party.contact_one
-            c2 = party.contact_two
-            residence_address = c1.residence.location.formatted_address if c1.residence else ""
-            exporter.add_row(
-                [
-                    party.location.formatted_address,
-                    party.party_datetime.strftime("%Y-%m-%d"),
-                    party.party_datetime.strftime("%-I:%M %p"),
-                    c1.first_name,
-                    c1.last_name,
-                    c1.email,
-                    ExcelExporter.format_phone(c1.phone_number or ""),
-                    c1.contact_preference.value.capitalize() if c1.contact_preference else None,
-                    residence_address,
-                    c2.first_name,
-                    c2.last_name,
-                    c2.email,
-                    ExcelExporter.format_phone(c2.phone_number),
-                    c2.contact_preference.value.capitalize(),
-                ]
-            )
-        return exporter.to_bytes()

--- a/backend/src/modules/police/police_service.py
+++ b/backend/src/modules/police/police_service.py
@@ -17,7 +17,7 @@ from src.core.exceptions import (
 )
 from src.core.utils.bcrypt_utils import hash_password, verify_password
 from src.core.utils.email_utils import EmailService
-from src.core.utils.excel_utils import ExcelExporter
+from src.core.utils.excel_utils import export_to_excel
 from src.core.utils.query_utils import (
     ListQueryParams,
     QueryFieldSet,
@@ -95,17 +95,16 @@ class PoliceService:
         return PaginatedPoliceResponse(**result.model_dump())
 
     def export_police_to_excel(self, police_response: PaginatedPoliceResponse) -> bytes:
-        headers = ["Email", "Role"]
-        exporter = ExcelExporter(sheet_title="Police Accounts")
-        exporter.set_headers(headers)
-        for police in police_response.items:
-            exporter.add_row(
-                [
-                    police.email,
-                    "Police Admin" if police.role == PoliceRole.POLICE_ADMIN else "Officer",
-                ]
-            )
-        return exporter.to_bytes()
+        return export_to_excel(
+            resource_name="Police Accounts",
+            field_map={
+                "Email": lambda p: p.email,
+                "Role": lambda p: "Police Admin"
+                if p.role == PoliceRole.POLICE_ADMIN
+                else "Officer",
+            },
+            items=police_response.items,
+        )
 
     async def signup_police(self, email: str, password: str) -> None:
         if not email.endswith(f"@{env.CHPD_EMAIL_DOMAIN}"):

--- a/backend/src/modules/student/student_service.py
+++ b/backend/src/modules/student/student_service.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import selectinload
 from src.core.database import get_session
 from src.core.exceptions import BadRequestException, ConflictException, NotFoundException
 from src.core.utils.date_utils import current_academic_year_start, is_same_academic_year
-from src.core.utils.excel_utils import ExcelExporter
-from src.core.utils.phone_utils import digits_only
+from src.core.utils.excel_utils import export_to_excel
+from src.core.utils.phone_utils import digits_only, format_phone
 from src.core.utils.query_utils import (
     ListQueryParams,
     QueryFieldSet,
@@ -161,50 +161,25 @@ class StudentService:
         return PaginatedStudentsResponse(**result.model_dump())
 
     def export_students_to_excel(self, students_response: PaginatedStudentsResponse) -> bytes:
-        headers = [
-            "Onyen",
-            "PID",
-            "First Name",
-            "Last Name",
-            "Email",
-            "Phone Number",
-            "Contact Preference",
-            "Is Registered",
-            "Residence Address",
-        ]
-        exporter = ExcelExporter(sheet_title=f"Students {datetime.now(UTC).strftime('%Y-%m-%d')}")
-        exporter.set_headers(headers)
-        for student in students_response.items:
-            # Mirrors the UI checkbox: "Yes" if last_registered is set
-            # (cleared to None when unmarked via PATCH /students/{id}/is-registered)
-            is_registered = "Yes" if student.last_registered is not None else "No"
-            residence_address = (
-                student.residence.location.formatted_address
-                if student.residence is not None
-                else None
-            )
-            phone = (
-                ExcelExporter.format_phone(student.phone_number) if student.phone_number else None
-            )
-            contact_preference = (
-                student.contact_preference.value.capitalize()
-                if student.contact_preference
-                else None
-            )
-            exporter.add_row(
-                [
-                    student.onyen,
-                    student.pid,
-                    student.first_name,
-                    student.last_name,
-                    student.email,
-                    phone,
-                    contact_preference,
-                    is_registered,
-                    residence_address,
-                ]
-            )
-        return exporter.to_bytes()
+        return export_to_excel(
+            resource_name="Students",
+            field_map={
+                "Onyen": lambda s: s.onyen,
+                "PID": lambda s: s.pid,
+                "First Name": lambda s: s.first_name,
+                "Last Name": lambda s: s.last_name,
+                "Email": lambda s: s.email,
+                "Phone Number": lambda s: format_phone(s.phone_number),
+                "Contact Preference": lambda s: (
+                    s.contact_preference.value.capitalize() if s.contact_preference else None
+                ),
+                "Is Registered": lambda s: "Yes" if s.last_registered is not None else "No",
+                "Residence Address": lambda s: (
+                    s.residence.location.formatted_address if s.residence is not None else None
+                ),
+            },
+            items=students_response.items,
+        )
 
     async def get_student_by_id(self, account_id: int) -> StudentDto:
         student_entity = await self._get_student_entity_by_account_id(account_id)


### PR DESCRIPTION
Replace the imperative `ExcelExporter` class (set_headers → add_row × N → to_bytes) with a single generic function that captures the recurring export pattern across all service modules.

Changes:

- Replaced `ExcelExporter` class with a module-level `export_to_excel[T]` function in `excel_utils.py` using PEP 695 generic syntax — accepts `resource_name`, a `dict[str, Callable[[T], Any]]` field map, and `list[T]` items; auto-formats the sheet title as `<ResourceName> YYYY-MM-DD`
- Moved `format_phone` from `ExcelExporter.format_phone` (static method) into `phone_utils.py` where it belongs alongside `digits_only`
- Updated all six export methods across `account_service`, `incident_service`, `location_service`, `party_service`, `police_service`, and `student_service` to use the new function
- The incident export case (`list[tuple[IncidentDto, str]]`) uses `T = tuple[IncidentDto, str]` with lambdas indexing `x[0]` / `x[1]` — no special handling needed
- Removed unused `datetime`/`UTC` imports from services that previously needed them only for the sheet title