### PR TITLE
feat: add police admin incidents tab using shared incident table

### DIFF
--- a/backend/src/modules/location/location_router.py
+++ b/backend/src/modules/location/location_router.py
@@ -101,7 +101,7 @@ async def get_place_details(
 async def get_locations(
     params: ListQueryParams = parse_list_query_params(),
     location_service: LocationService = Depends(),
-    _=Depends(authenticate_by_role("staff", "admin")),
+    _=Depends(authenticate_by_role("staff", "admin", "police_admin")),
 ) -> PaginatedLocationResponse:
     """
     Returns all locations with pagination, sorting, and filtering.

--- a/backend/test/modules/location/location_router_test.py
+++ b/backend/test/modules/location/location_router_test.py
@@ -64,7 +64,7 @@ test_location_search_no_results, test_location_search_ok = generate_search_tests
 )
 
 test_location_authentication = generate_auth_required_tests(
-    ({"admin", "staff"}, "GET", "/api/locations", None),
+    ({"admin", "staff", "police_admin"}, "GET", "/api/locations", None),
     ({"admin"}, "POST", "/api/locations", {"google_place_id": "ChIJ123abc"}),
     ({"admin", "staff"}, "GET", "/api/locations/1", None),
     ({"admin"}, "PUT", "/api/locations/1", {"google_place_id": "ChIJ123abc"}),

--- a/frontend/src/app/police/admin/[tab]/page.tsx
+++ b/frontend/src/app/police/admin/[tab]/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import PoliceAdminTable from "@/app/police/admin/_components/PoliceAdminTable";
+import {
+  DEFAULT_POLICE_ADMIN_TAB,
+  POLICE_ADMIN_TABS,
+  POLICE_ADMIN_TAB_CONFIG,
+  type PoliceAdminTabSlug,
+} from "@/app/police/admin/_lib/tabs";
+import { IncidentTable } from "@/app/staff/_components/incident/IncidentTable";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useParams, useRouter } from "next/navigation";
+
+const TAB_CONTENT: Record<PoliceAdminTabSlug, React.ReactNode> = {
+  accounts: <PoliceAdminTable />,
+  incidents: <IncidentTable />,
+};
+
+export default function PoliceAdminTabPage() {
+  const { tab } = useParams<{ tab: string }>();
+  const router = useRouter();
+
+  const isValidTab = POLICE_ADMIN_TABS.includes(tab as PoliceAdminTabSlug);
+
+  if (!isValidTab) {
+    router.replace(`/police/admin/${DEFAULT_POLICE_ADMIN_TAB}`);
+    return null;
+  }
+
+  const currentTab = tab as PoliceAdminTabSlug;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <Select
+        value={currentTab}
+        onValueChange={(value) => router.push(`/police/admin/${value}`)}
+      >
+        <SelectTrigger className="sm:hidden w-40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {POLICE_ADMIN_TABS.map((slug) => (
+            <SelectItem key={slug} value={slug}>
+              {POLICE_ADMIN_TAB_CONFIG[slug].label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Tabs
+        value={currentTab}
+        onValueChange={(value) => router.push(`/police/admin/${value}`)}
+        className="flex h-full min-h-0 flex-col gap-4"
+      >
+        <TabsList className="hidden sm:flex w-fit">
+          {POLICE_ADMIN_TABS.map((slug) => (
+            <TabsTrigger key={slug} value={slug}>
+              {POLICE_ADMIN_TAB_CONFIG[slug].label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {POLICE_ADMIN_TABS.map((slug) => (
+          <TabsContent key={slug} value={slug} className="flex-1 min-h-0">
+            {TAB_CONTENT[slug]}
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/app/police/admin/_lib/tabs.tsx
+++ b/frontend/src/app/police/admin/_lib/tabs.tsx
@@ -1,0 +1,13 @@
+export const POLICE_ADMIN_TABS = ["accounts", "incidents"] as const;
+
+export type PoliceAdminTabSlug = (typeof POLICE_ADMIN_TABS)[number];
+
+export const DEFAULT_POLICE_ADMIN_TAB: PoliceAdminTabSlug = "accounts";
+
+export const POLICE_ADMIN_TAB_CONFIG: Record<
+  PoliceAdminTabSlug,
+  { label: string }
+> = {
+  accounts: { label: "Accounts" },
+  incidents: { label: "Incidents" },
+};

--- a/frontend/src/app/police/admin/layout.tsx
+++ b/frontend/src/app/police/admin/layout.tsx
@@ -14,8 +14,8 @@ export default function PoliceAdminLayout({
 }) {
   return (
     <SidebarProvider>
-      <main className="h-full overflow-y-auto lg:overflow-hidden bg-background px-4 py-4 md:px-6 md:py-6">
-        <div className="mx-auto h-full max-w-6xl min-h-0 flex flex-col">
+      <main className="h-full overflow-y-auto lg:overflow-hidden bg-background">
+        <div className="container mx-auto px-6 pt-6 pb-2 h-full min-h-0 flex flex-col">
           <header className="mb-4">
             <h1 className="page-title text-secondary">
               Police Admin Dashboard

--- a/frontend/src/app/police/admin/layout.tsx
+++ b/frontend/src/app/police/admin/layout.tsx
@@ -1,3 +1,5 @@
+import Sidebar from "@/app/staff/_components/shared/sidebar/Sidebar";
+import { SidebarProvider } from "@/app/staff/_components/shared/sidebar/SidebarContext";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -10,5 +12,19 @@ export default function PoliceAdminLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <SidebarProvider>
+      <main className="h-full overflow-y-auto lg:overflow-hidden bg-background px-4 py-4 md:px-6 md:py-6">
+        <div className="mx-auto h-full max-w-6xl min-h-0 flex flex-col">
+          <header className="mb-4">
+            <h1 className="page-title text-secondary">
+              Police Admin Dashboard
+            </h1>
+          </header>
+          <div className="flex-1 min-h-0">{children}</div>
+        </div>
+      </main>
+      <Sidebar />
+    </SidebarProvider>
+  );
 }

--- a/frontend/src/app/police/admin/page.tsx
+++ b/frontend/src/app/police/admin/page.tsx
@@ -1,25 +1,6 @@
-"use client";
-
-import PoliceAdminTable from "@/app/police/admin/_components/PoliceAdminTable";
-import Sidebar from "@/app/staff/_components/shared/sidebar/Sidebar";
-import { SidebarProvider } from "@/app/staff/_components/shared/sidebar/SidebarContext";
+import { DEFAULT_POLICE_ADMIN_TAB } from "@/app/police/admin/_lib/tabs";
+import { redirect } from "next/navigation";
 
 export default function PoliceAdminPage() {
-  return (
-    <SidebarProvider>
-      <main className="h-full overflow-y-auto lg:overflow-hidden bg-background px-4 py-4 md:px-6 md:py-6">
-        <div className="mx-auto h-full max-w-6xl min-h-0 flex flex-col">
-          <header className="mb-4">
-            <h1 className="page-title text-secondary">
-              Police Admin Dashboard
-            </h1>
-          </header>
-          <div className="flex-1 min-h-0">
-            <PoliceAdminTable />
-          </div>
-        </div>
-      </main>
-      <Sidebar />
-    </SidebarProvider>
-  );
+  redirect(`/police/admin/${DEFAULT_POLICE_ADMIN_TAB}`);
 }

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -28,6 +28,7 @@ import { getErrorMessage } from "@/lib/errors";
 import { formatTime } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { format } from "date-fns";
+import { useSession } from "next-auth/react";
 import { useMemo, useState } from "react";
 import LocationInfoChipDetails from "../party/details/LocationInfoChipDetails";
 import { InfoChip } from "../shared/sidebar/InfoChip";
@@ -68,6 +69,7 @@ function truncateDescription(
 export const IncidentTable = () => {
   const { openSidebar, closeSidebar } = useSidebar();
   const { openSnackbar } = useSnackbar();
+  const { data: session } = useSession();
   const [editingIncident, setEditingIncident] = useState<IncidentDto | null>(
     null
   );
@@ -360,6 +362,9 @@ export const IncidentTable = () => {
         onStateChange={setServerParams}
         onExportCsv={exportCsv}
         isExporting={isExporting}
+        canManageRows={
+          session?.role === "admin" || session?.role === "police_admin"
+        }
         headerSlot={
           <IncidentSeverityCountsHeader
             counts={incidentsQuery.data?.severity_counts}

--- a/frontend/src/lib/auth/route-access.ts
+++ b/frontend/src/lib/auth/route-access.ts
@@ -8,7 +8,7 @@ export const ALLOWED_ROLES_FOR_PATH: Record<string, AppRole[]> = {
   "/new-party": STUDENT_AREA_ROLES,
   "/profile": STUDENT_AREA_ROLES,
   "/staff": ["staff", "admin"],
-  "/police/admin": ["police_admin"],
+  "/police/admin": ["police_admin", "admin"],
   "/police": ["officer", "police_admin", "admin"],
 };
 


### PR DESCRIPTION
## Summary
- add tabbed police admin routing at  with URL-persistent  and  tabs
- redirect  to  and move the shared dashboard shell into the police admin layout
- render the exact shared staff/admin  on 
- allow  access to  so the shared incidents table can load locations without 403
- keep incident table row management enabled for  in the shared table component

Closes #409