### PR TITLE
refactor: accessibility audit improvements

### DIFF
--- a/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
@@ -11,14 +11,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Field, FieldGroup, FieldLabel, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -39,8 +41,10 @@ import {
   isFromThisSchoolYear,
   phoneNumberSchema,
 } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
 import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 const partyFormSchema = z.object({
@@ -115,16 +119,21 @@ export default function PartyRegistrationForm({
   student,
   submissionError,
 }: PartyRegistrationFormProps) {
-  const [formData, setFormData] = useState<Partial<PartyFormValues>>({
-    address: initialValues?.address ?? "",
-    partyDate: initialValues?.partyDate ?? undefined,
-    partyTime: initialValues?.partyTime ?? DEFAULT_PARTY_TIME,
-    phoneNumber: initialValues?.phoneNumber ?? "",
-    secondContactFirstName: initialValues?.secondContactFirstName ?? "",
-    secondContactLastName: initialValues?.secondContactLastName ?? "",
-    contactPreference:
-      initialValues?.contactPreference ?? DEFAULT_CONTACT_PREFERENCE,
-    contactTwoEmail: initialValues?.contactTwoEmail ?? "",
+  const form = useForm<PartyFormValues>({
+    resolver: zodResolver(partyFormSchema),
+    defaultValues: {
+      address: initialValues?.address ?? "",
+      partyDate: initialValues?.partyDate ?? undefined,
+      partyTime: initialValues?.partyTime ?? DEFAULT_PARTY_TIME,
+      phoneNumber: initialValues?.phoneNumber ?? "",
+      secondContactFirstName: initialValues?.secondContactFirstName ?? "",
+      secondContactLastName: initialValues?.secondContactLastName ?? "",
+      contactPreference:
+        initialValues?.contactPreference ?? DEFAULT_CONTACT_PREFERENCE,
+      contactTwoEmail: initialValues?.contactTwoEmail ?? "",
+      studentPhoneNumber: undefined,
+      studentContactPreference: undefined,
+    },
   });
 
   const [placeId, setPlaceId] = useState<string>(
@@ -139,7 +148,7 @@ export default function PartyRegistrationForm({
     const residencePlaceId = student?.residence?.location.google_place_id;
     if (residencePlaceId) setPlaceId(residencePlaceId);
   }, [student, initialValues?.placeId, placeId]);
-  const [errors, setErrors] = useState<Record<string, string>>({});
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showAddressConfirmation, setShowAddressConfirmation] = useState(false);
   const pendingSubmitRef = useRef<{
@@ -147,84 +156,64 @@ export default function PartyRegistrationForm({
     placeId: string;
   } | null>(null);
 
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = partyFormSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
+  const handleValid = async (data: PartyFormValues) => {
     // If student hasn't provided contact info yet, validate inline fields
     if (!student?.phone_number) {
-      const studentInfoErrors: Record<string, string> = {};
-      if (
-        !result.data.studentPhoneNumber ||
-        !result.data.studentContactPreference
-      ) {
-        // STUDENT_INFO_NOT_PROVIDED — banner-style: show same message twice
-        // so it appears beneath whichever field the user is missing.
-        if (!result.data.studentPhoneNumber) {
-          studentInfoErrors.studentPhoneNumber =
-            PARTY_RULE_MESSAGES.STUDENT_INFO_NOT_PROVIDED;
-        }
-        if (!result.data.studentContactPreference) {
-          studentInfoErrors.studentContactPreference =
-            PARTY_RULE_MESSAGES.STUDENT_INFO_NOT_PROVIDED;
-        }
-        setErrors((prev) => ({ ...prev, ...studentInfoErrors }));
-        return;
+      let hasStudentInfoError = false;
+      // STUDENT_INFO_NOT_PROVIDED — banner-style: show same message twice
+      // so it appears beneath whichever field the user is missing.
+      if (!data.studentPhoneNumber) {
+        form.setError("studentPhoneNumber", {
+          message: PARTY_RULE_MESSAGES.STUDENT_INFO_NOT_PROVIDED,
+        });
+        hasStudentInfoError = true;
       }
+      if (!data.studentContactPreference) {
+        form.setError("studentContactPreference", {
+          message: PARTY_RULE_MESSAGES.STUDENT_INFO_NOT_PROVIDED,
+        });
+        hasStudentInfoError = true;
+      }
+      if (hasStudentInfoError) return;
     }
 
     // Validate contact two differs from contact one (the student)
-    const contactTwoErrors: Record<string, string> = {};
+    let hasContactTwoError = false;
     if (
       student?.email &&
-      result.data.contactTwoEmail.trim().toLowerCase() ===
+      data.contactTwoEmail.trim().toLowerCase() ===
         student.email.trim().toLowerCase()
     ) {
-      contactTwoErrors.contactTwoEmail =
-        PARTY_RULE_MESSAGES.CONTACT_TWO_EMAIL_MATCHES_CONTACT_ONE;
+      form.setError("contactTwoEmail", {
+        message: PARTY_RULE_MESSAGES.CONTACT_TWO_EMAIL_MATCHES_CONTACT_ONE,
+      });
+      hasContactTwoError = true;
     }
-    const studentPhone =
-      student?.phone_number ?? result.data.studentPhoneNumber;
+    const studentPhone = student?.phone_number ?? data.studentPhoneNumber;
     if (studentPhone) {
       const c1Digits = studentPhone.replace(/\D/g, "");
-      const c2Digits = result.data.phoneNumber;
+      const c2Digits = data.phoneNumber;
       if (c1Digits === c2Digits) {
-        contactTwoErrors.phoneNumber =
-          PARTY_RULE_MESSAGES.CONTACT_TWO_PHONE_MATCHES_CONTACT_ONE;
+        form.setError("phoneNumber", {
+          message: PARTY_RULE_MESSAGES.CONTACT_TWO_PHONE_MATCHES_CONTACT_ONE,
+        });
+        hasContactTwoError = true;
       }
     }
-    if (Object.keys(contactTwoErrors).length > 0) {
-      setErrors(contactTwoErrors);
-      return;
-    }
+    if (hasContactTwoError) return;
 
-    // Only set the address error if it wasn't already set by Zod
     if (!placeId) {
-      setErrors((prev) => ({
-        ...prev,
-        address: prev.address || "Please select an address from the dropdown",
-      }));
+      form.setError("address", {
+        message: "Please select an address from the dropdown",
+      });
       return;
     }
 
     const addressChanged =
-      !initialValues?.address || result.data.address !== initialValues.address;
+      !initialValues?.address || data.address !== initialValues.address;
 
     if (addressChanged) {
-      pendingSubmitRef.current = { data: result.data, placeId };
+      pendingSubmitRef.current = { data, placeId };
       setShowAddressConfirmation(true);
       return;
     }
@@ -232,28 +221,18 @@ export default function PartyRegistrationForm({
     // Proceed with submission if address didn't change
     setIsSubmitting(true);
     try {
-      await onSubmit(result.data, placeId); // ⭐ now sends placeId too
+      await onSubmit(data, placeId);
     } finally {
       setIsSubmitting(false);
-    }
-  };
-
-  const updateField = <K extends keyof PartyFormValues>(
-    field: K,
-    value: PartyFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      const newErrors = { ...errors };
-      delete newErrors[field];
-      setErrors(newErrors);
     }
   };
 
   const { schoolYear, changeDate } = getAcademicYearLabels();
 
   const handleAddressSelect = (address: AutocompleteResult | null) => {
-    updateField("address", address?.formatted_address || "");
+    form.setValue("address", address?.formatted_address || "", {
+      shouldValidate: true,
+    });
     setPlaceId(address?.google_place_id || "");
   };
 
@@ -272,359 +251,376 @@ export default function PartyRegistrationForm({
   const isStudentLoading = student === undefined;
 
   return (
-    <form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <FieldSet>
-          <div className="flex flex-col gap-4 lg:gap-6">
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:gap-8">
-              <Field data-invalid={!!errors.partyDate}>
-                <FieldLabel htmlFor="party-date" className="content-bold">
-                  Party Date
-                </FieldLabel>
-                <DatePicker
-                  id="party-date"
-                  value={formData.partyDate ?? null}
-                  onChange={(date) => updateField("partyDate", date as Date)}
-                  disabled={(date) =>
-                    !isAfter(
-                      startOfDay(date),
-                      addBusinessDays(startOfDay(new Date()), 1)
-                    )
-                  }
-                  forwardDate={true}
-                  aria-invalid={!!errors.partyDate}
-                  inputClassName="content"
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleValid)}>
+        <FieldGroup>
+          <FieldSet>
+            <div className="flex flex-col gap-4 lg:gap-6">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:gap-8">
+                <FormField
+                  control={form.control}
+                  name="partyDate"
+                  render={({ field, fieldState }) => (
+                    <FormItem>
+                      <FormLabel className="content-bold">Party Date</FormLabel>
+                      <FormControl>
+                        <DatePicker
+                          value={field.value ?? null}
+                          onChange={field.onChange}
+                          disabled={(date) =>
+                            !isAfter(
+                              startOfDay(date),
+                              addBusinessDays(startOfDay(new Date()), 1)
+                            )
+                          }
+                          forwardDate={true}
+                          aria-invalid={fieldState.invalid}
+                          inputClassName="content"
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Must be at least 2 business days from today
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                <FieldDescription>
-                  Must be at least 2 business days from today
-                </FieldDescription>
-                {errors.partyDate && (
-                  <FieldError>{errors.partyDate}</FieldError>
-                )}
-              </Field>
 
-              <Field data-invalid={!!errors.partyTime}>
-                <FieldLabel htmlFor="party-time" className="content-bold">
-                  Party Time
-                </FieldLabel>
-                <Input
-                  id="party-time"
-                  type="time"
-                  value={formData.partyTime}
-                  onChange={(e) => updateField("partyTime", e.target.value)}
-                  aria-invalid={!!errors.partyTime}
-                  className="content"
+                <FormField
+                  control={form.control}
+                  name="partyTime"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="content-bold">Party Time</FormLabel>
+                      <FormControl>
+                        <Input {...field} type="time" className="content" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                {errors.partyTime && (
-                  <FieldError>{errors.partyTime}</FieldError>
-                )}
-              </Field>
-            </div>
-
-            {isStudentLoading ? (
-              <Field>
-                <FieldLabel className="content-bold">Party Address</FieldLabel>
-                <Skeleton className="h-10 w-full" />
-              </Field>
-            ) : !validResidence ? (
-              <Field data-invalid={!!errors.address}>
-                <FieldLabel htmlFor="party-address" className="content-bold">
-                  Party Address
-                </FieldLabel>
-                <AddressSearch
-                  value={formData.address}
-                  onSelect={handleAddressSelect}
-                  locationService={locationService}
-                  placeholder="Search for the party address..."
-                  className="w-full"
-                  error={errors.address}
-                  initialSelection={initialAddress}
-                />
-                <FieldDescription className="content-sub italic">
-                  This will be added to your profile as your {schoolYear}{" "}
-                  location. You may change it after {changeDate}.
-                </FieldDescription>
-                {errors.address && <FieldError>{errors.address}</FieldError>}
-              </Field>
-            ) : (
-              <Field className="col-span-2 gap-1">
-                <FieldLabel className="content-bold">Party Address</FieldLabel>
-                <p className="content">
-                  {student?.residence?.location.formatted_address}
-                </p>
-                <p className="content-sub italic">
-                  You cannot change your address until {changeDate}. If you are
-                  experiencing hardship, contact{" "}
-                  <a
-                    href={`mailto:${clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}`}
-                    className="underline"
-                  >
-                    {clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}
-                  </a>{" "}
-                  for changes
-                </p>
-              </Field>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-4 lg:gap-6">
-            <div className="flex flex-col gap-1">
-              <h2 className="subhead-content">Your Contact Information</h2>
-              <p className="content-sub italic">
-                {student?.phone_number != null
-                  ? "You can edit preferences in your Profile Information."
-                  : "Please provide your contact information to complete registration."}
-              </p>
-            </div>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
-              <Field className="gap-1">
-                <FieldLabel className="content-bold">First Name</FieldLabel>
-                {isStudentLoading ? (
-                  <Skeleton className="h-6 w-full" />
-                ) : (
-                  <p className="content">{student?.first_name}</p>
-                )}
-              </Field>
-              <Field className="gap-1">
-                <FieldLabel className="content-bold">Last Name</FieldLabel>
-                {isStudentLoading ? (
-                  <Skeleton className="h-6 w-full" />
-                ) : (
-                  <p className="content">{student?.last_name}</p>
-                )}
-              </Field>
-              <Field
-                className="gap-1"
-                data-invalid={!!errors.studentPhoneNumber}
-              >
-                <FieldLabel className="content-bold">Phone Number</FieldLabel>
-                {isStudentLoading ? (
-                  <Skeleton className="h-6 w-full" />
-                ) : student?.phone_number != null ? (
-                  <p className="content">
-                    {formatPhoneNumberInput(student.phone_number)}
-                  </p>
-                ) : (
-                  <>
-                    <Input
-                      id="student-phone-number"
-                      type="tel"
-                      placeholder="(123) 456-7890"
-                      value={formatPhoneNumberInput(
-                        formData.studentPhoneNumber ?? ""
-                      )}
-                      onChange={(e) =>
-                        updateField(
-                          "studentPhoneNumber",
-                          e.target.value.replace(/\D/g, "").slice(0, 10)
-                        )
-                      }
-                      aria-invalid={!!errors.studentPhoneNumber}
-                      className="content"
-                    />
-                    {errors.studentPhoneNumber && (
-                      <FieldError>{errors.studentPhoneNumber}</FieldError>
-                    )}
-                  </>
-                )}
-              </Field>
-              <Field
-                className="gap-1"
-                data-invalid={!!errors.studentContactPreference}
-              >
-                <FieldLabel className="content-bold">
-                  Contact Preference
-                </FieldLabel>
-                {isStudentLoading ? (
-                  <Skeleton className="h-6 w-full" />
-                ) : student?.phone_number != null ? (
-                  <p className="content capitalize">
-                    {student.contact_preference}
-                  </p>
-                ) : (
-                  <>
-                    <Select
-                      value={formData.studentContactPreference}
-                      onValueChange={(value: "call" | "text") =>
-                        updateField("studentContactPreference", value)
-                      }
-                    >
-                      <SelectTrigger
-                        aria-invalid={!!errors.studentContactPreference}
-                        className="content"
-                      >
-                        <SelectValue placeholder="Select your preference" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="call" className="content">
-                          Call
-                        </SelectItem>
-                        <SelectItem value="text" className="content">
-                          Text
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                    {errors.studentContactPreference && (
-                      <FieldError>{errors.studentContactPreference}</FieldError>
-                    )}
-                  </>
-                )}
-              </Field>
-              <Field className="gap-1">
-                <FieldLabel className="content-bold">Email</FieldLabel>
-                {isStudentLoading ? (
-                  <Skeleton className="h-6 w-full" />
-                ) : (
-                  <p className="content">{student?.email}</p>
-                )}
-              </Field>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-4 lg:gap-6">
-            <h2 className="subhead-content">Second Contact Information</h2>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
-              <Field data-invalid={!!errors.secondContactFirstName}>
-                <FieldLabel
-                  htmlFor="second-contact-first-name"
-                  className="content-bold"
-                >
-                  First Name
-                </FieldLabel>
-                <Input
-                  id="second-contact-first-name"
-                  placeholder=""
-                  value={formData.secondContactFirstName}
-                  onChange={(e) =>
-                    updateField("secondContactFirstName", e.target.value)
-                  }
-                  aria-invalid={!!errors.secondContactFirstName}
-                  className="content"
-                />
-                {errors.secondContactFirstName && (
-                  <FieldError>{errors.secondContactFirstName}</FieldError>
-                )}
-              </Field>
-
-              <Field data-invalid={!!errors.secondContactLastName}>
-                <FieldLabel
-                  htmlFor="second-contact-last-name"
-                  className="content-bold"
-                >
-                  Last Name
-                </FieldLabel>
-                <Input
-                  id="second-contact-last-name"
-                  placeholder=""
-                  value={formData.secondContactLastName}
-                  onChange={(e) =>
-                    updateField("secondContactLastName", e.target.value)
-                  }
-                  aria-invalid={!!errors.secondContactLastName}
-                  className="content"
-                />
-                {errors.secondContactLastName && (
-                  <FieldError>{errors.secondContactLastName}</FieldError>
-                )}
-              </Field>
-            </div>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
-              <Field data-invalid={!!errors.phoneNumber}>
-                <FieldLabel htmlFor="phone-number" className="content-bold">
-                  Phone Number
-                </FieldLabel>
-                <Input
-                  id="phone-number"
-                  type="tel"
-                  placeholder="(123) 456-7890"
-                  value={formatPhoneNumberInput(formData.phoneNumber ?? "")}
-                  onChange={(e) =>
-                    updateField(
-                      "phoneNumber",
-                      e.target.value.replace(/\D/g, "").slice(0, 10)
-                    )
-                  }
-                  aria-invalid={!!errors.phoneNumber}
-                  className="content"
-                />
-                {errors.phoneNumber && (
-                  <FieldError>{errors.phoneNumber}</FieldError>
-                )}
-              </Field>
-
-              <Field data-invalid={!!errors.contactPreference}>
-                <FieldLabel
-                  htmlFor="contact-preference"
-                  className="content-bold"
-                >
-                  Contact Preference
-                </FieldLabel>
-                <Select
-                  value={formData.contactPreference}
-                  onValueChange={(value) =>
-                    updateField("contactPreference", value as "call" | "text")
-                  }
-                >
-                  <SelectTrigger
-                    id="contact-preference"
-                    aria-invalid={!!errors.contactPreference}
-                    className="content"
-                  >
-                    <SelectValue placeholder="Select your preference" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="call" className="content">
-                      Call
-                    </SelectItem>
-                    <SelectItem value="text" className="content">
-                      Text
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                {errors.contactPreference && (
-                  <FieldError>{errors.contactPreference}</FieldError>
-                )}
-              </Field>
-            </div>
-
-            <Field data-invalid={!!errors.contactTwoEmail}>
-              <FieldLabel htmlFor="contact-email" className="content-bold">
-                Contact Email
-              </FieldLabel>
-              <Input
-                id="contact-email"
-                type="email"
-                placeholder="student@unc.edu"
-                value={formData.contactTwoEmail}
-                onChange={(e) => updateField("contactTwoEmail", e.target.value)}
-                aria-invalid={!!errors.contactTwoEmail}
-                className="content"
-              />
-              {errors.contactTwoEmail && (
-                <FieldError>{errors.contactTwoEmail}</FieldError>
-              )}
-            </Field>
-          </div>
-
-          <Field className="flex flex-col items-center">
-            <p className="content text-center my-2 lg:my-4">
-              Please ensure all information provided is correct before
-              submitting
-            </p>
-            {submissionError && (
-              <div
-                className="w-full rounded-md bg-destructive/10 p-3 text-sm text-destructive mb-2"
-                role="alert"
-              >
-                {submissionError}
               </div>
-            )}
-            <Button type="submit" disabled={isSubmitting} className="w-fit!">
-              {isSubmitting ? "Submitting..." : "Submit Event"}
-            </Button>
-          </Field>
-        </FieldSet>
-      </FieldGroup>
+
+              {isStudentLoading ? (
+                <Field>
+                  <FieldLabel className="content-bold">
+                    Party Address
+                  </FieldLabel>
+                  <Skeleton className="h-10 w-full" />
+                </Field>
+              ) : !validResidence ? (
+                <FormField
+                  control={form.control}
+                  name="address"
+                  render={({ field, fieldState }) => (
+                    <FormItem>
+                      <FormLabel className="content-bold">
+                        Party Address
+                      </FormLabel>
+                      <FormControl>
+                        <AddressSearch
+                          value={field.value}
+                          onSelect={handleAddressSelect}
+                          locationService={locationService}
+                          placeholder="Search for the party address..."
+                          className="w-full"
+                          error={fieldState.error?.message}
+                          initialSelection={initialAddress}
+                        />
+                      </FormControl>
+                      <FormDescription className="content-sub italic">
+                        This will be added to your profile as your {schoolYear}{" "}
+                        location. You may change it after {changeDate}.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ) : (
+                <Field className="col-span-2 gap-1">
+                  <FieldLabel className="content-bold">
+                    Party Address
+                  </FieldLabel>
+                  <p className="content">
+                    {student?.residence?.location.formatted_address}
+                  </p>
+                  <p className="content-sub italic">
+                    You cannot change your address until {changeDate}. If you
+                    are experiencing hardship, contact{" "}
+                    <a
+                      href={`mailto:${clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}`}
+                      className="underline"
+                    >
+                      {clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}
+                    </a>{" "}
+                    for changes
+                  </p>
+                </Field>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-4 lg:gap-6">
+              <div className="flex flex-col gap-1">
+                <h2 className="subhead-content">Your Contact Information</h2>
+                <p className="content-sub italic">
+                  {student?.phone_number != null
+                    ? "You can edit preferences in your Profile Information."
+                    : "Please provide your contact information to complete registration."}
+                </p>
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+                <Field className="gap-1">
+                  <FieldLabel className="content-bold">First Name</FieldLabel>
+                  {isStudentLoading ? (
+                    <Skeleton className="h-6 w-full" />
+                  ) : (
+                    <p className="content">{student?.first_name}</p>
+                  )}
+                </Field>
+                <Field className="gap-1">
+                  <FieldLabel className="content-bold">Last Name</FieldLabel>
+                  {isStudentLoading ? (
+                    <Skeleton className="h-6 w-full" />
+                  ) : (
+                    <p className="content">{student?.last_name}</p>
+                  )}
+                </Field>
+                {isStudentLoading ? (
+                  <Field className="gap-1">
+                    <FieldLabel className="content-bold">
+                      Phone Number
+                    </FieldLabel>
+                    <Skeleton className="h-6 w-full" />
+                  </Field>
+                ) : student?.phone_number != null ? (
+                  <Field className="gap-1">
+                    <FieldLabel className="content-bold">
+                      Phone Number
+                    </FieldLabel>
+                    <p className="content">
+                      {formatPhoneNumberInput(student.phone_number)}
+                    </p>
+                  </Field>
+                ) : (
+                  <FormField
+                    control={form.control}
+                    name="studentPhoneNumber"
+                    render={({ field }) => (
+                      <FormItem className="gap-1">
+                        <FormLabel className="content-bold">
+                          Phone Number
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="tel"
+                            placeholder="(123) 456-7890"
+                            value={formatPhoneNumberInput(field.value ?? "")}
+                            onChange={(e) =>
+                              field.onChange(
+                                e.target.value.replace(/\D/g, "").slice(0, 10)
+                              )
+                            }
+                            className="content"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+                {isStudentLoading ? (
+                  <Field className="gap-1">
+                    <FieldLabel className="content-bold">
+                      Contact Preference
+                    </FieldLabel>
+                    <Skeleton className="h-6 w-full" />
+                  </Field>
+                ) : student?.phone_number != null ? (
+                  <Field className="gap-1">
+                    <FieldLabel className="content-bold">
+                      Contact Preference
+                    </FieldLabel>
+                    <p className="content capitalize">
+                      {student.contact_preference}
+                    </p>
+                  </Field>
+                ) : (
+                  <FormField
+                    control={form.control}
+                    name="studentContactPreference"
+                    render={({ field }) => (
+                      <FormItem className="gap-1">
+                        <FormLabel className="content-bold">
+                          Contact Preference
+                        </FormLabel>
+                        <Select
+                          value={field.value}
+                          onValueChange={field.onChange}
+                        >
+                          <FormControl>
+                            <SelectTrigger className="content">
+                              <SelectValue placeholder="Select your preference" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="call" className="content">
+                              Call
+                            </SelectItem>
+                            <SelectItem value="text" className="content">
+                              Text
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+                <Field className="gap-1">
+                  <FieldLabel className="content-bold">Email</FieldLabel>
+                  {isStudentLoading ? (
+                    <Skeleton className="h-6 w-full" />
+                  ) : (
+                    <p className="content">{student?.email}</p>
+                  )}
+                </Field>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-4 lg:gap-6">
+              <h2 className="subhead-content">Second Contact Information</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+                <FormField
+                  control={form.control}
+                  name="secondContactFirstName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="content-bold">First Name</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="" className="content" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="secondContactLastName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="content-bold">Last Name</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="" className="content" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+                <FormField
+                  control={form.control}
+                  name="phoneNumber"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="content-bold">
+                        Phone Number
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="tel"
+                          placeholder="(123) 456-7890"
+                          value={formatPhoneNumberInput(field.value ?? "")}
+                          onChange={(e) =>
+                            field.onChange(
+                              e.target.value.replace(/\D/g, "").slice(0, 10)
+                            )
+                          }
+                          className="content"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="contactPreference"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="content-bold">
+                        Contact Preference
+                      </FormLabel>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="content">
+                            <SelectValue placeholder="Select your preference" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="call" className="content">
+                            Call
+                          </SelectItem>
+                          <SelectItem value="text" className="content">
+                            Text
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="contactTwoEmail"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="content-bold">
+                      Contact Email
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="email"
+                        placeholder="student@unc.edu"
+                        className="content"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <Field className="flex flex-col items-center">
+              <p className="content text-center my-2 lg:my-4">
+                Please ensure all information provided is correct before
+                submitting
+              </p>
+              {submissionError && (
+                <div
+                  className="w-full rounded-md bg-destructive/10 p-3 text-sm text-destructive mb-2"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <Button type="submit" disabled={isSubmitting} className="w-fit!">
+                {isSubmitting ? "Submitting..." : "Submit Event"}
+              </Button>
+            </Field>
+          </FieldSet>
+        </FieldGroup>
+      </form>
 
       <Dialog
         open={showAddressConfirmation}
@@ -677,6 +673,6 @@ export default function PartyRegistrationForm({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </form>
+    </Form>
   );
 }

--- a/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import AddressSearch from "@/components/AddressSearch";
-import DatePicker from "@/components/DatePicker";
+import { SubmitButton } from "@/components/form/SubmitButton";
+import {
+  AddressField,
+  DateField,
+  PhoneField,
+  SelectField,
+  TextField,
+} from "@/components/form/fields";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,23 +18,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Field, FieldGroup, FieldLabel, FieldSet } from "@/components/ui/field";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Form } from "@/components/ui/form";
 import { Skeleton } from "@/components/ui/skeleton";
 import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
@@ -229,13 +219,6 @@ export default function PartyRegistrationForm({
 
   const { schoolYear, changeDate } = getAcademicYearLabels();
 
-  const handleAddressSelect = (address: AutocompleteResult | null) => {
-    form.setValue("address", address?.formatted_address || "", {
-      shouldValidate: true,
-    });
-    setPlaceId(address?.google_place_id || "");
-  };
-
   // Build initial address object for AddressSearch if we have prefilled values
   const initialAddress: AutocompleteResult | undefined =
     initialValues?.address && initialValues?.placeId
@@ -257,47 +240,29 @@ export default function PartyRegistrationForm({
           <FieldSet>
             <div className="flex flex-col gap-4 lg:gap-6">
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:gap-8">
-                <FormField
+                <DateField
                   control={form.control}
                   name="partyDate"
-                  render={({ field, fieldState }) => (
-                    <FormItem>
-                      <FormLabel className="content-bold">Party Date</FormLabel>
-                      <FormControl>
-                        <DatePicker
-                          value={field.value ?? null}
-                          onChange={field.onChange}
-                          disabled={(date) =>
-                            !isAfter(
-                              startOfDay(date),
-                              addBusinessDays(startOfDay(new Date()), 1)
-                            )
-                          }
-                          forwardDate={true}
-                          aria-invalid={fieldState.invalid}
-                          inputClassName="content"
-                        />
-                      </FormControl>
-                      <FormDescription>
-                        Must be at least 2 business days from today
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Party Date"
+                  labelClassName="content-bold"
+                  inputClassName="content"
+                  forwardDate={true}
+                  description="Must be at least 2 business days from today"
+                  disabled={(date) =>
+                    !isAfter(
+                      startOfDay(date),
+                      addBusinessDays(startOfDay(new Date()), 1)
+                    )
+                  }
                 />
 
-                <FormField
+                <TextField
                   control={form.control}
                   name="partyTime"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="content-bold">Party Time</FormLabel>
-                      <FormControl>
-                        <Input {...field} type="time" className="content" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Party Time"
+                  labelClassName="content-bold"
+                  inputClassName="content"
+                  type="time"
                 />
               </div>
 
@@ -309,32 +274,24 @@ export default function PartyRegistrationForm({
                   <Skeleton className="h-10 w-full" />
                 </Field>
               ) : !validResidence ? (
-                <FormField
+                <AddressField
                   control={form.control}
                   name="address"
-                  render={({ field, fieldState }) => (
-                    <FormItem>
-                      <FormLabel className="content-bold">
-                        Party Address
-                      </FormLabel>
-                      <FormControl>
-                        <AddressSearch
-                          value={field.value}
-                          onSelect={handleAddressSelect}
-                          locationService={locationService}
-                          placeholder="Search for the party address..."
-                          className="w-full"
-                          error={fieldState.error?.message}
-                          initialSelection={initialAddress}
-                        />
-                      </FormControl>
-                      <FormDescription className="content-sub italic">
-                        This will be added to your profile as your {schoolYear}{" "}
-                        location. You may change it after {changeDate}.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Party Address"
+                  labelClassName="content-bold"
+                  placeholder="Search for the party address..."
+                  locationService={locationService}
+                  initialSelection={initialAddress}
+                  onSelect={(address) =>
+                    setPlaceId(address?.google_place_id || "")
+                  }
+                  descriptionClassName="content-sub italic"
+                  description={
+                    <>
+                      This will be added to your profile as your {schoolYear}{" "}
+                      location. You may change it after {changeDate}.
+                    </>
+                  }
                 />
               ) : (
                 <Field className="col-span-2 gap-1">
@@ -345,15 +302,14 @@ export default function PartyRegistrationForm({
                     {student?.residence?.location.formatted_address}
                   </p>
                   <p className="content-sub italic">
-                    You cannot change your address until {changeDate}. If you
-                    are experiencing hardship, contact{" "}
+                    You cannot change your address until {changeDate}. For
+                    extraneous circumstances, contact{" "}
                     <a
                       href={`mailto:${clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}`}
                       className="underline"
                     >
                       {clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}
                     </a>{" "}
-                    for changes
                   </p>
                 </Field>
               )}
@@ -402,31 +358,13 @@ export default function PartyRegistrationForm({
                     </p>
                   </Field>
                 ) : (
-                  <FormField
+                  <PhoneField
                     control={form.control}
                     name="studentPhoneNumber"
-                    render={({ field }) => (
-                      <FormItem className="gap-1">
-                        <FormLabel className="content-bold">
-                          Phone Number
-                        </FormLabel>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            type="tel"
-                            placeholder="(123) 456-7890"
-                            value={formatPhoneNumberInput(field.value ?? "")}
-                            onChange={(e) =>
-                              field.onChange(
-                                e.target.value.replace(/\D/g, "").slice(0, 10)
-                              )
-                            }
-                            className="content"
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+                    label="Phone Number"
+                    labelClassName="content-bold"
+                    inputClassName="content"
+                    className="gap-1"
                   />
                 )}
                 {isStudentLoading ? (
@@ -446,35 +384,19 @@ export default function PartyRegistrationForm({
                     </p>
                   </Field>
                 ) : (
-                  <FormField
+                  <SelectField
                     control={form.control}
                     name="studentContactPreference"
-                    render={({ field }) => (
-                      <FormItem className="gap-1">
-                        <FormLabel className="content-bold">
-                          Contact Preference
-                        </FormLabel>
-                        <Select
-                          value={field.value}
-                          onValueChange={field.onChange}
-                        >
-                          <FormControl>
-                            <SelectTrigger className="content">
-                              <SelectValue placeholder="Select your preference" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            <SelectItem value="call" className="content">
-                              Call
-                            </SelectItem>
-                            <SelectItem value="text" className="content">
-                              Text
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+                    label="Contact Preference"
+                    labelClassName="content-bold"
+                    triggerClassName="content"
+                    itemClassName="content"
+                    placeholder="Select your preference"
+                    className="gap-1"
+                    options={[
+                      { value: "call", label: "Call" },
+                      { value: "text", label: "Text" },
+                    ]}
                   />
                 )}
                 <Field className="gap-1">
@@ -491,113 +413,56 @@ export default function PartyRegistrationForm({
             <div className="flex flex-col gap-4 lg:gap-6">
               <h2 className="subhead-content">Second Contact Information</h2>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
-                <FormField
+                <TextField
                   control={form.control}
                   name="secondContactFirstName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="content-bold">First Name</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder="" className="content" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="First Name"
+                  labelClassName="content-bold"
+                  inputClassName="content"
+                  placeholder=""
                 />
 
-                <FormField
+                <TextField
                   control={form.control}
                   name="secondContactLastName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="content-bold">Last Name</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder="" className="content" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Last Name"
+                  labelClassName="content-bold"
+                  inputClassName="content"
+                  placeholder=""
                 />
               </div>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
-                <FormField
+                <PhoneField
                   control={form.control}
                   name="phoneNumber"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="content-bold">
-                        Phone Number
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type="tel"
-                          placeholder="(123) 456-7890"
-                          value={formatPhoneNumberInput(field.value ?? "")}
-                          onChange={(e) =>
-                            field.onChange(
-                              e.target.value.replace(/\D/g, "").slice(0, 10)
-                            )
-                          }
-                          className="content"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Phone Number"
+                  labelClassName="content-bold"
+                  inputClassName="content"
                 />
 
-                <FormField
+                <SelectField
                   control={form.control}
                   name="contactPreference"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="content-bold">
-                        Contact Preference
-                      </FormLabel>
-                      <Select
-                        value={field.value}
-                        onValueChange={field.onChange}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="content">
-                            <SelectValue placeholder="Select your preference" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          <SelectItem value="call" className="content">
-                            Call
-                          </SelectItem>
-                          <SelectItem value="text" className="content">
-                            Text
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Contact Preference"
+                  labelClassName="content-bold"
+                  triggerClassName="content"
+                  itemClassName="content"
+                  placeholder="Select your preference"
+                  options={[
+                    { value: "call", label: "Call" },
+                    { value: "text", label: "Text" },
+                  ]}
                 />
               </div>
 
-              <FormField
+              <TextField
                 control={form.control}
                 name="contactTwoEmail"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="content-bold">
-                      Contact Email
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="email"
-                        placeholder="student@unc.edu"
-                        className="content"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="Contact Email"
+                labelClassName="content-bold"
+                inputClassName="content"
+                type="email"
+                placeholder="student@unc.edu"
               />
             </div>
 
@@ -614,9 +479,11 @@ export default function PartyRegistrationForm({
                   {submissionError}
                 </div>
               )}
-              <Button type="submit" disabled={isSubmitting} className="w-fit!">
-                {isSubmitting ? "Submitting..." : "Submit Event"}
-              </Button>
+              <SubmitButton
+                pending={isSubmitting}
+                label="Submit Event"
+                className="w-fit!"
+              />
             </Field>
           </FieldSet>
         </FieldGroup>

--- a/frontend/src/app/(student)/_components/RegistrationStatus.tsx
+++ b/frontend/src/app/(student)/_components/RegistrationStatus.tsx
@@ -64,7 +64,7 @@ export default function RegistrationStatus({
         )}
         {isCompleted ? (
           <>
-            <div className="flex items-center gap-2 text-gray-800">
+            <div className="flex items-center gap-2">
               <CheckCircle className="size-4 mb-0.5" />
               <p className="content">
                 Completed on{" "}
@@ -90,7 +90,7 @@ export default function RegistrationStatus({
               rel="noopener noreferrer"
             >
               Schedule a meeting
-              <ExternalLink className="size-4 ml-2" />
+              <ExternalLink className="size-4 ml-2" aria-hidden="true" />
             </a>
           </div>
         )}

--- a/frontend/src/app/(student)/_components/info/DialogItem.tsx
+++ b/frontend/src/app/(student)/_components/info/DialogItem.tsx
@@ -24,7 +24,7 @@ export default function DialogItem({ title, children }: DialogItemProps) {
       <Button
         variant="ghost"
         onClick={() => setOpen(true)}
-        className="flex h-auto w-full items-center justify-between gap-4 rounded-none border-b px-6 py-4 text-left last:border-b-0 hover:bg-muted/50"
+        className="flex h-auto w-full items-center justify-between gap-4 rounded-none border-b px-6 has-[>svg]:px-4 py-4 text-left last:border-b-0 hover:bg-muted/50"
       >
         <span>{title}</span>
         <Info className="size-4 shrink-0 text-muted-foreground" />

--- a/frontend/src/app/(student)/_components/info/DialogItem.tsx
+++ b/frontend/src/app/(student)/_components/info/DialogItem.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -20,13 +21,14 @@ export default function DialogItem({ title, children }: DialogItemProps) {
 
   return (
     <>
-      <button
+      <Button
+        variant="ghost"
         onClick={() => setOpen(true)}
-        className="flex w-full cursor-pointer items-center justify-between gap-4 border-b px-6 py-4 text-left last:border-b-0 hover:bg-muted/50"
+        className="flex h-auto w-full items-center justify-between gap-4 rounded-none border-b px-6 py-4 text-left last:border-b-0 hover:bg-muted/50"
       >
         <span>{title}</span>
         <Info className="size-4 shrink-0 text-muted-foreground" />
-      </button>
+      </Button>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-4xl">
           <DialogHeader>

--- a/frontend/src/app/(student)/_components/tracker/EditPartyDialog.tsx
+++ b/frontend/src/app/(student)/_components/tracker/EditPartyDialog.tsx
@@ -94,7 +94,7 @@ export function EditPartyDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Edit Party</DialogTitle>
         </DialogHeader>

--- a/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
+++ b/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
@@ -21,6 +21,10 @@ import { useCallback, useMemo, useState } from "react";
 import RegistrationIncidentCard from "./RegistrationIncidentCard";
 import RegistrationPartyCard from "./RegistrationPartyCard";
 
+const EMPTY_CLASS =
+  "flex h-full items-center justify-center px-12 text-center content-sub text-base!";
+const TAB_CONTENT_CLASS = "h-full w-full overflow-y-auto rounded-md bg-card";
+
 function PartiesLoading() {
   return (
     <div className="px-4 py-4 gap-4 sm:gap-7 flex flex-col">
@@ -42,10 +46,10 @@ function PartiesError() {
   );
 }
 
+type TabValue = "active" | "past" | "incidents";
+
 export default function RegistrationTracker(): React.JSX.Element {
-  const [activeTab, setActiveTab] = useState<"active" | "past" | "incidents">(
-    "active"
-  );
+  const [activeTab, setActiveTab] = useState<TabValue>("active");
   const [editParty, setEditParty] = useState<PartyDto | null>(null);
   const [deleteParty, setDeleteParty] = useState<PartyDto | null>(null);
 
@@ -136,35 +140,94 @@ export default function RegistrationTracker(): React.JSX.Element {
     return Object.entries(groups);
   }, [sortedIncidents]);
 
+  const tabs: Array<{
+    value: TabValue;
+    label: string;
+    children: React.ReactNode;
+  }> = [
+    {
+      value: "active",
+      label: "Active",
+      children:
+        activeParties.length === 0 ? (
+          <p className={EMPTY_CLASS}>
+            {showPartySmartPrompt
+              ? "Schedule and attend the Party Smart course below to register your first party!"
+              : "No active registrations"}
+          </p>
+        ) : (
+          activeParties.map((party) => (
+            <RegistrationPartyCard
+              key={party.id}
+              party={party}
+              showActions
+              residenceLocationId={residenceLocationId}
+              isPartiesPending={isPartiesPending}
+              onEdit={handleEditParty}
+              onDelete={handleDeleteParty}
+            />
+          ))
+        ),
+    },
+    {
+      value: "past",
+      label: "Past",
+      children:
+        pastParties.length === 0 ? (
+          <p className={EMPTY_CLASS}>Your party history will appear here.</p>
+        ) : (
+          pastParties.map((party) => (
+            <RegistrationPartyCard
+              key={party.id}
+              party={party}
+              showAddress
+              residenceLocationId={residenceLocationId}
+              isPartiesPending={isPartiesPending}
+              onEdit={handleEditParty}
+              onDelete={handleDeleteParty}
+            />
+          ))
+        ),
+    },
+    {
+      value: "incidents",
+      label: "Incidents",
+      children:
+        sortedIncidents.length === 0 ? (
+          <p className={EMPTY_CLASS}>
+            Violations reported at your residence, like noise complaints, will
+            appear here and may result in a hold on future party registrations.
+          </p>
+        ) : (
+          groupedIncidents.map(([date, dayIncidents]) => (
+            <RegistrationIncidentCard
+              key={date}
+              date={date}
+              incidents={dayIncidents}
+            />
+          ))
+        ),
+    },
+  ];
+
   return (
     <div className="flex flex-col flex-1 min-h-0 mb-6">
       <Tabs
         value={activeTab}
-        onValueChange={(value) =>
-          setActiveTab(value as "active" | "past" | "incidents")
-        }
+        onValueChange={(value) => setActiveTab(value as TabValue)}
         className="flex flex-col flex-1 min-h-0"
       >
         <div className="mt-2 flex items-end justify-between shrink-0">
           <TabsList className="w-fit flex gap-4">
-            <TabsTrigger
-              value="active"
-              className="px-0 subhead-content cursor-pointer"
-            >
-              Active
-            </TabsTrigger>
-            <TabsTrigger
-              value="past"
-              className="px-0 subhead-content cursor-pointer"
-            >
-              Past
-            </TabsTrigger>
-            <TabsTrigger
-              value="incidents"
-              className="px-0 subhead-content cursor-pointer"
-            >
-              Incidents
-            </TabsTrigger>
+            {tabs.map(({ value, label }) => (
+              <TabsTrigger
+                key={value}
+                value={value}
+                className="px-0 subhead-content cursor-pointer"
+              >
+                {label}
+              </TabsTrigger>
+            ))}
           </TabsList>
           <div>
             {courseCompleted && !residenceHasActiveHold ? (
@@ -189,77 +252,19 @@ export default function RegistrationTracker(): React.JSX.Element {
         </div>
 
         <Card className="w-full flex-1 min-h-0 overflow-hidden mt-2 flex flex-col">
-          <TabsContent value="active" className="h-full">
-            <div className="h-full w-full overflow-y-auto rounded-md bg-card">
-              {isPartiesPending ? (
-                <PartiesLoading />
-              ) : isPartiesError ? (
-                <PartiesError />
-              ) : activeParties.length === 0 ? (
-                <p className="flex h-full items-center justify-center px-4 text-center content-sub text-base!">
-                  {showPartySmartPrompt
-                    ? "Schedule and attend the Party Smart course below to register your first party!"
-                    : "No active registrations"}
-                </p>
-              ) : (
-                activeParties.map((party) => (
-                  <RegistrationPartyCard
-                    key={party.id}
-                    party={party}
-                    showActions
-                    residenceLocationId={residenceLocationId}
-                    isPartiesPending={isPartiesPending}
-                    onEdit={handleEditParty}
-                    onDelete={handleDeleteParty}
-                  />
-                ))
-              )}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="past" className="h-full">
-            <div className="h-full w-full overflow-y-auto rounded-md bg-card">
-              {isPartiesPending ? (
-                <PartiesLoading />
-              ) : isPartiesError ? (
-                <PartiesError />
-              ) : pastParties.length === 0 ? (
-                <p className="text-center content-sub py-8">
-                  No past registrations
-                </p>
-              ) : (
-                pastParties.map((party) => (
-                  <RegistrationPartyCard
-                    key={party.id}
-                    party={party}
-                    showAddress
-                    residenceLocationId={residenceLocationId}
-                    isPartiesPending={isPartiesPending}
-                    onEdit={handleEditParty}
-                    onDelete={handleDeleteParty}
-                  />
-                ))
-              )}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="incidents" className="h-full">
-            <div className="h-full w-full overflow-y-auto rounded-md bg-card">
-              {isPartiesPending ? (
-                <PartiesLoading />
-              ) : sortedIncidents.length === 0 ? (
-                <p className="text-center content-sub py-8">No incidents</p>
-              ) : (
-                groupedIncidents.map(([date, dayIncidents]) => (
-                  <RegistrationIncidentCard
-                    key={date}
-                    date={date}
-                    incidents={dayIncidents}
-                  />
-                ))
-              )}
-            </div>
-          </TabsContent>
+          {tabs.map(({ value, children }) => (
+            <TabsContent key={value} value={value} className="h-full">
+              <div className={TAB_CONTENT_CLASS}>
+                {isPartiesPending ? (
+                  <PartiesLoading />
+                ) : isPartiesError ? (
+                  <PartiesError />
+                ) : (
+                  children
+                )}
+              </div>
+            </TabsContent>
+          ))}
         </Card>
       </Tabs>
 

--- a/frontend/src/app/(student)/about-party-registration/page.tsx
+++ b/frontend/src/app/(student)/about-party-registration/page.tsx
@@ -5,7 +5,7 @@ import PartyRegistrationInfo from "../_components/info/PartyRegistrationInfo";
 export default function AboutPartyRegistration() {
   return (
     <div className="flex flex-col items-center">
-      <main className="mx-4 mt-4 max-w-4xl">
+      <div className="mx-4 mt-4 max-w-4xl">
         <nav className="flex items-center content">
           <ArrowLeft className="h-4" />
           <Link href="/">Back</Link>
@@ -13,7 +13,7 @@ export default function AboutPartyRegistration() {
         <div className="mx-8">
           <PartyRegistrationInfo className="mt-4" />
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/(student)/about-party-smart/page.tsx
+++ b/frontend/src/app/(student)/about-party-smart/page.tsx
@@ -5,7 +5,7 @@ import PartySmartInfo from "../_components/info/PartySmartInfo";
 export default function AboutPartySmart() {
   return (
     <div className="flex flex-col items-center h-full">
-      <main className="px-4 py-4 w-full max-w-4xl flex flex-col h-full min-h-0">
+      <div className="px-4 py-4 w-full max-w-4xl flex flex-col h-full min-h-0">
         <div className="flex items-center content">
           <ArrowLeft className="h-4" />
           <Link href="/new-party">Back</Link>
@@ -13,7 +13,7 @@ export default function AboutPartySmart() {
         <div className="mx-0 sm:mx-8 flex-1 min-h-0 flex flex-col">
           <PartySmartInfo className="mt-4" />
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/(student)/new-party/page.tsx
+++ b/frontend/src/app/(student)/new-party/page.tsx
@@ -137,7 +137,7 @@ export default function RegistrationForm() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <main className="mx-4 mt-4">
+      <div className="mx-4 mt-4">
         <nav className="flex items-center content pb-2 lg:hidden">
           <ArrowLeft className="h-4" />
           <Link href="/">Back</Link>
@@ -168,7 +168,7 @@ export default function RegistrationForm() {
             </div>
           </div>
         </Card>
-      </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/(student)/page.tsx
+++ b/frontend/src/app/(student)/page.tsx
@@ -67,7 +67,7 @@ export default function StudentDashboard() {
         <div className="flex-1" />
         <div className="flex flex-col items-center text-center content [@media(max-height:725px)]:hidden">
           <AlertTriangleIcon />
-          <p className="max-w-md">
+          <p className="max-w-md mt-1">
             Keep in mind that the party registration program only pertains to
             nuisance noise complaints. Calls to 911 for other violations will
             likely result in local law enforcement showing up without a warning.

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -1,25 +1,12 @@
 "use client";
 
 import AddressSearch from "@/components/AddressSearch";
+import { SubmitButton } from "@/components/form/SubmitButton";
+import { PhoneField, SelectField } from "@/components/form/fields";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { FieldGroup, FieldSet } from "@/components/ui/field";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Form } from "@/components/ui/form";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import {
@@ -33,7 +20,6 @@ import { getErrorMessage } from "@/lib/errors";
 import {
   cn,
   formatPhoneNumber,
-  formatPhoneNumberInput,
   getAcademicYearLabels,
   isFromThisSchoolYear,
   phoneNumberSchema,
@@ -289,62 +275,28 @@ function StudentInfo() {
               </div>
 
               <div className="flex flex-wrap gap-x-12 gap-y-4">
-                <FormField
+                <PhoneField
                   control={form.control}
                   name="phone_number"
-                  render={({ field }) => (
-                    <FormItem className="flex-1 min-w-50">
-                      <FormLabel className="subhead-content">
-                        Phone Number
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type="tel"
-                          placeholder="(123) 456-7890"
-                          value={formatPhoneNumberInput(field.value ?? "")}
-                          onChange={(e) =>
-                            field.onChange(
-                              e.target.value.replace(/\D/g, "").slice(0, 10)
-                            )
-                          }
-                          className="content"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Phone Number"
+                  labelClassName="subhead-content"
+                  inputClassName="content"
+                  className="flex-1 min-w-50"
                 />
 
-                <FormField
+                <SelectField
                   control={form.control}
                   name="contact_preference"
-                  render={({ field }) => (
-                    <FormItem className="flex-1 min-w-50">
-                      <FormLabel className="subhead-content">
-                        Contact Method
-                      </FormLabel>
-                      <Select
-                        value={field.value}
-                        onValueChange={field.onChange}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="content">
-                            <SelectValue placeholder="Select your preference" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          <SelectItem value="call" className="content">
-                            Call
-                          </SelectItem>
-                          <SelectItem value="text" className="content">
-                            Text
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  label="Contact Method"
+                  labelClassName="subhead-content"
+                  triggerClassName="content"
+                  itemClassName="content"
+                  placeholder="Select your preference"
+                  className="flex-1 min-w-50"
+                  options={[
+                    { value: "call", label: "Call" },
+                    { value: "text", label: "Text" },
+                  ]}
                 />
                 {!validAddress && (
                   <div className="basis-full flex flex-col gap-2">
@@ -390,9 +342,11 @@ function StudentInfo() {
               <Button type="button" onClick={handleCancel}>
                 Cancel
               </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Saving..." : "Save"}
-              </Button>
+              <SubmitButton
+                pending={isSubmitting}
+                label="Save"
+                pendingLabel="Saving..."
+              />
             </div>
           </FieldSet>
         </FieldGroup>

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -233,7 +233,7 @@ function StudentInfo() {
             <p className="text-sm">Please try again later.</p>
           </div>
         ) : (
-          <section>
+          <div>
             <div className="flex flex-wrap gap-x-12 gap-y-6 mb-4">
               <ProfileField
                 label="First Name"
@@ -271,12 +271,12 @@ function StudentInfo() {
               isLoading={isLoading}
               className="my-6"
             />
-          </section>
+          </div>
         )}
 
-        <section className="flex justify-center">
+        <div className="flex justify-center">
           <Button variant="default">Log Out</Button>
-        </section>
+        </div>
       </div>
     );
   }
@@ -317,7 +317,7 @@ function StudentInfo() {
       </div>
       <FieldGroup>
         <FieldSet className="rounded-lg w-full flex flex-col">
-          <section>
+          <div>
             <div className="mb-3">
               <div className="flex flex-wrap gap-x-12 gap-y-2">
                 <div className="flex-1 min-w-50">
@@ -434,7 +434,7 @@ function StudentInfo() {
                 </WarningNote>
               </div>
             )}
-          </section>
+          </div>
 
           {errors.submit && (
             <div className="p-4 bg-red-50 border border-red-200 rounded-md text-center">

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -458,7 +458,7 @@ function StudentInfo() {
 export default function StudentProfilePage() {
   return (
     <div className="flex flex-col items-center h-full overflow-y-auto">
-      <main className="w-5/6 mx-4 my-4 max-w-2xl flex flex-col">
+      <div className="w-5/6 mx-4 my-4 max-w-2xl flex flex-col">
         <nav className="flex items-center content pb-2">
           <ArrowLeft className="h-4" />
           <Link href="/">Back</Link>
@@ -466,7 +466,7 @@ export default function StudentProfilePage() {
         <Card className="max-w-4xl mt-2 w-full border">
           <StudentInfo />
         </Card>
-      </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -3,13 +3,15 @@
 import AddressSearch from "@/components/AddressSearch";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { FieldGroup, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -37,9 +39,11 @@ import {
   isFromThisSchoolYear,
   phoneNumberSchema,
 } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowLeft, Pencil, TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 const locationService = new LocationService();
@@ -63,11 +67,6 @@ const mapStudentToFormData = (student: StudentDto): StudentInfoValues => ({
   contact_preference: student.contact_preference ?? "text",
   address: student.residence?.location.formatted_address ?? "",
 });
-
-interface StudentInfoFormData extends StudentInfoValues {
-  location_place_id?: string;
-  formatted_address?: string;
-}
 
 function ProfileField({
   label,
@@ -106,102 +105,71 @@ function StudentInfo() {
   const updateStudentMutation = useUpdateStudent();
   const updateResidenceMutation = useUpdateResidence();
   const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState<StudentInfoFormData>({
-    first_name: "",
-    last_name: "",
-    phone_number: "",
-    contact_preference: "text",
-    address: "",
-    location_place_id: "",
-    formatted_address: "",
+  const [locationPlaceId, setLocationPlaceId] = useState("");
+  const [formattedAddress, setFormattedAddress] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const form = useForm<StudentInfoValues>({
+    resolver: zodResolver(studentInfoSchema),
+    defaultValues: {
+      first_name: "",
+      last_name: "",
+      phone_number: "",
+      contact_preference: "text",
+      address: "",
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmitting = form.formState.isSubmitting;
 
-  useEffect(() => {
-    if (student && !isEditing) {
-      setFormData(mapStudentToFormData(student));
-    }
-  }, [student, isEditing]);
+  const startEditing = () => {
+    if (student) form.reset(mapStudentToFormData(student));
+    setLocationPlaceId("");
+    setFormattedAddress("");
+    setSubmitError(null);
+    setIsEditing(true);
+  };
 
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = studentInfoSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
+  const handleValid = async (data: StudentInfoValues) => {
+    setSubmitError(null);
+    if (!student) {
+      setSubmitError("Student data not loaded");
       return;
     }
 
-    setIsSubmitting(true);
+    const studentFieldsChanged =
+      data.phone_number !== student.phone_number ||
+      data.contact_preference !== student.contact_preference;
+
+    const residenceChanged = !!locationPlaceId;
+
     try {
-      if (!student) {
-        throw new Error("Student data not loaded");
-      }
-
-      const studentFieldsChanged =
-        formData.phone_number !== student.phone_number ||
-        formData.contact_preference !== student.contact_preference;
-
-      const residenceChanged = !!formData.location_place_id;
-
       if (studentFieldsChanged) {
         await updateStudentMutation.mutateAsync({
-          phone_number: result.data.phone_number,
-          contact_preference: result.data.contact_preference,
+          phone_number: data.phone_number,
+          contact_preference: data.contact_preference,
           last_registered: student.last_registered,
         });
       }
 
-      if (residenceChanged && formData.location_place_id) {
+      if (residenceChanged && locationPlaceId) {
         await updateResidenceMutation.mutateAsync({
-          residence_place_id: formData.location_place_id,
-          formatted_address: formData.formatted_address || "",
+          residence_place_id: locationPlaceId,
+          formatted_address: formattedAddress || "",
         });
       }
 
-      setFormData((prev) => ({
-        ...prev,
-        location_place_id: "",
-        formatted_address: prev.formatted_address,
-      }));
-
+      setLocationPlaceId("");
       setIsEditing(false);
     } catch (error) {
-      setErrors({ submit: getErrorMessage(error) });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const updateField = <K extends keyof StudentInfoFormData>(
-    field: K,
-    value: StudentInfoFormData[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[field];
-        return newErrors;
-      });
+      setSubmitError(getErrorMessage(error));
     }
   };
 
   const displayData = {
-    first_name: formData.first_name ?? student?.first_name ?? "",
-    last_name: formData.last_name ?? student?.last_name ?? "",
-    phone_number: formData.phone_number ?? student?.phone_number ?? "",
-    contact_preference:
-      formData.contact_preference ?? student?.contact_preference ?? undefined,
+    first_name: student?.first_name ?? "",
+    last_name: student?.last_name ?? "",
+    phone_number: student?.phone_number ?? "",
+    contact_preference: student?.contact_preference ?? undefined,
   };
   const { schoolYear, changeDate } = getAcademicYearLabels();
 
@@ -218,7 +186,7 @@ function StudentInfo() {
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => setIsEditing(true)}
+              onClick={startEditing}
               aria-label="Edit profile"
               disabled={isLoading || !student}
             >
@@ -282,177 +250,158 @@ function StudentInfo() {
   }
 
   const handleCancel = () => {
-    setFormData({
-      first_name: student?.first_name ?? "",
-      last_name: student?.last_name ?? "",
-      phone_number: student?.phone_number ?? "",
-      contact_preference: student?.contact_preference ?? "call",
-      address: student?.residence?.location.formatted_address ?? "",
-      location_place_id: "",
-      formatted_address: student?.residence?.location.formatted_address ?? "",
-    });
-    setErrors({});
+    if (student) form.reset(mapStudentToFormData(student));
+    setLocationPlaceId("");
+    setFormattedAddress("");
+    setSubmitError(null);
     setIsEditing(false);
   };
 
   const handleAddressSelect = (address: AutocompleteResult | null) => {
-    setFormData((prev) => ({
-      ...prev,
-      location_place_id: address?.google_place_id || "",
-      formatted_address: address?.formatted_address || "",
-    }));
-    if (errors.location_place_id) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.location_place_id;
-        return newErrors;
-      });
-    }
+    setLocationPlaceId(address?.google_place_id || "");
+    setFormattedAddress(address?.formatted_address || "");
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-card rounded-lg w-full p-8">
-      <div className="mb-6">
-        <h1 className="page-title">Edit Profile Information</h1>
-      </div>
-      <FieldGroup>
-        <FieldSet className="rounded-lg w-full flex flex-col">
-          <div>
-            <div className="mb-3">
-              <div className="flex flex-wrap gap-x-12 gap-y-2">
-                <div className="flex-1 min-w-50">
-                  <p className="subhead-content mb-2">First Name</p>
-                  <p className="content pb-2">{displayData.first_name}</p>
-                </div>
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleValid)}
+        className="bg-card rounded-lg w-full p-8"
+      >
+        <div className="mb-6">
+          <h1 className="page-title">Edit Profile Information</h1>
+        </div>
+        <FieldGroup>
+          <FieldSet className="rounded-lg w-full flex flex-col">
+            <div>
+              <div className="mb-3">
+                <div className="flex flex-wrap gap-x-12 gap-y-2">
+                  <div className="flex-1 min-w-50">
+                    <p className="subhead-content mb-2">First Name</p>
+                    <p className="content pb-2">{displayData.first_name}</p>
+                  </div>
 
-                <div className="flex-1 min-w-50">
-                  <p className="subhead-content mb-2">Last Name</p>
-                  <p className="content pb-2">{displayData.last_name}</p>
+                  <div className="flex-1 min-w-50">
+                    <p className="subhead-content mb-2">Last Name</p>
+                    <p className="content pb-2">{displayData.last_name}</p>
+                  </div>
                 </div>
+                <WarningNote>
+                  Your name is associated with your Onyen
+                </WarningNote>
               </div>
-              <WarningNote>Your name is associated with your Onyen</WarningNote>
-            </div>
 
-            <div className="flex flex-wrap gap-x-12 gap-y-4">
-              <Field
-                data-invalid={!!errors.phone_number}
-                className="flex-1 min-w-50"
-              >
-                <FieldLabel htmlFor="phone-number" className="subhead-content">
-                  Phone Number
-                </FieldLabel>
-                <Input
-                  id="phone-number"
-                  type="tel"
-                  placeholder="(123) 456-7890"
-                  value={formatPhoneNumberInput(formData.phone_number ?? "")}
-                  onChange={(e) =>
-                    updateField(
-                      "phone_number",
-                      e.target.value.replace(/\D/g, "").slice(0, 10)
-                    )
-                  }
-                  aria-invalid={!!errors.phone_number}
-                  className="content"
-                />
-                {errors.phone_number && (
-                  <FieldError>{errors.phone_number}</FieldError>
-                )}
-              </Field>
-
-              <Field
-                data-invalid={!!errors.contact_preference}
-                className="flex-1 min-w-50"
-              >
-                <FieldLabel
-                  htmlFor="contact-preference"
-                  className="subhead-content"
-                >
-                  Contact Method
-                </FieldLabel>
-                <Select
-                  value={formData.contact_preference}
-                  onValueChange={(value: "call" | "text") =>
-                    updateField("contact_preference", value)
-                  }
-                >
-                  <SelectTrigger id="contact-preference" className="content">
-                    <SelectValue placeholder="Select your preference" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="call" className="content">
-                      Call
-                    </SelectItem>
-                    <SelectItem value="text" className="content">
-                      Text
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                {errors.contact_preference && (
-                  <FieldError>{errors.contact_preference}</FieldError>
-                )}
-              </Field>
-              {!validAddress && (
-                <Field
-                  data-invalid={!!errors.location_place_id}
-                  className="basis-full"
-                >
-                  <FieldLabel htmlFor="address" className="subhead-content">
-                    {schoolYear} Address
-                  </FieldLabel>
-                  <AddressSearch
-                    onSelect={handleAddressSelect}
-                    locationService={locationService}
-                    placeholder="Search for the location address..."
-                    className="w-full"
-                    error={errors.location_place_id}
-                    chapelHillOnly
-                  />
-                  {errors.location_place_id && (
-                    <FieldError>{errors.location_place_id}</FieldError>
+              <div className="flex flex-wrap gap-x-12 gap-y-4">
+                <FormField
+                  control={form.control}
+                  name="phone_number"
+                  render={({ field }) => (
+                    <FormItem className="flex-1 min-w-50">
+                      <FormLabel className="subhead-content">
+                        Phone Number
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="tel"
+                          placeholder="(123) 456-7890"
+                          value={formatPhoneNumberInput(field.value ?? "")}
+                          onChange={(e) =>
+                            field.onChange(
+                              e.target.value.replace(/\D/g, "").slice(0, 10)
+                            )
+                          }
+                          className="content"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
                   )}
-                </Field>
+                />
+
+                <FormField
+                  control={form.control}
+                  name="contact_preference"
+                  render={({ field }) => (
+                    <FormItem className="flex-1 min-w-50">
+                      <FormLabel className="subhead-content">
+                        Contact Method
+                      </FormLabel>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="content">
+                            <SelectValue placeholder="Select your preference" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="call" className="content">
+                            Call
+                          </SelectItem>
+                          <SelectItem value="text" className="content">
+                            Text
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                {!validAddress && (
+                  <div className="basis-full flex flex-col gap-2">
+                    <p className="subhead-content">{schoolYear} Address</p>
+                    <AddressSearch
+                      onSelect={handleAddressSelect}
+                      locationService={locationService}
+                      placeholder="Search for the location address..."
+                      className="w-full"
+                      chapelHillOnly
+                    />
+                  </div>
+                )}
+              </div>
+
+              {validAddress && (
+                <div className="mt-6">
+                  <p className="subhead-content">{schoolYear} Address</p>
+                  <p className="content my-2">
+                    {student?.residence?.location.formatted_address}
+                  </p>
+
+                  <WarningNote>
+                    You cannot change your address until {changeDate}. For
+                    extraneous circumstances, contact{" "}
+                    <a
+                      href={`mailto:${clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}`}
+                      className="underline"
+                    >
+                      {clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}
+                    </a>{" "}
+                  </WarningNote>
+                </div>
               )}
             </div>
 
-            {validAddress && (
-              <div className="mt-6">
-                <p className="subhead-content">{schoolYear} Address</p>
-                <p className="content my-2">
-                  {student?.residence?.location.formatted_address}
-                </p>
-
-                <WarningNote>
-                  You cannot change your address until {changeDate}. For
-                  extraneous circumstances, contact{" "}
-                  <a
-                    href={`mailto:${clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}`}
-                    className="underline"
-                  >
-                    {clientEnv.NEXT_PUBLIC_CONTACT_EMAIL}
-                  </a>{" "}
-                </WarningNote>
+            {submitError && (
+              <div className="p-4 bg-red-50 border border-red-200 rounded-md text-center">
+                <p className="text-sm text-red-600">{submitError}</p>
               </div>
             )}
-          </div>
 
-          {errors.submit && (
-            <div className="p-4 bg-red-50 border border-red-200 rounded-md text-center">
-              <FieldError className="text-red-600">{errors.submit}</FieldError>
+            <div className="flex justify-center gap-12">
+              <Button type="button" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving..." : "Save"}
+              </Button>
             </div>
-          )}
-
-          <div className="flex justify-center gap-12">
-            <Button type="button" onClick={handleCancel}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Saving..." : "Save"}
-            </Button>
-          </div>
-        </FieldSet>
-      </FieldGroup>
-    </form>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
   );
 }
 

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -21,7 +21,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import {
   useCurrentStudent,
@@ -45,8 +44,6 @@ import Link from "next/link";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
-
-const locationService = new LocationService();
 
 const studentInfoSchema = z.object({
   first_name: z.string().min(1, "First name is required"),
@@ -354,7 +351,6 @@ function StudentInfo() {
                     <p className="subhead-content">{schoolYear} Address</p>
                     <AddressSearch
                       onSelect={handleAddressSelect}
-                      locationService={locationService}
                       placeholder="Search for the location address..."
                       className="w-full"
                       chapelHillOnly

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -215,14 +215,15 @@ function StudentInfo() {
         <div className="mb-6 flex justify-between items-center">
           <h1 className="page-title">Profile</h1>
           {!error && (
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={() => setIsEditing(true)}
-              className="bg-transparent"
               aria-label="Edit profile"
               disabled={isLoading || !student}
             >
-              <Pencil className="content cursor-pointer" />
-            </button>
+              <Pencil className="content" />
+            </Button>
           )}
         </div>
 

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -55,7 +55,7 @@ function ProfileField({
   label,
   value,
   isLoading,
-  className,
+  className = "flex-1 min-w-50",
 }: {
   label: string;
   value: React.ReactNode;
@@ -63,8 +63,8 @@ function ProfileField({
   className?: string;
 }) {
   return (
-    <div className={cn(!isLoading && "border-b", className)}>
-      <p className="subhead-content mb-2">{label}</p>
+    <div className={cn(!isLoading && "", className)}>
+      <p className="subhead-content mb-1">{label}</p>
       {isLoading ? (
         <Skeleton className="h-6 w-full" />
       ) : (
@@ -77,7 +77,7 @@ function ProfileField({
 function WarningNote({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-row gap-2">
-      <TriangleAlert className="w-4 h-4 content" />
+      <TriangleAlert className="w-4 h-4 content-sub translate-y-0.5" />
       <p className="content-sub italic flex-1">{children}</p>
     </div>
   );
@@ -163,7 +163,7 @@ function StudentInfo() {
   if (!isEditing) {
     return (
       <div className="bg-card rounded-lg p-8 w-full flex flex-col">
-        <div className="mb-6 flex justify-between items-center">
+        <div className="flex justify-between items-center">
           <h1 className="page-title">Profile</h1>
           {!error && (
             <Button
@@ -173,7 +173,7 @@ function StudentInfo() {
               aria-label="Edit profile"
               disabled={isLoading || !student}
             >
-              <Pencil className="content" />
+              <Pencil className="size-5" />
             </Button>
           )}
         </div>
@@ -184,25 +184,22 @@ function StudentInfo() {
             <p className="text-sm">Please try again later.</p>
           </div>
         ) : (
-          <div>
+          <div className="mt-6 mb-8">
             <div className="flex flex-wrap gap-x-12 gap-y-6 mb-4">
               <ProfileField
                 label="First Name"
                 value={displayData.first_name}
                 isLoading={isLoading}
-                className="flex-1 min-w-50"
               />
               <ProfileField
                 label="Last Name"
                 value={displayData.last_name}
                 isLoading={isLoading}
-                className="flex-1 min-w-50"
               />
               <ProfileField
                 label="Phone Number"
                 value={formatPhoneNumber(displayData.phone_number) || "—"}
                 isLoading={isLoading}
-                className="flex-1 min-w-50"
               />
               <ProfileField
                 label="Contact Method"
@@ -213,14 +210,13 @@ function StudentInfo() {
                     : "—"
                 }
                 isLoading={isLoading}
-                className="flex-1 min-w-50"
               />
             </div>
             <ProfileField
               label={`${schoolYear} Address`}
               value={student?.residence?.location.formatted_address ?? "None"}
               isLoading={isLoading}
-              className="my-6"
+              className="mt-6"
             />
           </div>
         )}
@@ -257,17 +253,19 @@ function StudentInfo() {
         <FieldGroup>
           <FieldSet className="rounded-lg w-full flex flex-col">
             <div>
-              <div className="mb-3">
-                <div className="flex flex-wrap gap-x-12 gap-y-2">
-                  <div className="flex-1 min-w-50">
-                    <p className="subhead-content mb-2">First Name</p>
-                    <p className="content pb-2">{displayData.first_name}</p>
-                  </div>
+              <div className="mb-6">
+                <div className="flex flex-wrap gap-x-12 gap-y-2 mb-2">
+                  <ProfileField
+                    label="First Name"
+                    value={displayData.first_name}
+                    isLoading={false}
+                  />
 
-                  <div className="flex-1 min-w-50">
-                    <p className="subhead-content mb-2">Last Name</p>
-                    <p className="content pb-2">{displayData.last_name}</p>
-                  </div>
+                  <ProfileField
+                    label="Last Name"
+                    value={displayData.last_name}
+                    isLoading={false}
+                  />
                 </div>
                 <WarningNote>
                   Your name is associated with your Onyen
@@ -313,8 +311,8 @@ function StudentInfo() {
 
               {validAddress && (
                 <div className="mt-6">
-                  <p className="subhead-content">{schoolYear} Address</p>
-                  <p className="content my-2">
+                  <p className="subhead-content mb-1">{schoolYear} Address</p>
+                  <p className="content mb-2">
                     {student?.residence?.location.formatted_address}
                   </p>
 

--- a/frontend/src/app/auth-error/page.tsx
+++ b/frontend/src/app/auth-error/page.tsx
@@ -48,7 +48,7 @@ export default async function AuthErrorPage({ searchParams }: Props) {
   const isPermanent = error === "AccessDenied" || error === "MissingEmail";
 
   return (
-    <main className="flex h-full items-center justify-center px-4">
+    <div className="flex h-full items-center justify-center px-4">
       <div className="flex flex-col items-center text-center max-w-md gap-4">
         <TriangleAlert className="size-12 text-destructive" />
         <div className="space-y-2">
@@ -68,6 +68,6 @@ export default async function AuthErrorPage({ searchParams }: Props) {
           </Button>
         )}
       </div>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -42,8 +42,20 @@ export default function RootLayout({
         className={`${avenirNext.variable} font-(family-name:--font-avenir-next) antialiased h-screen overflow-hidden flex flex-col`}
       >
         <Providers>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded focus:shadow"
+          >
+            Skip to main content
+          </a>
           <Header />
-          <main className="flex-1 overflow-hidden min-h-0">{children}</main>
+          <main
+            id="main-content"
+            tabIndex={-1}
+            className="flex-1 overflow-hidden min-h-0"
+          >
+            {children}
+          </main>
           <Footer />
         </Providers>
       </body>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
       >
         <Providers>
           <Header />
-          <div className="flex-1 overflow-hidden min-h-0">{children}</div>
+          <main className="flex-1 overflow-hidden min-h-0">{children}</main>
           <Footer />
         </Providers>
       </body>

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -40,7 +40,7 @@ function NotificationsContent() {
   const hasMutationError = unsubscribe.isError || resubscribe.isError;
 
   return (
-    <main className="flex h-full items-center justify-center px-4 py-6">
+    <div className="flex h-full items-center justify-center px-4 py-6">
       <Card className="w-full max-w-md">
         <CardHeader className="px-10 pt-8 text-center">
           <div className="flex justify-center mb-3">
@@ -105,6 +105,6 @@ function NotificationsContent() {
           )}
         </CardContent>
       </Card>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/police/(auth)/_components/AuthCard.tsx
+++ b/frontend/src/app/police/(auth)/_components/AuthCard.tsx
@@ -19,7 +19,7 @@ export default function AuthCard({
   children,
 }: AuthCardProps) {
   return (
-    <main className="h-full overflow-y-auto flex items-center justify-center px-4 py-6">
+    <div className="h-full overflow-y-auto flex items-center justify-center px-4 py-6">
       <Card className="w-full max-w-md my-auto">
         <CardHeader className="px-10 pt-6 text-center">
           <div className="flex justify-center mb-3">
@@ -35,6 +35,6 @@ export default function AuthCard({
         </CardHeader>
         {children}
       </Card>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/police/(auth)/login/page.tsx
+++ b/frontend/src/app/police/(auth)/login/page.tsx
@@ -4,16 +4,25 @@ import AuthCard from "@/app/police/(auth)/_components/AuthCard";
 import ResendVerificationButton from "@/app/police/(auth)/_components/ResendVerificationButton";
 import { Button } from "@/components/ui/button";
 import { CardContent } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { usePoliceLogin } from "@/lib/api/auth/auth.queries";
 import { clientEnv } from "@/lib/config/env.client";
 import { getErrorMessage } from "@/lib/errors";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { isAxiosError } from "axios";
 import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 const policeLoginSchema = z.object({
@@ -35,14 +44,18 @@ function PoliceLoginForm() {
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") || "/police";
 
-  const [formData, setFormData] = useState<Partial<PoliceLoginFormValues>>({
-    email: "",
-    password: "",
-  });
-  const [errors, setErrors] = useState<Record<string, string>>({});
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [showResendVerification, setShowResendVerification] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+
+  const form = useForm<PoliceLoginFormValues>({
+    resolver: zodResolver(policeLoginSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+  const email = form.watch("email");
 
   const policeLoginMutation = usePoliceLogin({
     onSuccess: () => {
@@ -70,110 +83,97 @@ function PoliceLoginForm() {
     },
   });
 
-  const updateField = <K extends keyof PoliceLoginFormValues>(
-    field: K,
-    value: PoliceLoginFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const next = { ...prev };
-        delete next[field];
-        return next;
-      });
-    }
+  const handleValid = (data: PoliceLoginFormValues) => {
+    policeLoginMutation.mutate(data);
   };
-
-  function handleSubmit(e: { preventDefault: () => void }) {
-    e.preventDefault();
-    setSubmissionError(null);
-    setShowResendVerification(false);
-
-    const result = policeLoginSchema.safeParse(formData);
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    policeLoginMutation.mutate(result.data);
-  }
 
   return (
     <AuthCard title="Police Sign In">
       <CardContent className="px-10 pb-6">
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              placeholder={`officer@${clientEnv.NEXT_PUBLIC_CHPD_EMAIL_DOMAIN}`}
-              value={formData.email}
-              onChange={(e) => updateField("email", e.target.value)}
-              autoComplete="email"
-              aria-invalid={!!errors.email}
-            />
-            {errors.email && (
-              <p className="text-sm text-destructive">{errors.email}</p>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="password">Password</Label>
-            <div className="relative">
-              <Input
-                id="password"
-                type={showPassword ? "text" : "password"}
-                value={formData.password}
-                onChange={(e) => updateField("password", e.target.value)}
-                autoComplete="current-password"
-                aria-invalid={!!errors.password}
-                className="pr-10"
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setShowPassword((v) => !v)}
-                className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                aria-label={showPassword ? "Hide password" : "Show password"}
-              >
-                {showPassword ? (
-                  <EyeOff className="size-4" />
-                ) : (
-                  <Eye className="size-4" />
-                )}
-              </Button>
-            </div>
-            {errors.password && (
-              <p className="text-sm text-destructive">{errors.password}</p>
-            )}
-          </div>
-
-          {submissionError && (
-            <p className="text-sm text-destructive text-center">
-              {submissionError}
-            </p>
-          )}
-
-          {showResendVerification && formData.email && (
-            <ResendVerificationButton email={formData.email} />
-          )}
-
-          <Button
-            type="submit"
-            className="w-full"
-            disabled={policeLoginMutation.isPending}
+        <Form {...form}>
+          <form
+            onSubmit={(e) => {
+              setSubmissionError(null);
+              setShowResendVerification(false);
+              form.handleSubmit(handleValid)(e);
+            }}
+            className="space-y-5"
           >
-            {policeLoginMutation.isPending ? "Signing in..." : "Sign In"}
-          </Button>
-        </form>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder={`officer@${clientEnv.NEXT_PUBLIC_CHPD_EMAIL_DOMAIN}`}
+                      autoComplete="email"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <div className="relative">
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type={showPassword ? "text" : "password"}
+                        autoComplete="current-password"
+                        className="pr-10"
+                      />
+                    </FormControl>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => setShowPassword((v) => !v)}
+                      className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={
+                        showPassword ? "Hide password" : "Show password"
+                      }
+                    >
+                      {showPassword ? (
+                        <EyeOff className="size-4" />
+                      ) : (
+                        <Eye className="size-4" />
+                      )}
+                    </Button>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {submissionError && (
+              <p className="text-sm text-destructive text-center">
+                {submissionError}
+              </p>
+            )}
+
+            {showResendVerification && email && (
+              <ResendVerificationButton email={email} />
+            )}
+
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={policeLoginMutation.isPending}
+            >
+              {policeLoginMutation.isPending ? "Signing in..." : "Sign In"}
+            </Button>
+          </form>
+        </Form>
 
         <p className="mt-4 text-center text-sm text-muted-foreground">
           Need an account?{" "}

--- a/frontend/src/app/police/(auth)/login/page.tsx
+++ b/frontend/src/app/police/(auth)/login/page.tsx
@@ -136,10 +136,12 @@ function PoliceLoginForm() {
                 aria-invalid={!!errors.password}
                 className="pr-10"
               />
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="icon-sm"
                 onClick={() => setShowPassword((v) => !v)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-foreground"
+                className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                 aria-label={showPassword ? "Hide password" : "Show password"}
               >
                 {showPassword ? (
@@ -147,7 +149,7 @@ function PoliceLoginForm() {
                 ) : (
                   <Eye className="size-4" />
                 )}
-              </button>
+              </Button>
             </div>
             {errors.password && (
               <p className="text-sm text-destructive">{errors.password}</p>

--- a/frontend/src/app/police/(auth)/login/page.tsx
+++ b/frontend/src/app/police/(auth)/login/page.tsx
@@ -2,23 +2,15 @@
 
 import AuthCard from "@/app/police/(auth)/_components/AuthCard";
 import ResendVerificationButton from "@/app/police/(auth)/_components/ResendVerificationButton";
-import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/form/SubmitButton";
+import { PasswordField, TextField } from "@/components/form/fields";
 import { CardContent } from "@/components/ui/card";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { Form } from "@/components/ui/form";
 import { usePoliceLogin } from "@/lib/api/auth/auth.queries";
 import { clientEnv } from "@/lib/config/env.client";
 import { getErrorMessage } from "@/lib/errors";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { isAxiosError } from "axios";
-import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
@@ -46,7 +38,6 @@ function PoliceLoginForm() {
 
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [showResendVerification, setShowResendVerification] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
 
   const form = useForm<PoliceLoginFormValues>({
     resolver: zodResolver(policeLoginSchema),
@@ -99,60 +90,20 @@ function PoliceLoginForm() {
             }}
             className="space-y-5"
           >
-            <FormField
+            <TextField
               control={form.control}
               name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Email</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="email"
-                      placeholder={`officer@${clientEnv.NEXT_PUBLIC_CHPD_EMAIL_DOMAIN}`}
-                      autoComplete="email"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+              label="Email"
+              type="email"
+              placeholder={`officer@${clientEnv.NEXT_PUBLIC_CHPD_EMAIL_DOMAIN}`}
+              autoComplete="email"
             />
 
-            <FormField
+            <PasswordField
               control={form.control}
               name="password"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Password</FormLabel>
-                  <div className="relative">
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type={showPassword ? "text" : "password"}
-                        autoComplete="current-password"
-                        className="pr-10"
-                      />
-                    </FormControl>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => setShowPassword((v) => !v)}
-                      className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                      aria-label={
-                        showPassword ? "Hide password" : "Show password"
-                      }
-                    >
-                      {showPassword ? (
-                        <EyeOff className="size-4" />
-                      ) : (
-                        <Eye className="size-4" />
-                      )}
-                    </Button>
-                  </div>
-                  <FormMessage />
-                </FormItem>
-              )}
+              label="Password"
+              autoComplete="current-password"
             />
 
             {submissionError && (
@@ -165,13 +116,12 @@ function PoliceLoginForm() {
               <ResendVerificationButton email={email} />
             )}
 
-            <Button
-              type="submit"
+            <SubmitButton
+              pending={policeLoginMutation.isPending}
+              label="Sign In"
+              pendingLabel="Signing in..."
               className="w-full"
-              disabled={policeLoginMutation.isPending}
-            >
-              {policeLoginMutation.isPending ? "Signing in..." : "Sign In"}
-            </Button>
+            />
           </form>
         </Form>
 

--- a/frontend/src/app/police/(auth)/signup/page.tsx
+++ b/frontend/src/app/police/(auth)/signup/page.tsx
@@ -150,10 +150,12 @@ export default function PoliceSignupPage() {
                   aria-invalid={!!errors.password}
                   className="pr-10"
                 />
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="icon-sm"
                   onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-foreground"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
                   {showPassword ? (
@@ -161,7 +163,7 @@ export default function PoliceSignupPage() {
                   ) : (
                     <Eye className="size-4" />
                   )}
-                </button>
+                </Button>
               </div>
               {errors.password && (
                 <p className="text-sm text-destructive">{errors.password}</p>
@@ -182,10 +184,12 @@ export default function PoliceSignupPage() {
                   aria-invalid={!!errors.confirm_password}
                   className="pr-10"
                 />
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="icon-sm"
                   onClick={() => setShowConfirmPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-foreground"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                   aria-label={
                     showConfirmPassword ? "Hide password" : "Show password"
                   }
@@ -195,7 +199,7 @@ export default function PoliceSignupPage() {
                   ) : (
                     <Eye className="size-4" />
                   )}
-                </button>
+                </Button>
               </div>
               {errors.confirm_password && (
                 <p className="text-sm text-destructive">

--- a/frontend/src/app/police/(auth)/signup/page.tsx
+++ b/frontend/src/app/police/(auth)/signup/page.tsx
@@ -4,15 +4,24 @@ import AuthCard from "@/app/police/(auth)/_components/AuthCard";
 import ResendVerificationButton from "@/app/police/(auth)/_components/ResendVerificationButton";
 import { Button } from "@/components/ui/button";
 import { CardContent } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { usePoliceSignup } from "@/lib/api/auth/auth.queries";
 import { clientEnv } from "@/lib/config/env.client";
 import { getErrorMessage } from "@/lib/errors";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { isAxiosError } from "axios";
 import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 const allowedDomain = clientEnv.NEXT_PUBLIC_CHPD_EMAIL_DOMAIN;
@@ -35,16 +44,20 @@ const policeSignupSchema = z
 type PoliceSignupFormValues = z.infer<typeof policeSignupSchema>;
 
 export default function PoliceSignupPage() {
-  const [formData, setFormData] = useState<Partial<PoliceSignupFormValues>>({
-    email: "",
-    password: "",
-    confirm_password: "",
-  });
-  const [errors, setErrors] = useState<Record<string, string>>({});
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [isComplete, setIsComplete] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const form = useForm<PoliceSignupFormValues>({
+    resolver: zodResolver(policeSignupSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+      confirm_password: "",
+    },
+  });
+  const email = form.watch("email");
 
   const policeSignupMutation = usePoliceSignup({
     onSuccess: () => {
@@ -60,42 +73,13 @@ export default function PoliceSignupPage() {
     },
   });
 
-  const updateField = <K extends keyof PoliceSignupFormValues>(
-    field: K,
-    value: PoliceSignupFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const next = { ...prev };
-        delete next[field];
-        return next;
-      });
-    }
-  };
-
-  function handleSubmit(e: { preventDefault: () => void }) {
-    e.preventDefault();
-    setSubmissionError(null);
-
-    const result = policeSignupSchema.safeParse(formData);
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
+  const handleValid = (data: PoliceSignupFormValues) => {
     policeSignupMutation.mutate({
-      email: result.data.email,
-      password: result.data.password,
-      confirm_password: result.data.confirm_password,
+      email: data.email,
+      password: data.password,
+      confirm_password: data.confirm_password,
     });
-  }
+  };
 
   return (
     <AuthCard
@@ -109,10 +93,7 @@ export default function PoliceSignupPage() {
       <CardContent className="px-10 py-6">
         {isComplete ? (
           <div className="space-y-4 text-center">
-            <ResendVerificationButton
-              email={formData.email ?? ""}
-              startInCooldown
-            />
+            <ResendVerificationButton email={email ?? ""} startInCooldown />
             <Link
               href="/police/login"
               className="text-sm text-primary underline"
@@ -121,116 +102,133 @@ export default function PoliceSignupPage() {
             </Link>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-5">
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                autoComplete="email"
-                placeholder={`officer@${allowedDomain}`}
-                value={formData.email}
-                onChange={(e) => updateField("email", e.target.value)}
-                aria-invalid={!!errors.email}
+          <Form {...form}>
+            <form
+              onSubmit={(e) => {
+                setSubmissionError(null);
+                form.handleSubmit(handleValid)(e);
+              }}
+              className="space-y-5"
+            >
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={`officer@${allowedDomain}`}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-              {errors.email && (
-                <p className="text-sm text-destructive">{errors.email}</p>
-              )}
-            </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <div className="relative">
-                <Input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  autoComplete="new-password"
-                  value={formData.password}
-                  onChange={(e) => updateField("password", e.target.value)}
-                  aria-invalid={!!errors.password}
-                  className="pr-10"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  aria-label={showPassword ? "Hide password" : "Show password"}
-                >
-                  {showPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </Button>
-              </div>
-              {errors.password && (
-                <p className="text-sm text-destructive">{errors.password}</p>
-              )}
-            </div>
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <div className="relative">
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type={showPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          className="pr-10"
+                        />
+                      </FormControl>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => setShowPassword((v) => !v)}
+                        className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                        aria-label={
+                          showPassword ? "Hide password" : "Show password"
+                        }
+                      >
+                        {showPassword ? (
+                          <EyeOff className="size-4" />
+                        ) : (
+                          <Eye className="size-4" />
+                        )}
+                      </Button>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <div className="space-y-2">
-              <Label htmlFor="confirm-password">Confirm Password</Label>
-              <div className="relative">
-                <Input
-                  id="confirm-password"
-                  type={showConfirmPassword ? "text" : "password"}
-                  autoComplete="new-password"
-                  value={formData.confirm_password}
-                  onChange={(e) =>
-                    updateField("confirm_password", e.target.value)
-                  }
-                  aria-invalid={!!errors.confirm_password}
-                  className="pr-10"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={() => setShowConfirmPassword((v) => !v)}
-                  className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  aria-label={
-                    showConfirmPassword ? "Hide password" : "Show password"
-                  }
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </Button>
-              </div>
-              {errors.confirm_password && (
-                <p className="text-sm text-destructive">
-                  {errors.confirm_password}
+              <FormField
+                control={form.control}
+                name="confirm_password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Confirm Password</FormLabel>
+                    <div className="relative">
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type={showConfirmPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          className="pr-10"
+                        />
+                      </FormControl>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => setShowConfirmPassword((v) => !v)}
+                        className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                        aria-label={
+                          showConfirmPassword
+                            ? "Hide password"
+                            : "Show password"
+                        }
+                      >
+                        {showConfirmPassword ? (
+                          <EyeOff className="size-4" />
+                        ) : (
+                          <Eye className="size-4" />
+                        )}
+                      </Button>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {submissionError && (
+                <p className="text-center text-sm text-destructive">
+                  {submissionError}
                 </p>
               )}
-            </div>
 
-            {submissionError && (
-              <p className="text-center text-sm text-destructive">
-                {submissionError}
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={policeSignupMutation.isPending}
+              >
+                {policeSignupMutation.isPending
+                  ? "Creating Account..."
+                  : "Create Account"}
+              </Button>
+
+              <p className="text-center text-sm text-muted-foreground">
+                Already have an account?{" "}
+                <Link href="/police/login" className="text-primary underline">
+                  Sign in
+                </Link>
               </p>
-            )}
-
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={policeSignupMutation.isPending}
-            >
-              {policeSignupMutation.isPending
-                ? "Creating Account..."
-                : "Create Account"}
-            </Button>
-
-            <p className="text-center text-sm text-muted-foreground">
-              Already have an account?{" "}
-              <Link href="/police/login" className="text-primary underline">
-                Sign in
-              </Link>
-            </p>
-          </form>
+            </form>
+          </Form>
         )}
       </CardContent>
     </AuthCard>

--- a/frontend/src/app/police/(auth)/signup/page.tsx
+++ b/frontend/src/app/police/(auth)/signup/page.tsx
@@ -2,23 +2,15 @@
 
 import AuthCard from "@/app/police/(auth)/_components/AuthCard";
 import ResendVerificationButton from "@/app/police/(auth)/_components/ResendVerificationButton";
-import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/form/SubmitButton";
+import { PasswordField, TextField } from "@/components/form/fields";
 import { CardContent } from "@/components/ui/card";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { Form } from "@/components/ui/form";
 import { usePoliceSignup } from "@/lib/api/auth/auth.queries";
 import { clientEnv } from "@/lib/config/env.client";
 import { getErrorMessage } from "@/lib/errors";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { isAxiosError } from "axios";
-import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -46,8 +38,6 @@ type PoliceSignupFormValues = z.infer<typeof policeSignupSchema>;
 export default function PoliceSignupPage() {
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [isComplete, setIsComplete] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const form = useForm<PoliceSignupFormValues>({
     resolver: zodResolver(policeSignupSchema),
@@ -110,99 +100,27 @@ export default function PoliceSignupPage() {
               }}
               className="space-y-5"
             >
-              <FormField
+              <TextField
                 control={form.control}
                 name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="email"
-                        autoComplete="email"
-                        placeholder={`officer@${allowedDomain}`}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="Email"
+                type="email"
+                autoComplete="email"
+                placeholder={`officer@${allowedDomain}`}
               />
 
-              <FormField
+              <PasswordField
                 control={form.control}
                 name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <div className="relative">
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type={showPassword ? "text" : "password"}
-                          autoComplete="new-password"
-                          className="pr-10"
-                        />
-                      </FormControl>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => setShowPassword((v) => !v)}
-                        className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                        aria-label={
-                          showPassword ? "Hide password" : "Show password"
-                        }
-                      >
-                        {showPassword ? (
-                          <EyeOff className="size-4" />
-                        ) : (
-                          <Eye className="size-4" />
-                        )}
-                      </Button>
-                    </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="Password"
+                autoComplete="new-password"
               />
 
-              <FormField
+              <PasswordField
                 control={form.control}
                 name="confirm_password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Confirm Password</FormLabel>
-                    <div className="relative">
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type={showConfirmPassword ? "text" : "password"}
-                          autoComplete="new-password"
-                          className="pr-10"
-                        />
-                      </FormControl>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => setShowConfirmPassword((v) => !v)}
-                        className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                        aria-label={
-                          showConfirmPassword
-                            ? "Hide password"
-                            : "Show password"
-                        }
-                      >
-                        {showConfirmPassword ? (
-                          <EyeOff className="size-4" />
-                        ) : (
-                          <Eye className="size-4" />
-                        )}
-                      </Button>
-                    </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="Confirm Password"
+                autoComplete="new-password"
               />
 
               {submissionError && (
@@ -211,15 +129,12 @@ export default function PoliceSignupPage() {
                 </p>
               )}
 
-              <Button
-                type="submit"
+              <SubmitButton
+                pending={policeSignupMutation.isPending}
+                label="Create Account"
+                pendingLabel="Creating Account..."
                 className="w-full"
-                disabled={policeSignupMutation.isPending}
-              >
-                {policeSignupMutation.isPending
-                  ? "Creating Account..."
-                  : "Create Account"}
-              </Button>
+              />
 
               <p className="text-center text-sm text-muted-foreground">
                 Already have an account?{" "}

--- a/frontend/src/app/police/_components/PartyCard.tsx
+++ b/frontend/src/app/police/_components/PartyCard.tsx
@@ -2,6 +2,7 @@
 
 import { PhoneLink } from "@/components/PhoneLink";
 import IncidentFlag from "@/components/icons/IncidentFlag";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -160,14 +161,16 @@ const PartyCard = memo(function PartyCard({
           </div>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="icon-sm"
                 onClick={(e) => e.stopPropagation()}
-                className="rounded-md p-1 text-secondary transition-colors hover:bg-accent hover:text-foreground"
+                className="text-secondary hover:text-foreground"
                 aria-label="Open incident menu"
               >
                 <EllipsisVertical height={16} />
-              </button>
+              </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent className="w-52" align="end">
               {INCIDENT_MENU_ITEMS.map(({ severity, label }) => (

--- a/frontend/src/app/police/_components/PartyList.tsx
+++ b/frontend/src/app/police/_components/PartyList.tsx
@@ -117,8 +117,13 @@ const PartyList = ({
         className="flex flex-col flex-1 min-h-0 w-full overflow-y-auto scroll-smooth"
       >
         {exactMatchData && (
-          <section>
-            <h2 className="px-4 pt-4 subhead-content">Exact Match:</h2>
+          <section aria-labelledby="party-list-exact-match">
+            <h2
+              id="party-list-exact-match"
+              className="px-4 pt-4 subhead-content"
+            >
+              Exact Match:
+            </h2>
             <ul className="list-none">
               <li className="border-b border-border">
                 <PartyCard
@@ -132,7 +137,7 @@ const PartyList = ({
           </section>
         )}
         {parties.length > 0 && (
-          <section>
+          <section aria-label="Nearby parties">
             {exactMatchData && (
               <h2 className="px-4 pt-4 subhead-content">Nearby Parties:</h2>
             )}

--- a/frontend/src/app/police/admin/layout.tsx
+++ b/frontend/src/app/police/admin/layout.tsx
@@ -14,7 +14,7 @@ export default function PoliceAdminLayout({
 }) {
   return (
     <SidebarProvider>
-      <main className="h-full overflow-y-auto lg:overflow-hidden bg-background">
+      <div className="h-full overflow-y-auto lg:overflow-hidden bg-background">
         <div className="container mx-auto px-6 pt-6 pb-2 h-full min-h-0 flex flex-col">
           <header className="mb-4">
             <h1 className="page-title text-secondary">
@@ -23,7 +23,7 @@ export default function PoliceAdminLayout({
           </header>
           <div className="flex-1 min-h-0">{children}</div>
         </div>
-      </main>
+      </div>
       <Sidebar />
     </SidebarProvider>
   );

--- a/frontend/src/app/police/page.tsx
+++ b/frontend/src/app/police/page.tsx
@@ -197,7 +197,7 @@ export default function PolicePage() {
   const showPaginationRow = isPartiesLoading || !error;
 
   return (
-    <main className="h-full overflow-y-auto lg:overflow-hidden px-4 py-4 md:px-6">
+    <div className="h-full overflow-y-auto lg:overflow-hidden px-4 py-4 md:px-6">
       <div className="grid lg:h-full gap-6 lg:grid-cols-[minmax(22rem,34rem)_minmax(0,1fr)]">
         {/* Left panel */}
         <section
@@ -350,6 +350,6 @@ export default function PolicePage() {
           </div>
         </section>
       </div>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/staff/_components/account/AccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTableForm.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { FieldGroup, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -16,7 +18,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 export const accountTableFormSchema = z.object({
@@ -37,111 +40,84 @@ export default function AccountTableForm({
   editData,
   submissionError,
 }: AccountTableFormProps) {
-  const [formData, setFormData] = useState<Partial<AccountTableFormValues>>({
-    email: editData?.email ?? "",
-    role: editData?.role ?? undefined,
+  const form = useForm<AccountTableFormValues>({
+    resolver: zodResolver(accountTableFormSchema),
+    defaultValues: {
+      email: editData?.email ?? "",
+      role: editData?.role ?? undefined,
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = accountTableFormSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await onSubmit(result.data);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const updateField = <K extends keyof AccountTableFormValues>(
-    field: K,
-    value: AccountTableFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[field];
-        return newErrors;
-      });
-    }
-  };
+  const isSubmitting = form.formState.isSubmitting;
 
   const isEditMode = !!editData;
   return (
-    <form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <FieldSet>
-          <Field data-invalid={!!errors.email}>
-            <FieldLabel htmlFor="email">Email</FieldLabel>
-            <Input
-              id="email"
-              type="email"
-              placeholder="staff@unc.edu"
-              value={formData.email}
-              onChange={(e) => updateField("email", e.target.value)}
-              aria-invalid={!!errors.email}
-              disabled={isEditMode}
-              title={
-                isEditMode
-                  ? "Email cannot be changed after invite is sent"
-                  : undefined
-              }
-              autoComplete="off"
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FieldGroup>
+          <FieldSet>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder="staff@unc.edu"
+                      disabled={isEditMode}
+                      title={
+                        isEditMode
+                          ? "Email cannot be changed after invite is sent"
+                          : undefined
+                      }
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.email && <FieldError>{errors.email}</FieldError>}
-          </Field>
 
-          <Field data-invalid={!!errors.role}>
-            <FieldLabel htmlFor="role">Role</FieldLabel>
-            <Select
-              value={formData.role}
-              onValueChange={(value) =>
-                updateField("role", value as "staff" | "admin")
-              }
-            >
-              <SelectTrigger id="role">
-                <SelectValue placeholder="Select role" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="staff">Staff</SelectItem>
-                <SelectItem value="admin">Admin</SelectItem>
-              </SelectContent>
-            </Select>
-            {errors.role && <FieldError>{errors.role}</FieldError>}
-          </Field>
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select role" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="staff">Staff</SelectItem>
+                      <SelectItem value="admin">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-          <Field orientation="vertical" className="space-y-3">
-            {submissionError && (
-              <div
-                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                role="alert"
-              >
-                {submissionError}
-              </div>
-            )}
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Submitting..." : "Send Invite"}
-            </Button>
-          </Field>
-        </FieldSet>
-      </FieldGroup>
-    </form>
+            <div className="space-y-3">
+              {submissionError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Submitting..." : "Send Invite"}
+              </Button>
+            </div>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/app/staff/_components/account/AccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTableForm.tsx
@@ -102,7 +102,7 @@ export default function AccountTableForm({
               )}
             />
 
-            <div className="space-y-3">
+            <div className="space-y-3 *:w-full">
               {submissionError && (
                 <div
                   className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"

--- a/frontend/src/app/staff/_components/account/AccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTableForm.tsx
@@ -1,23 +1,7 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { FieldGroup, FieldSet } from "@/components/ui/field";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { FormShell } from "@/components/form/FormShell";
+import { SelectField, TextField } from "@/components/form/fields";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -47,77 +31,41 @@ export default function AccountTableForm({
       role: editData?.role ?? undefined,
     },
   });
-  const isSubmitting = form.formState.isSubmitting;
 
   const isEditMode = !!editData;
+
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
-        <FieldGroup>
-          <FieldSet>
-            <FormField
-              control={form.control}
-              name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Email</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="email"
-                      placeholder="staff@unc.edu"
-                      disabled={isEditMode}
-                      title={
-                        isEditMode
-                          ? "Email cannot be changed after invite is sent"
-                          : undefined
-                      }
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <FormShell
+      form={form}
+      onSubmit={onSubmit}
+      submitLabel="Send Invite"
+      submissionError={submissionError}
+    >
+      <TextField
+        control={form.control}
+        name="email"
+        label="Email"
+        type="email"
+        placeholder="staff@unc.edu"
+        disabled={isEditMode}
+        title={
+          isEditMode
+            ? "Email cannot be changed after invite is sent"
+            : undefined
+        }
+        autoComplete="off"
+      />
 
-            <FormField
-              control={form.control}
-              name="role"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Role</FormLabel>
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select role" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="staff">Staff</SelectItem>
-                      <SelectItem value="admin">Admin</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="space-y-3 *:w-full">
-              {submissionError && (
-                <div
-                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                  role="alert"
-                >
-                  {submissionError}
-                </div>
-              )}
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Submitting..." : "Send Invite"}
-              </Button>
-            </div>
-          </FieldSet>
-        </FieldGroup>
-      </form>
-    </Form>
+      <SelectField
+        control={form.control}
+        name="role"
+        label="Role"
+        placeholder="Select role"
+        options={[
+          { value: "staff", label: "Staff" },
+          { value: "admin", label: "Admin" },
+        ]}
+      />
+    </FormShell>
   );
 }

--- a/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { FieldGroup, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -17,7 +19,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PoliceRole } from "@/lib/api/police/police.types";
-import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 export const policeAccountFormSchema = z.object({
@@ -41,134 +44,110 @@ export default function PoliceAccountTableForm({
   submissionError,
   disableVerificationToggle = false,
 }: Props) {
-  const [formData, setFormData] = useState<Partial<PoliceAccountFormValues>>({
-    email: editData?.email ?? "",
-    role: editData?.role ?? "officer",
-    is_verified: editData?.is_verified ?? false,
+  const form = useForm<PoliceAccountFormValues>({
+    resolver: zodResolver(policeAccountFormSchema),
+    defaultValues: {
+      email: editData?.email ?? "",
+      role: editData?.role ?? "officer",
+      is_verified: editData?.is_verified ?? false,
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = policeAccountFormSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await onSubmit(result.data);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const updateField = <K extends keyof PoliceAccountFormValues>(
-    field: K,
-    value: PoliceAccountFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[field];
-        return newErrors;
-      });
-    }
-  };
+  const isSubmitting = form.formState.isSubmitting;
 
   return (
-    <form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <FieldSet>
-          <Field data-invalid={!!errors.email}>
-            <FieldLabel htmlFor="police-email">Email</FieldLabel>
-            <Input
-              id="police-email"
-              type="email"
-              placeholder="officer@department.gov"
-              value={formData.email}
-              onChange={(e) => updateField("email", e.target.value)}
-              aria-invalid={!!errors.email}
-              autoComplete="off"
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FieldGroup>
+          <FieldSet>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder="officer@department.gov"
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.email && <FieldError>{errors.email}</FieldError>}
-          </Field>
 
-          <Field data-invalid={!!errors.role}>
-            <FieldLabel htmlFor="police-role">Role</FieldLabel>
-            <Select
-              value={formData.role}
-              onValueChange={(value) =>
-                updateField("role", value as PoliceAccountFormValues["role"])
-              }
-            >
-              <SelectTrigger id="police-role" aria-invalid={!!errors.role}>
-                <SelectValue placeholder="Select role" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="officer">Officer</SelectItem>
-                <SelectItem value="police_admin">Police Admin</SelectItem>
-              </SelectContent>
-            </Select>
-            {errors.role && <FieldError>{errors.role}</FieldError>}
-          </Field>
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select role" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="officer">Officer</SelectItem>
+                      <SelectItem value="police_admin">Police Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-          <Field
-            orientation="vertical"
-            data-disabled={disableVerificationToggle}
-          >
-            <FieldLabel htmlFor="police-is-verified">Status</FieldLabel>
-            <Select
-              value={String(!!formData.is_verified)}
-              onValueChange={(value) =>
-                updateField("is_verified", value === "true")
-              }
-              disabled={disableVerificationToggle}
-            >
-              <SelectTrigger
-                id="police-is-verified"
-                title={
-                  disableVerificationToggle
-                    ? "Only OCSL admins can change this field"
-                    : undefined
-                }
-              >
-                <SelectValue placeholder="Select verification status" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="true">Active</SelectItem>
-                <SelectItem value="false">Unverified</SelectItem>
-              </SelectContent>
-            </Select>
-          </Field>
+            <FormField
+              control={form.control}
+              name="is_verified"
+              render={({ field }) => (
+                <FormItem data-disabled={disableVerificationToggle}>
+                  <FormLabel>Status</FormLabel>
+                  <Select
+                    value={String(!!field.value)}
+                    onValueChange={(value) => field.onChange(value === "true")}
+                    disabled={disableVerificationToggle}
+                  >
+                    <FormControl>
+                      <SelectTrigger
+                        title={
+                          disableVerificationToggle
+                            ? "Only OCSL admins can change this field"
+                            : undefined
+                        }
+                      >
+                        <SelectValue placeholder="Select verification status" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="true">Active</SelectItem>
+                      <SelectItem value="false">Unverified</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-          <Field orientation="vertical" className="space-y-3">
-            {submissionError && (
-              <div
-                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                role="alert"
-              >
-                {submissionError}
-              </div>
-            )}
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Submitting..." : "Save Changes"}
-            </Button>
-          </Field>
-        </FieldSet>
-      </FieldGroup>
-    </form>
+            <div className="space-y-3">
+              {submissionError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Submitting..." : "Save Changes"}
+              </Button>
+            </div>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
@@ -132,7 +132,7 @@ export default function PoliceAccountTableForm({
               )}
             />
 
-            <div className="space-y-3">
+            <div className="space-y-3 *:w-full">
               {submissionError && (
                 <div
                   className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"

--- a/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
@@ -1,28 +1,13 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { FieldGroup, FieldSet } from "@/components/ui/field";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { FormShell } from "@/components/form/FormShell";
+import { SelectField, TextField } from "@/components/form/fields";
 import { PoliceRole } from "@/lib/api/police/police.types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 
+// Exported schema/type: is_verified is a boolean — this is what callers expect.
 export const policeAccountFormSchema = z.object({
   email: z.email({ pattern: z.regexes.html5Email }).min(1, "Email is required"),
   role: z.enum(["officer", "police_admin"]),
@@ -30,6 +15,16 @@ export const policeAccountFormSchema = z.object({
 });
 
 export type PoliceAccountFormValues = z.infer<typeof policeAccountFormSchema>;
+
+// Internal form schema: is_verified as a string enum so SelectField can bind
+// it directly. handleValid converts back to boolean before calling onSubmit.
+const formSchema = z.object({
+  email: z.email({ pattern: z.regexes.html5Email }).min(1, "Email is required"),
+  role: z.enum(["officer", "police_admin"]),
+  is_verified: z.enum(["true", "false"]),
+});
+
+type FormValues = z.infer<typeof formSchema>;
 
 interface Props {
   onSubmit: (data: PoliceAccountFormValues) => void | Promise<void>;
@@ -44,110 +39,61 @@ export default function PoliceAccountTableForm({
   submissionError,
   disableVerificationToggle = false,
 }: Props) {
-  const form = useForm<PoliceAccountFormValues>({
-    resolver: zodResolver(policeAccountFormSchema),
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       email: editData?.email ?? "",
       role: editData?.role ?? "officer",
-      is_verified: editData?.is_verified ?? false,
+      is_verified: editData?.is_verified ? "true" : "false",
     },
   });
-  const isSubmitting = form.formState.isSubmitting;
+
+  const handleValid = (data: FormValues) =>
+    onSubmit({ ...data, is_verified: data.is_verified === "true" });
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
-        <FieldGroup>
-          <FieldSet>
-            <FormField
-              control={form.control}
-              name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Email</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="email"
-                      placeholder="officer@department.gov"
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <FormShell
+      form={form}
+      onSubmit={handleValid}
+      submitLabel="Save Changes"
+      submissionError={submissionError}
+    >
+      <TextField
+        control={form.control}
+        name="email"
+        label="Email"
+        type="email"
+        placeholder="officer@department.gov"
+        autoComplete="off"
+      />
 
-            <FormField
-              control={form.control}
-              name="role"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Role</FormLabel>
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select role" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="officer">Officer</SelectItem>
-                      <SelectItem value="police_admin">Police Admin</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <SelectField
+        control={form.control}
+        name="role"
+        label="Role"
+        placeholder="Select role"
+        options={[
+          { value: "officer", label: "Officer" },
+          { value: "police_admin", label: "Police Admin" },
+        ]}
+      />
 
-            <FormField
-              control={form.control}
-              name="is_verified"
-              render={({ field }) => (
-                <FormItem data-disabled={disableVerificationToggle}>
-                  <FormLabel>Status</FormLabel>
-                  <Select
-                    value={String(!!field.value)}
-                    onValueChange={(value) => field.onChange(value === "true")}
-                    disabled={disableVerificationToggle}
-                  >
-                    <FormControl>
-                      <SelectTrigger
-                        title={
-                          disableVerificationToggle
-                            ? "Only OCSL admins can change this field"
-                            : undefined
-                        }
-                      >
-                        <SelectValue placeholder="Select verification status" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="true">Active</SelectItem>
-                      <SelectItem value="false">Unverified</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="space-y-3 *:w-full">
-              {submissionError && (
-                <div
-                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                  role="alert"
-                >
-                  {submissionError}
-                </div>
-              )}
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Submitting..." : "Save Changes"}
-              </Button>
-            </div>
-          </FieldSet>
-        </FieldGroup>
-      </form>
-    </Form>
+      <SelectField
+        control={form.control}
+        name="is_verified"
+        label="Status"
+        placeholder="Select verification status"
+        disabled={disableVerificationToggle}
+        triggerTitle={
+          disableVerificationToggle
+            ? "Only OCSL admins can change this field"
+            : undefined
+        }
+        options={[
+          { value: "true", label: "Active" },
+          { value: "false", label: "Unverified" },
+        ]}
+      />
+    </FormShell>
   );
 }

--- a/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
@@ -3,14 +3,16 @@
 import AddressSearch from "@/components/AddressSearch";
 import DatePicker from "@/components/DatePicker";
 import { Button } from "@/components/ui/button";
+import { FieldGroup, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -28,8 +30,9 @@ import {
 } from "@/lib/api/incident/incident.types";
 import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
-import { useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 const incidentSeverityValues: IncidentSeverity[] = [
@@ -71,207 +74,185 @@ export default function IncidentTableForm({
       }
     : null;
 
-  const [formData, setFormData] = useState<IncidentTableFormValues>({
-    location_place_id: editData?.location?.google_place_id ?? "",
-    incident_datetime: editData?.incident_datetime ?? new Date(),
-    incident_time: editData?.incident_datetime
-      ? format(editData.incident_datetime, "HH:mm")
-      : "",
-    severity: editData?.severity ?? "in_person_warning",
-    description: editData?.description ?? "",
-    reference_id: editData?.reference_id ?? null,
+  const form = useForm<IncidentTableFormValues>({
+    resolver: zodResolver(incidentTableFormSchema),
+    defaultValues: {
+      location_place_id: editData?.location?.google_place_id ?? "",
+      incident_datetime: editData?.incident_datetime ?? new Date(),
+      incident_time: editData?.incident_datetime
+        ? format(editData.incident_datetime, "HH:mm")
+        : "",
+      severity: editData?.severity ?? "in_person_warning",
+      description: editData?.description ?? "",
+      reference_id: editData?.reference_id ?? null,
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmitting = form.formState.isSubmitting;
 
-  const updateField = <K extends keyof IncidentTableFormValues>(
-    field: K,
-    value: IncidentTableFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const next = { ...prev };
-        delete next[field];
-        return next;
-      });
-    }
-  };
+  const handleValid = (data: IncidentTableFormValues) => {
+    const [hours, minutes] = data.incident_time.split(":").map(Number);
+    const combined_datetime = new Date(data.incident_datetime);
+    combined_datetime.setHours(hours, minutes, 0, 0);
 
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = incidentTableFormSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      const { incident_datetime, incident_time } = result.data;
-      const [hours, minutes] = incident_time.split(":").map(Number);
-      const combined_datetime = new Date(incident_datetime);
-      combined_datetime.setHours(hours, minutes, 0, 0);
-
-      await onSubmit({
-        location_place_id: result.data.location_place_id,
-        incident_datetime: combined_datetime,
-        description: result.data.description,
-        severity: result.data.severity,
-        reference_id: result.data.reference_id || null,
-      });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleAddressSelect = (address: AutocompleteResult | null) => {
-    setFormData((prev) => ({
-      ...prev,
-      location_place_id: address?.google_place_id || "",
-    }));
-    if (errors.location_place_id) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.location_place_id;
-        return newErrors;
-      });
-    }
+    return onSubmit({
+      location_place_id: data.location_place_id,
+      incident_datetime: combined_datetime,
+      description: data.description,
+      severity: data.severity,
+      reference_id: data.reference_id || null,
+    });
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <FieldSet>
-          <Field data-invalid={!!errors.location_place_id}>
-            <FieldLabel>Location</FieldLabel>
-            <AddressSearch
-              value={
-                formData.location_place_id ===
-                editData?.location?.google_place_id
-                  ? (editData?.location?.formatted_address ?? "")
-                  : ""
-              }
-              initialSelection={initialAddressSelection}
-              onSelect={handleAddressSelect}
-              locationService={locationService}
-              placeholder="Search for the location address..."
-              className="w-full"
-              error={errors.location_place_id}
-              chapelHillOnly
-            />
-            {errors.location_place_id && (
-              <FieldError>{errors.location_place_id}</FieldError>
-            )}
-          </Field>
-
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <Field data-invalid={!!errors.incident_datetime}>
-              <FieldLabel htmlFor="incident-date">Incident Date</FieldLabel>
-              <DatePicker
-                id="incident-date"
-                dateFormat="MM/dd/yy"
-                value={formData.incident_datetime ?? null}
-                onChange={(date) =>
-                  updateField("incident_datetime", date as Date)
-                }
-              />
-              {errors.incident_datetime && (
-                <FieldError>{errors.incident_datetime}</FieldError>
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleValid)}>
+        <FieldGroup>
+          <FieldSet>
+            <FormField
+              control={form.control}
+              name="location_place_id"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>Location</FormLabel>
+                  <FormControl>
+                    <AddressSearch
+                      value={
+                        field.value === editData?.location?.google_place_id
+                          ? (editData?.location?.formatted_address ?? "")
+                          : ""
+                      }
+                      initialSelection={initialAddressSelection}
+                      onSelect={(address) =>
+                        field.onChange(address?.google_place_id || "")
+                      }
+                      locationService={locationService}
+                      placeholder="Search for the location address..."
+                      className="w-full"
+                      error={fieldState.error?.message}
+                      chapelHillOnly
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </Field>
+            />
 
-            <Field data-invalid={!!errors.incident_time}>
-              <FieldLabel htmlFor="incident-time">Incident Time</FieldLabel>
-              <Input
-                id="incident-time"
-                type="time"
-                value={formData.incident_time}
-                onChange={(e) => updateField("incident_time", e.target.value)}
-                aria-invalid={!!errors.incident_time}
-                autoComplete="off"
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="incident_datetime"
+                render={({ field, fieldState }) => (
+                  <FormItem>
+                    <FormLabel>Incident Date</FormLabel>
+                    <FormControl>
+                      <DatePicker
+                        dateFormat="MM/dd/yy"
+                        value={field.value ?? null}
+                        onChange={field.onChange}
+                        aria-invalid={fieldState.invalid}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-              {errors.incident_time && (
-                <FieldError>{errors.incident_time}</FieldError>
+
+              <FormField
+                control={form.control}
+                name="incident_time"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Incident Time</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="time" autoComplete="off" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="severity"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Severity</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select severity" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {incidentSeverityValues.map((severity) => (
+                        <SelectItem key={severity} value={severity}>
+                          {INCIDENT_SEVERITY_LABELS[severity]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
               )}
-            </Field>
-          </div>
-
-          <Field data-invalid={!!errors.severity}>
-            <FieldLabel>Severity</FieldLabel>
-            <Select
-              value={formData.severity}
-              onValueChange={(value) =>
-                updateField("severity", value as IncidentSeverity)
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select severity" />
-              </SelectTrigger>
-              <SelectContent>
-                {incidentSeverityValues.map((severity) => (
-                  <SelectItem key={severity} value={severity}>
-                    {INCIDENT_SEVERITY_LABELS[severity]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.severity && <FieldError>{errors.severity}</FieldError>}
-          </Field>
-
-          <Field data-invalid={!!errors.reference_id}>
-            <FieldLabel>Reference ID</FieldLabel>
-            <Input
-              value={formData.reference_id ?? ""}
-              onChange={(e) => updateField("reference_id", e.target.value)}
-              placeholder="Optional"
-              autoComplete="off"
             />
-            <FieldDescription>
-              Add a ticket or report ID if one exists.
-            </FieldDescription>
-            {errors.reference_id && (
-              <FieldError>{errors.reference_id}</FieldError>
-            )}
-          </Field>
 
-          <Field data-invalid={!!errors.description}>
-            <FieldLabel>Description</FieldLabel>
-            <Textarea
-              value={formData.description ?? ""}
-              onChange={(e) => updateField("description", e.target.value)}
-              placeholder="Optional"
-              className=" w-full min-h-24 px-3 py-2 rounded-md border border-input bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-vertical shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 "
+            <FormField
+              control={form.control}
+              name="reference_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Reference ID</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ""}
+                      placeholder="Optional"
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Add a ticket or report ID if one exists.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.description && (
-              <FieldError>{errors.description}</FieldError>
-            )}
-          </Field>
 
-          <Field orientation="vertical" className="space-y-3">
-            {submissionError && (
-              <div
-                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                role="alert"
-              >
-                {submissionError}
-              </div>
-            )}
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Submitting..." : "Save"}
-            </Button>
-          </Field>
-        </FieldSet>
-      </FieldGroup>
-    </form>
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder="Optional"
+                      className=" w-full min-h-24 px-3 py-2 rounded-md border border-input bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-vertical shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 "
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="space-y-3">
+              {submissionError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Submitting..." : "Save"}
+              </Button>
+            </div>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
@@ -28,7 +28,6 @@ import {
   IncidentDto,
   IncidentSeverity,
 } from "@/lib/api/incident/incident.types";
-import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
@@ -65,8 +64,6 @@ export default function IncidentTableForm({
   editData,
   submissionError,
 }: IncidentTableFormProps) {
-  const locationService = new LocationService();
-
   const initialAddressSelection: AutocompleteResult | null = editData?.location
     ? {
         formatted_address: editData.location.formatted_address,
@@ -125,7 +122,6 @@ export default function IncidentTableForm({
                       onSelect={(address) =>
                         field.onChange(address?.google_place_id || "")
                       }
-                      locationService={locationService}
                       placeholder="Search for the location address..."
                       className="w-full"
                       error={fieldState.error?.message}
@@ -237,7 +233,7 @@ export default function IncidentTableForm({
               )}
             />
 
-            <div className="space-y-3">
+            <div className="space-y-3 *:w-full">
               {submissionError && (
                 <div
                   className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"

--- a/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
@@ -1,27 +1,13 @@
 "use client";
 
-import AddressSearch from "@/components/AddressSearch";
-import DatePicker from "@/components/DatePicker";
-import { Button } from "@/components/ui/button";
-import { FieldGroup, FieldSet } from "@/components/ui/field";
+import { FormShell } from "@/components/form/FormShell";
 import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
+  AddressField,
+  DateField,
+  SelectField,
+  TextField,
+  TextareaField,
+} from "@/components/form/fields";
 import {
   INCIDENT_SEVERITY_LABELS,
   IncidentCreateDto,
@@ -42,9 +28,7 @@ const incidentSeverityValues: IncidentSeverity[] = [
 
 const incidentTableFormSchema = z.object({
   location_place_id: z.string().min(1, "Location is required"),
-  incident_datetime: z.date({
-    message: "Incident date is required",
-  }),
+  incident_datetime: z.date({ message: "Incident date is required" }),
   incident_time: z.string().min(1, "Incident time is required"),
   severity: z.enum(incidentSeverityValues),
   description: z.string(),
@@ -84,7 +68,6 @@ export default function IncidentTableForm({
       reference_id: editData?.reference_id ?? null,
     },
   });
-  const isSubmitting = form.formState.isSubmitting;
 
   const handleValid = (data: IncidentTableFormValues) => {
     const [hours, minutes] = data.incident_time.split(":").map(Number);
@@ -101,154 +84,65 @@ export default function IncidentTableForm({
   };
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleValid)}>
-        <FieldGroup>
-          <FieldSet>
-            <FormField
-              control={form.control}
-              name="location_place_id"
-              render={({ field, fieldState }) => (
-                <FormItem>
-                  <FormLabel>Location</FormLabel>
-                  <FormControl>
-                    <AddressSearch
-                      value={
-                        field.value === editData?.location?.google_place_id
-                          ? (editData?.location?.formatted_address ?? "")
-                          : ""
-                      }
-                      initialSelection={initialAddressSelection}
-                      onSelect={(address) =>
-                        field.onChange(address?.google_place_id || "")
-                      }
-                      placeholder="Search for the location address..."
-                      className="w-full"
-                      error={fieldState.error?.message}
-                      chapelHillOnly
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <FormShell
+      form={form}
+      onSubmit={handleValid}
+      submitLabel="Save"
+      submissionError={submissionError}
+    >
+      <AddressField
+        control={form.control}
+        name="location_place_id"
+        label="Location"
+        placeholder="Search for the location address..."
+        chapelHillOnly
+        initialSelection={initialAddressSelection}
+        getStoredValue={(address) => address?.google_place_id || ""}
+      />
 
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <FormField
-                control={form.control}
-                name="incident_datetime"
-                render={({ field, fieldState }) => (
-                  <FormItem>
-                    <FormLabel>Incident Date</FormLabel>
-                    <FormControl>
-                      <DatePicker
-                        dateFormat="MM/dd/yy"
-                        value={field.value ?? null}
-                        onChange={field.onChange}
-                        aria-invalid={fieldState.invalid}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <DateField
+          control={form.control}
+          name="incident_datetime"
+          label="Incident Date"
+          dateFormat="MM/dd/yy"
+        />
+        <TextField
+          control={form.control}
+          name="incident_time"
+          label="Incident Time"
+          type="time"
+          autoComplete="off"
+        />
+      </div>
 
-              <FormField
-                control={form.control}
-                name="incident_time"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Incident Time</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="time" autoComplete="off" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+      <SelectField
+        control={form.control}
+        name="severity"
+        label="Severity"
+        placeholder="Select severity"
+        options={incidentSeverityValues.map((severity) => ({
+          value: severity,
+          label: INCIDENT_SEVERITY_LABELS[severity],
+        }))}
+      />
 
-            <FormField
-              control={form.control}
-              name="severity"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Severity</FormLabel>
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select severity" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {incidentSeverityValues.map((severity) => (
-                        <SelectItem key={severity} value={severity}>
-                          {INCIDENT_SEVERITY_LABELS[severity]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <TextField
+        control={form.control}
+        name="reference_id"
+        label="Reference ID"
+        placeholder="Optional"
+        autoComplete="off"
+        description="Add a ticket or report ID if one exists."
+      />
 
-            <FormField
-              control={form.control}
-              name="reference_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Reference ID</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      value={field.value ?? ""}
-                      placeholder="Optional"
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Add a ticket or report ID if one exists.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Description</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      placeholder="Optional"
-                      className=" w-full min-h-24 px-3 py-2 rounded-md border border-input bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-vertical shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 "
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="space-y-3 *:w-full">
-              {submissionError && (
-                <div
-                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                  role="alert"
-                >
-                  {submissionError}
-                </div>
-              )}
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Submitting..." : "Save"}
-              </Button>
-            </div>
-          </FieldSet>
-        </FieldGroup>
-      </form>
-    </Form>
+      <TextareaField
+        control={form.control}
+        name="description"
+        label="Description"
+        placeholder="Optional"
+        textareaClassName=" w-full min-h-24 px-3 py-2 rounded-md border border-input bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-vertical shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 "
+      />
+    </FormShell>
   );
 }

--- a/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
+++ b/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
@@ -51,8 +51,11 @@ const IncidentSidebarCard = memo(function IncidentSidebarCard({
             </CollapsibleTrigger>
             {role === "admin" && (
               <DropdownMenu>
-                <DropdownMenuTrigger className="ml-2">
-                  <MoreHorizontal className="size-4" />
+                <DropdownMenuTrigger
+                  className="ml-2"
+                  aria-label="Incident options"
+                >
+                  <MoreHorizontal className="size-4" aria-hidden="true" />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
                   <DropdownMenuItem

--- a/frontend/src/app/staff/_components/location/LocationTable.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTable.tsx
@@ -124,12 +124,12 @@ export const LocationTable = () => {
         },
       },
       cell: ({ row }) => {
-        const holdDate = row.getValue("hold_expiration") as Date | null;
+        const holdDate = row.getValue<Date | null>("hold_expiration");
         if (holdDate) {
-          const formattedDate = format(new Date(holdDate), "MM-dd-yyyy");
+          const formattedDate = format(holdDate, "M/dd/yyyy");
           return `Expires: ${formattedDate}`;
         }
-        return "No";
+        return "None";
       },
     },
   ];

--- a/frontend/src/app/staff/_components/location/LocationTableForm.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTableForm.tsx
@@ -1,18 +1,7 @@
 "use client";
 
-import AddressSearch from "@/components/AddressSearch";
-import DatePicker from "@/components/DatePicker";
-import { Button } from "@/components/ui/button";
-import { FieldGroup, FieldSet } from "@/components/ui/field";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
+import { FormShell } from "@/components/form/FormShell";
+import { AddressField, DateField } from "@/components/form/fields";
 import {
   HoverCard,
   HoverCardContent,
@@ -66,102 +55,54 @@ export default function LocationTableForm({
       holdExpiration: editData?.holdExpiration ?? null,
     },
   });
-  const isSubmitting = form.formState.isSubmitting;
-
-  const handleAddressSelect = (address: AutocompleteResult | null) => {
-    form.setValue("address", address?.formatted_address || "", {
-      shouldValidate: true,
-    });
-    form.setValue("placeId", address?.google_place_id || "", {
-      shouldValidate: true,
-    });
-  };
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
-        <FieldGroup>
-          <FieldSet>
-            <FormField
-              control={form.control}
-              name="address"
-              render={({ field, fieldState }) => (
-                <FormItem>
-                  <FormLabel>Address</FormLabel>
-                  <FormControl>
-                    <AddressSearch
-                      value={field.value}
-                      initialSelection={initialAddressSelection}
-                      onSelect={handleAddressSelect}
-                      placeholder="Search for the location address..."
-                      className="w-full"
-                      error={fieldState.error?.message}
-                      chapelHillOnly
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <FormShell
+      form={form}
+      onSubmit={onSubmit}
+      submitLabel="Save Changes"
+      submissionError={submissionError}
+    >
+      <AddressField
+        control={form.control}
+        name="address"
+        label="Address"
+        placeholder="Search for the location address..."
+        chapelHillOnly
+        initialSelection={initialAddressSelection}
+        onSelect={(address) =>
+          form.setValue("placeId", address?.google_place_id || "", {
+            shouldValidate: true,
+          })
+        }
+      />
 
-            <FormField
-              control={form.control}
-              name="holdExpiration"
-              render={({ field, fieldState }) => (
-                <FormItem>
-                  <FormLabel className="flex items-center gap-1">
-                    Hold Expiration
-                    <HoverCard>
-                      <HoverCardTrigger asChild>
-                        <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
-                      </HoverCardTrigger>
-                      <HoverCardContent className="max-w-64">
-                        A location has an active hold when a hold expiration
-                        date is set and has not yet passed. An active hold
-                        prevents students from registering parties at this
-                        location.
-                      </HoverCardContent>
-                    </HoverCard>
-                  </FormLabel>
-                  <FormControl>
-                    <DatePicker
-                      value={field.value}
-                      onChange={field.onChange}
-                      aria-invalid={fieldState.invalid}
-                      disabled={(date) =>
-                        !isAfter(
-                          startOfDay(date),
-                          addBusinessDays(startOfDay(new Date()), 1)
-                        )
-                      }
-                      forwardDate={true}
-                      clearable
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Leave blank if there is no hold on this location.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="space-y-3 *:w-full">
-              {submissionError && (
-                <div
-                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                  role="alert"
-                >
-                  {submissionError}
-                </div>
-              )}
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Submitting..." : "Save Changes"}
-              </Button>
-            </div>
-          </FieldSet>
-        </FieldGroup>
-      </form>
-    </Form>
+      <DateField
+        control={form.control}
+        name="holdExpiration"
+        labelClassName="flex items-center gap-1"
+        label={
+          <>
+            Hold Expiration
+            <HoverCard>
+              <HoverCardTrigger asChild>
+                <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
+              </HoverCardTrigger>
+              <HoverCardContent className="max-w-64">
+                A location has an active hold when a hold expiration date is set
+                and has not yet passed. An active hold prevents students from
+                registering parties at this location.
+              </HoverCardContent>
+            </HoverCard>
+          </>
+        }
+        description="Leave blank if there is no hold on this location."
+        forwardDate={true}
+        clearable
+        disabled={(date) =>
+          !isAfter(startOfDay(date), addBusinessDays(startOfDay(new Date()), 1))
+        }
+      />
+    </FormShell>
   );
 }

--- a/frontend/src/app/staff/_components/location/LocationTableForm.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTableForm.tsx
@@ -3,14 +3,16 @@
 import AddressSearch from "@/components/AddressSearch";
 import DatePicker from "@/components/DatePicker";
 import { Button } from "@/components/ui/button";
+import { FieldGroup, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   HoverCard,
   HoverCardContent,
@@ -18,9 +20,10 @@ import {
 } from "@/components/ui/hover-card";
 import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
 import { Info } from "lucide-react";
-import { useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 export const locationTableFormSchema = z.object({
@@ -53,141 +56,115 @@ export default function LocationTableForm({
         }
       : null;
 
-  const [formData, setFormData] = useState<Partial<LocationTableFormValues>>({
-    address: editData?.address ?? "",
-    placeId: editData?.placeId ?? undefined,
-    holdExpiration: editData?.holdExpiration ?? null,
+  const form = useForm<
+    z.input<typeof locationTableFormSchema>,
+    unknown,
+    LocationTableFormValues
+  >({
+    resolver: zodResolver(locationTableFormSchema),
+    defaultValues: {
+      address: editData?.address ?? "",
+      placeId: editData?.placeId ?? "",
+      holdExpiration: editData?.holdExpiration ?? null,
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = locationTableFormSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await onSubmit(result.data);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  const isSubmitting = form.formState.isSubmitting;
 
   const handleAddressSelect = (address: AutocompleteResult | null) => {
-    setFormData((prev) => ({
-      ...prev,
-      address: address?.formatted_address || "",
-      placeId: address?.google_place_id || undefined,
-    }));
-    if (errors.address) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.address;
-        return newErrors;
-      });
-    }
-  };
-
-  const updateField = <K extends keyof LocationTableFormValues>(
-    field: K,
-    value: LocationTableFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[field];
-        return newErrors;
-      });
-    }
+    form.setValue("address", address?.formatted_address || "", {
+      shouldValidate: true,
+    });
+    form.setValue("placeId", address?.google_place_id || "", {
+      shouldValidate: true,
+    });
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <FieldSet>
-          <Field data-invalid={!!errors.address}>
-            <FieldLabel htmlFor="address">Address</FieldLabel>
-            <AddressSearch
-              id="address"
-              value={formData.address}
-              initialSelection={initialAddressSelection}
-              onSelect={handleAddressSelect}
-              locationService={locationService}
-              placeholder="Search for the location address..."
-              className="w-full"
-              error={errors.address}
-              chapelHillOnly
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FieldGroup>
+          <FieldSet>
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>Address</FormLabel>
+                  <FormControl>
+                    <AddressSearch
+                      value={field.value}
+                      initialSelection={initialAddressSelection}
+                      onSelect={handleAddressSelect}
+                      locationService={locationService}
+                      placeholder="Search for the location address..."
+                      className="w-full"
+                      error={fieldState.error?.message}
+                      chapelHillOnly
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.address && <FieldError>{errors.address}</FieldError>}
-          </Field>
 
-          <Field data-invalid={!!errors.holdExpiration}>
-            <FieldLabel
-              htmlFor="hold-expiration"
-              className="flex items-center gap-1"
-            >
-              Hold Expiration
-              <HoverCard>
-                <HoverCardTrigger asChild>
-                  <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-w-64">
-                  A location has an active hold when a hold expiration date is
-                  set and has not yet passed. An active hold prevents students
-                  from registering parties at this location.
-                </HoverCardContent>
-              </HoverCard>
-            </FieldLabel>
-            <DatePicker
-              id="hold-expiration"
-              value={formData.holdExpiration}
-              onChange={(date) => updateField("holdExpiration", date)}
-              disabled={(date) =>
-                !isAfter(
-                  startOfDay(date),
-                  addBusinessDays(startOfDay(new Date()), 1)
-                )
-              }
-              forwardDate={true}
-              clearable
+            <FormField
+              control={form.control}
+              name="holdExpiration"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel className="flex items-center gap-1">
+                    Hold Expiration
+                    <HoverCard>
+                      <HoverCardTrigger asChild>
+                        <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
+                      </HoverCardTrigger>
+                      <HoverCardContent className="max-w-64">
+                        A location has an active hold when a hold expiration
+                        date is set and has not yet passed. An active hold
+                        prevents students from registering parties at this
+                        location.
+                      </HoverCardContent>
+                    </HoverCard>
+                  </FormLabel>
+                  <FormControl>
+                    <DatePicker
+                      value={field.value}
+                      onChange={field.onChange}
+                      aria-invalid={fieldState.invalid}
+                      disabled={(date) =>
+                        !isAfter(
+                          startOfDay(date),
+                          addBusinessDays(startOfDay(new Date()), 1)
+                        )
+                      }
+                      forwardDate={true}
+                      clearable
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Leave blank if there is no hold on this location.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            <FieldDescription>
-              Leave blank if there is no hold on this location.
-            </FieldDescription>
-            {errors.holdExpiration && (
-              <FieldError>{errors.holdExpiration}</FieldError>
-            )}
-          </Field>
 
-          <Field orientation="vertical" className="space-y-3">
-            {submissionError && (
-              <div
-                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                role="alert"
-              >
-                {submissionError}
-              </div>
-            )}
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Submitting..." : "Save Changes"}
-            </Button>
-          </Field>
-        </FieldSet>
-      </FieldGroup>
-    </form>
+            <div className="space-y-3">
+              {submissionError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Submitting..." : "Save Changes"}
+              </Button>
+            </div>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/app/staff/_components/location/LocationTableForm.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTableForm.tsx
@@ -18,7 +18,6 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
@@ -47,7 +46,6 @@ export default function LocationTableForm({
   editData,
   submissionError,
 }: LocationTableFormProps) {
-  const locationService = new LocationService();
   const initialAddressSelection: AutocompleteResult | null =
     editData?.address && editData?.placeId
       ? {
@@ -95,7 +93,6 @@ export default function LocationTableForm({
                       value={field.value}
                       initialSelection={initialAddressSelection}
                       onSelect={handleAddressSelect}
-                      locationService={locationService}
                       placeholder="Search for the location address..."
                       className="w-full"
                       error={fieldState.error?.message}
@@ -149,7 +146,7 @@ export default function LocationTableForm({
               )}
             />
 
-            <div className="space-y-3">
+            <div className="space-y-3 *:w-full">
               {submissionError && (
                 <div
                   className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"

--- a/frontend/src/app/staff/_components/party/PartyTableForm.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTableForm.tsx
@@ -21,10 +21,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { PARTY_RULE_MESSAGES, PartyDto } from "@/lib/api/party/party.types";
-import { AdminStudentService } from "@/lib/api/student/admin-student.service";
 import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, format, isAfter, startOfDay } from "date-fns";
@@ -96,8 +94,6 @@ export default function PartyTableForm({
 }: PartyTableFormProps) {
   const { data: session } = useSession();
   const isAdmin = session?.role === "admin";
-  const locationService = useMemo(() => new LocationService(), []);
-  const adminStudentService = useMemo(() => new AdminStudentService(), []);
 
   const partyTableFormSchema = useMemo(
     () => createPartyTableFormSchema(isAdmin),
@@ -158,7 +154,6 @@ export default function PartyTableForm({
                           : null
                       }
                       onSelect={handleAddressSelect}
-                      locationService={locationService}
                       placeholder="Search for the party address..."
                       className="w-full"
                       error={fieldState.error?.message}
@@ -237,7 +232,6 @@ export default function PartyTableForm({
                       onSelect={(student) =>
                         field.onChange(student?.student_id ?? undefined)
                       }
-                      adminStudentService={adminStudentService}
                       placeholder="Search by name, PID, email, onyen, etc..."
                       className="w-full"
                       error={fieldState.error?.message}
@@ -360,7 +354,7 @@ export default function PartyTableForm({
               />
             </FieldSet>
 
-            <div className="space-y-3">
+            <div className="space-y-3 *:w-full">
               {submissionError && (
                 <div
                   className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"

--- a/frontend/src/app/staff/_components/party/PartyTableForm.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTableForm.tsx
@@ -4,14 +4,15 @@ import AddressSearch from "@/components/AddressSearch";
 import DatePicker from "@/components/DatePicker";
 import StudentSearch from "@/components/StudentSearch";
 import { Button } from "@/components/ui/button";
+import { FieldGroup, FieldLegend, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -24,11 +25,12 @@ import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { PARTY_RULE_MESSAGES, PartyDto } from "@/lib/api/party/party.types";
 import { AdminStudentService } from "@/lib/api/student/admin-student.service";
-import { StudentSuggestionDto } from "@/lib/api/student/student.types";
 import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, format, isAfter, startOfDay } from "date-fns";
 import { useSession } from "next-auth/react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 export const createPartyTableFormSchema = (isAdmin: boolean) => {
@@ -77,6 +79,9 @@ export const createPartyTableFormSchema = (isAdmin: boolean) => {
 export type PartyTableFormValues = z.infer<
   ReturnType<typeof createPartyTableFormSchema>
 >;
+type PartyTableFormInput = z.input<
+  ReturnType<typeof createPartyTableFormSchema>
+>;
 
 interface PartyTableFormProps {
   onSubmit: (data: PartyTableFormValues) => void | Promise<void>;
@@ -94,309 +99,283 @@ export default function PartyTableForm({
   const locationService = useMemo(() => new LocationService(), []);
   const adminStudentService = useMemo(() => new AdminStudentService(), []);
 
-  const partyTableFormSchema = createPartyTableFormSchema(isAdmin);
+  const partyTableFormSchema = useMemo(
+    () => createPartyTableFormSchema(isAdmin),
+    [isAdmin]
+  );
 
-  const [formData, setFormData] = useState<Partial<PartyTableFormValues>>({
-    address: editData?.location.formatted_address ?? "",
-    placeId: editData?.location.google_place_id ?? undefined,
-    partyDate: editData?.party_datetime ?? undefined,
-    partyTime: editData?.party_datetime
-      ? format(editData.party_datetime, "HH:mm")
-      : "",
-    contactOneStudentId: editData?.contact_one.id ?? undefined,
-    contactTwoEmail: editData?.contact_two.email ?? "",
-    contactTwoFirstName: editData?.contact_two.first_name ?? "",
-    contactTwoLastName: editData?.contact_two.last_name ?? "",
-    contactTwoPhoneNumber: editData?.contact_two.phone_number ?? "",
-    contactTwoPreference: editData?.contact_two.contact_preference ?? undefined,
+  const form = useForm<PartyTableFormInput, unknown, PartyTableFormValues>({
+    resolver: zodResolver(partyTableFormSchema),
+    defaultValues: {
+      address: editData?.location.formatted_address ?? "",
+      placeId: editData?.location.google_place_id ?? "",
+      partyDate: editData?.party_datetime ?? undefined,
+      partyTime: editData?.party_datetime
+        ? format(editData.party_datetime, "HH:mm")
+        : "",
+      contactOneStudentId: editData?.contact_one.id ?? undefined,
+      contactTwoEmail: editData?.contact_two.email ?? "",
+      contactTwoFirstName: editData?.contact_two.first_name ?? "",
+      contactTwoLastName: editData?.contact_two.last_name ?? "",
+      contactTwoPhoneNumber: editData?.contact_two.phone_number ?? "",
+      contactTwoPreference:
+        editData?.contact_two.contact_preference ?? undefined,
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = partyTableFormSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await onSubmit(result.data);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleStudentSelect = (student: StudentSuggestionDto | null) => {
-    setFormData((prev) => ({
-      ...prev,
-      contactOneStudentId: student?.student_id ?? undefined,
-    }));
-    if (errors.contactOneStudentId) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.contactOneStudentId;
-        return newErrors;
-      });
-    }
-  };
+  const isSubmitting = form.formState.isSubmitting;
 
   const handleAddressSelect = (address: AutocompleteResult | null) => {
-    setFormData((prev) => ({
-      ...prev,
-      address: address?.formatted_address || "",
-      placeId: address?.google_place_id || undefined,
-    }));
-    if (errors.address) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.address;
-        return newErrors;
-      });
-    }
-  };
-
-  const updateField = <K extends keyof PartyTableFormValues>(
-    field: K,
-    value: PartyTableFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[field];
-        return newErrors;
-      });
-    }
+    form.setValue("address", address?.formatted_address || "", {
+      shouldValidate: true,
+    });
+    form.setValue("placeId", address?.google_place_id || "", {
+      shouldValidate: true,
+    });
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <FieldSet>
-          <Field data-invalid={!!errors.address}>
-            <FieldLabel htmlFor="party-address">Party Address</FieldLabel>
-            <AddressSearch
-              id="party-address"
-              value={formData.address}
-              initialSelection={
-                editData?.location
-                  ? {
-                      formatted_address: editData.location.formatted_address,
-                      google_place_id: editData.location.google_place_id,
-                    }
-                  : null
-              }
-              onSelect={handleAddressSelect}
-              locationService={locationService}
-              placeholder="Search for the party address..."
-              className="w-full"
-              error={errors.address}
-              chapelHillOnly
-            />
-            {errors.address && <FieldError>{errors.address}</FieldError>}
-          </Field>
-
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <Field data-invalid={!!errors.partyDate}>
-              <FieldLabel htmlFor="party-date">Party Date</FieldLabel>
-              <DatePicker
-                id="party-date"
-                dateFormat="MM/dd/yy"
-                value={formData.partyDate ?? null}
-                onChange={(date) => updateField("partyDate", date as Date)}
-                forwardDate={true}
-                disabled={
-                  isAdmin
-                    ? undefined
-                    : (date) =>
-                        !isAfter(
-                          startOfDay(date),
-                          addBusinessDays(startOfDay(new Date()), 1)
-                        )
-                }
-              />
-              {errors.partyDate && <FieldError>{errors.partyDate}</FieldError>}
-            </Field>
-
-            <Field data-invalid={!!errors.partyTime}>
-              <FieldLabel htmlFor="party-time">Party Time</FieldLabel>
-              <Input
-                id="party-time"
-                type="time"
-                value={formData.partyTime}
-                onChange={(e) => updateField("partyTime", e.target.value)}
-                aria-invalid={!!errors.partyTime}
-                autoComplete="off"
-              />
-              {errors.partyTime && <FieldError>{errors.partyTime}</FieldError>}
-            </Field>
-          </div>
-
-          <Field data-invalid={!!errors.contactOneStudentId}>
-            <FieldLabel htmlFor="contact-one-student">First Contact</FieldLabel>
-            <StudentSearch
-              initialSelection={
-                editData?.contact_one
-                  ? {
-                      student_id: editData.contact_one.id,
-                      first_name: editData.contact_one.first_name,
-                      last_name: editData.contact_one.last_name,
-                      matched_field_name: "email",
-                      matched_field_value: editData.contact_one.email,
-                    }
-                  : null
-              }
-              onSelect={handleStudentSelect}
-              adminStudentService={adminStudentService}
-              placeholder="Search by name, PID, email, onyen, etc..."
-              className="w-full"
-              error={errors.contactOneStudentId}
-            />
-            {errors.contactOneStudentId && (
-              <FieldError>{errors.contactOneStudentId}</FieldError>
-            )}
-          </Field>
-
-          <FieldSet className="pt-2">
-            <FieldLegend className="font-semibold text-foreground">
-              Second Contact Information
-            </FieldLegend>
-
-            <Field data-invalid={!!errors.contactTwoEmail}>
-              <FieldLabel htmlFor="contact-two-email">Contact Email</FieldLabel>
-              <Input
-                id="contact-two-email"
-                type="email"
-                placeholder="student@unc.edu"
-                value={formData.contactTwoEmail}
-                onChange={(e) => updateField("contactTwoEmail", e.target.value)}
-                aria-invalid={!!errors.contactTwoEmail}
-                autoComplete="off"
-              />
-              {errors.contactTwoEmail && (
-                <FieldError>{errors.contactTwoEmail}</FieldError>
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FieldGroup>
+          <FieldSet>
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>Party Address</FormLabel>
+                  <FormControl>
+                    <AddressSearch
+                      value={field.value}
+                      initialSelection={
+                        editData?.location
+                          ? {
+                              formatted_address:
+                                editData.location.formatted_address,
+                              google_place_id:
+                                editData.location.google_place_id,
+                            }
+                          : null
+                      }
+                      onSelect={handleAddressSelect}
+                      locationService={locationService}
+                      placeholder="Search for the party address..."
+                      className="w-full"
+                      error={fieldState.error?.message}
+                      chapelHillOnly
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </Field>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Field data-invalid={!!errors.contactTwoFirstName}>
-                <FieldLabel htmlFor="contact-two-first-name">
-                  First Name
-                </FieldLabel>
-                <Input
-                  id="contact-two-first-name"
-                  type="text"
-                  placeholder="John"
-                  value={formData.contactTwoFirstName}
-                  onChange={(e) =>
-                    updateField("contactTwoFirstName", e.target.value)
-                  }
-                  aria-invalid={!!errors.contactTwoFirstName}
-                  autoComplete="off"
-                />
-                {errors.contactTwoFirstName && (
-                  <FieldError>{errors.contactTwoFirstName}</FieldError>
-                )}
-              </Field>
+            />
 
-              <Field data-invalid={!!errors.contactTwoLastName}>
-                <FieldLabel htmlFor="contact-two-last-name">
-                  Last Name
-                </FieldLabel>
-                <Input
-                  id="contact-two-last-name"
-                  type="text"
-                  placeholder="Doe"
-                  value={formData.contactTwoLastName}
-                  onChange={(e) =>
-                    updateField("contactTwoLastName", e.target.value)
-                  }
-                  aria-invalid={!!errors.contactTwoLastName}
-                  autoComplete="off"
-                />
-                {errors.contactTwoLastName && (
-                  <FieldError>{errors.contactTwoLastName}</FieldError>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="partyDate"
+                render={({ field, fieldState }) => (
+                  <FormItem>
+                    <FormLabel>Party Date</FormLabel>
+                    <FormControl>
+                      <DatePicker
+                        dateFormat="MM/dd/yy"
+                        value={field.value ?? null}
+                        onChange={field.onChange}
+                        aria-invalid={fieldState.invalid}
+                        forwardDate={true}
+                        disabled={
+                          isAdmin
+                            ? undefined
+                            : (date) =>
+                                !isAfter(
+                                  startOfDay(date),
+                                  addBusinessDays(startOfDay(new Date()), 1)
+                                )
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
                 )}
-              </Field>
+              />
+
+              <FormField
+                control={form.control}
+                name="partyTime"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Party Time</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="time" autoComplete="off" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
 
-            <Field data-invalid={!!errors.contactTwoPhoneNumber}>
-              <FieldLabel htmlFor="contact-two-phone-number">
-                {" "}
-                Phone Number
-              </FieldLabel>
-              <Input
-                id="contact-two-phone-number"
-                type="tel"
-                placeholder="(123) 456-7890"
-                value={formatPhoneNumberInput(
-                  formData.contactTwoPhoneNumber || ""
+            <FormField
+              control={form.control}
+              name="contactOneStudentId"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>First Contact</FormLabel>
+                  <FormControl>
+                    <StudentSearch
+                      initialSelection={
+                        editData?.contact_one
+                          ? {
+                              student_id: editData.contact_one.id,
+                              first_name: editData.contact_one.first_name,
+                              last_name: editData.contact_one.last_name,
+                              matched_field_name: "email",
+                              matched_field_value: editData.contact_one.email,
+                            }
+                          : null
+                      }
+                      onSelect={(student) =>
+                        field.onChange(student?.student_id ?? undefined)
+                      }
+                      adminStudentService={adminStudentService}
+                      placeholder="Search by name, PID, email, onyen, etc..."
+                      className="w-full"
+                      error={fieldState.error?.message}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FieldSet className="pt-2">
+              <FieldLegend className="font-semibold text-foreground">
+                Second Contact Information
+              </FieldLegend>
+
+              <FormField
+                control={form.control}
+                name="contactTwoEmail"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Contact Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="email"
+                        placeholder="student@unc.edu"
+                        autoComplete="off"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
                 )}
-                onChange={(e) => {
-                  const digitsOnly = e.target.value
-                    .replace(/\D/g, "")
-                    .slice(0, 10);
-                  updateField("contactTwoPhoneNumber", digitsOnly);
-                }}
-                aria-invalid={!!errors.contactTwoPhoneNumber}
-                maxLength={14}
-                autoComplete="off"
               />
-              {errors.contactTwoPhoneNumber && (
-                <FieldError>{errors.contactTwoPhoneNumber}</FieldError>
-              )}
-            </Field>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="contactTwoFirstName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>First Name</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="text"
+                          placeholder="John"
+                          autoComplete="off"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <Field data-invalid={!!errors.contactTwoPreference}>
-              <FieldLabel htmlFor="contact-two-preference">
-                Contact Preference
-              </FieldLabel>
-              <Select
-                value={formData.contactTwoPreference}
-                onValueChange={(value) =>
-                  updateField("contactTwoPreference", value as "call" | "text")
-                }
-              >
-                <SelectTrigger id="contact-two-preference">
-                  <SelectValue placeholder="Select preference" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="call">Call</SelectItem>
-                  <SelectItem value="text">Text</SelectItem>
-                </SelectContent>
-              </Select>
-              {errors.contactTwoPreference && (
-                <FieldError>{errors.contactTwoPreference}</FieldError>
-              )}
-            </Field>
-          </FieldSet>
-
-          <Field orientation="vertical" className="space-y-3">
-            {submissionError && (
-              <div
-                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                role="alert"
-              >
-                {submissionError}
+                <FormField
+                  control={form.control}
+                  name="contactTwoLastName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Last Name</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="text"
+                          placeholder="Doe"
+                          autoComplete="off"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
               </div>
-            )}
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Submitting..." : "Save Changes"}
-            </Button>
-          </Field>
-        </FieldSet>
-      </FieldGroup>
-    </form>
+
+              <FormField
+                control={form.control}
+                name="contactTwoPhoneNumber"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Phone Number</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="tel"
+                        placeholder="(123) 456-7890"
+                        value={formatPhoneNumberInput(field.value ?? "")}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value.replace(/\D/g, "").slice(0, 10)
+                          )
+                        }
+                        maxLength={14}
+                        autoComplete="off"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="contactTwoPreference"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Contact Preference</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select preference" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="call">Call</SelectItem>
+                        <SelectItem value="text">Text</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </FieldSet>
+
+            <div className="space-y-3">
+              {submissionError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Submitting..." : "Save Changes"}
+              </Button>
+            </div>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/app/staff/_components/party/PartyTableForm.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTableForm.tsx
@@ -1,29 +1,24 @@
 "use client";
 
-import AddressSearch from "@/components/AddressSearch";
-import DatePicker from "@/components/DatePicker";
 import StudentSearch from "@/components/StudentSearch";
-import { Button } from "@/components/ui/button";
-import { FieldGroup, FieldLegend, FieldSet } from "@/components/ui/field";
+import { FormShell } from "@/components/form/FormShell";
 import {
-  Form,
+  AddressField,
+  DateField,
+  PhoneField,
+  SelectField,
+  TextField,
+} from "@/components/form/fields";
+import { FieldLegend, FieldSet } from "@/components/ui/field";
+import {
   FormControl,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { PARTY_RULE_MESSAGES, PartyDto } from "@/lib/api/party/party.types";
-import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
+import { phoneNumberSchema } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, format, isAfter, startOfDay } from "date-fns";
 import { useSession } from "next-auth/react";
@@ -33,13 +28,9 @@ import * as z from "zod";
 
 export const createPartyTableFormSchema = (isAdmin: boolean) => {
   const partyDateSchema = isAdmin
-    ? z.date({
-        message: "Party date is required",
-      })
+    ? z.date({ message: "Party date is required" })
     : z
-        .date({
-          message: "Party date is required",
-        })
+        .date({ message: "Party date is required" })
         .refine(
           (date) =>
             isAfter(
@@ -118,258 +109,141 @@ export default function PartyTableForm({
         editData?.contact_two.contact_preference ?? undefined,
     },
   });
-  const isSubmitting = form.formState.isSubmitting;
-
-  const handleAddressSelect = (address: AutocompleteResult | null) => {
-    form.setValue("address", address?.formatted_address || "", {
-      shouldValidate: true,
-    });
-    form.setValue("placeId", address?.google_place_id || "", {
-      shouldValidate: true,
-    });
-  };
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
-        <FieldGroup>
-          <FieldSet>
-            <FormField
-              control={form.control}
-              name="address"
-              render={({ field, fieldState }) => (
-                <FormItem>
-                  <FormLabel>Party Address</FormLabel>
-                  <FormControl>
-                    <AddressSearch
-                      value={field.value}
-                      initialSelection={
-                        editData?.location
-                          ? {
-                              formatted_address:
-                                editData.location.formatted_address,
-                              google_place_id:
-                                editData.location.google_place_id,
-                            }
-                          : null
+    <FormShell
+      form={form}
+      onSubmit={onSubmit}
+      submitLabel="Save Changes"
+      submissionError={submissionError}
+    >
+      <AddressField
+        control={form.control}
+        name="address"
+        label="Party Address"
+        placeholder="Search for the party address..."
+        chapelHillOnly
+        initialSelection={
+          editData?.location
+            ? {
+                formatted_address: editData.location.formatted_address,
+                google_place_id: editData.location.google_place_id,
+              }
+            : null
+        }
+        onSelect={(address) =>
+          form.setValue("placeId", address?.google_place_id || "", {
+            shouldValidate: true,
+          })
+        }
+      />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <DateField
+          control={form.control}
+          name="partyDate"
+          label="Party Date"
+          dateFormat="MM/dd/yy"
+          forwardDate={true}
+          disabled={
+            isAdmin
+              ? undefined
+              : (date) =>
+                  !isAfter(
+                    startOfDay(date),
+                    addBusinessDays(startOfDay(new Date()), 1)
+                  )
+          }
+        />
+        <TextField
+          control={form.control}
+          name="partyTime"
+          label="Party Time"
+          type="time"
+          autoComplete="off"
+        />
+      </div>
+
+      <FormField
+        control={form.control}
+        name="contactOneStudentId"
+        render={({ field, fieldState }) => (
+          <FormItem>
+            <FormLabel>First Contact</FormLabel>
+            <FormControl>
+              <StudentSearch
+                initialSelection={
+                  editData?.contact_one
+                    ? {
+                        student_id: editData.contact_one.id,
+                        first_name: editData.contact_one.first_name,
+                        last_name: editData.contact_one.last_name,
+                        matched_field_name: "email",
+                        matched_field_value: editData.contact_one.email,
                       }
-                      onSelect={handleAddressSelect}
-                      placeholder="Search for the party address..."
-                      className="w-full"
-                      error={fieldState.error?.message}
-                      chapelHillOnly
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <FormField
-                control={form.control}
-                name="partyDate"
-                render={({ field, fieldState }) => (
-                  <FormItem>
-                    <FormLabel>Party Date</FormLabel>
-                    <FormControl>
-                      <DatePicker
-                        dateFormat="MM/dd/yy"
-                        value={field.value ?? null}
-                        onChange={field.onChange}
-                        aria-invalid={fieldState.invalid}
-                        forwardDate={true}
-                        disabled={
-                          isAdmin
-                            ? undefined
-                            : (date) =>
-                                !isAfter(
-                                  startOfDay(date),
-                                  addBusinessDays(startOfDay(new Date()), 1)
-                                )
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                    : null
+                }
+                onSelect={(student) =>
+                  field.onChange(student?.student_id ?? undefined)
+                }
+                placeholder="Search by name, PID, email, onyen, etc..."
+                error={fieldState.error?.message}
               />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
 
-              <FormField
-                control={form.control}
-                name="partyTime"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Party Time</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="time" autoComplete="off" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+      <FieldSet className="pt-2">
+        <FieldLegend className="font-semibold text-foreground">
+          Second Contact Information
+        </FieldLegend>
 
-            <FormField
-              control={form.control}
-              name="contactOneStudentId"
-              render={({ field, fieldState }) => (
-                <FormItem>
-                  <FormLabel>First Contact</FormLabel>
-                  <FormControl>
-                    <StudentSearch
-                      initialSelection={
-                        editData?.contact_one
-                          ? {
-                              student_id: editData.contact_one.id,
-                              first_name: editData.contact_one.first_name,
-                              last_name: editData.contact_one.last_name,
-                              matched_field_name: "email",
-                              matched_field_value: editData.contact_one.email,
-                            }
-                          : null
-                      }
-                      onSelect={(student) =>
-                        field.onChange(student?.student_id ?? undefined)
-                      }
-                      placeholder="Search by name, PID, email, onyen, etc..."
-                      className="w-full"
-                      error={fieldState.error?.message}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+        <TextField
+          control={form.control}
+          name="contactTwoEmail"
+          label="Contact Email"
+          type="email"
+          placeholder="student@unc.edu"
+          autoComplete="off"
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <TextField
+            control={form.control}
+            name="contactTwoFirstName"
+            label="First Name"
+            type="text"
+            placeholder="John"
+            autoComplete="off"
+          />
+          <TextField
+            control={form.control}
+            name="contactTwoLastName"
+            label="Last Name"
+            type="text"
+            placeholder="Doe"
+            autoComplete="off"
+          />
+        </div>
 
-            <FieldSet className="pt-2">
-              <FieldLegend className="font-semibold text-foreground">
-                Second Contact Information
-              </FieldLegend>
+        <PhoneField
+          control={form.control}
+          name="contactTwoPhoneNumber"
+          label="Phone Number"
+        />
 
-              <FormField
-                control={form.control}
-                name="contactTwoEmail"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Contact Email</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="email"
-                        placeholder="student@unc.edu"
-                        autoComplete="off"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="contactTwoFirstName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>First Name</FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type="text"
-                          placeholder="John"
-                          autoComplete="off"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="contactTwoLastName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Last Name</FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type="text"
-                          placeholder="Doe"
-                          autoComplete="off"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <FormField
-                control={form.control}
-                name="contactTwoPhoneNumber"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Phone Number</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="tel"
-                        placeholder="(123) 456-7890"
-                        value={formatPhoneNumberInput(field.value ?? "")}
-                        onChange={(e) =>
-                          field.onChange(
-                            e.target.value.replace(/\D/g, "").slice(0, 10)
-                          )
-                        }
-                        maxLength={14}
-                        autoComplete="off"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="contactTwoPreference"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Contact Preference</FormLabel>
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select preference" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="call">Call</SelectItem>
-                        <SelectItem value="text">Text</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </FieldSet>
-
-            <div className="space-y-3 *:w-full">
-              {submissionError && (
-                <div
-                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                  role="alert"
-                >
-                  {submissionError}
-                </div>
-              )}
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Submitting..." : "Save Changes"}
-              </Button>
-            </div>
-          </FieldSet>
-        </FieldGroup>
-      </form>
-    </Form>
+        <SelectField
+          control={form.control}
+          name="contactTwoPreference"
+          label="Contact Preference"
+          placeholder="Select preference"
+          options={[
+            { value: "call", label: "Call" },
+            { value: "text", label: "Text" },
+          ]}
+        />
+      </FieldSet>
+    </FormShell>
   );
 }

--- a/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
+++ b/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
@@ -10,6 +10,7 @@ import {
   LocationDto,
   NestedIncidentDto,
 } from "@/lib/api/location/location.types";
+import { PlusIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useCallback, useState } from "react";
 import { createPortal } from "react-dom";
@@ -100,7 +101,7 @@ export default function IncidentInfoChipDetails({
         headerActionNode &&
         createPortal(
           <Button variant="default" size="sm" onClick={handleAdd}>
-            Add New
+            <PlusIcon className="size-4" />
           </Button>,
           headerActionNode
         )}

--- a/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
+++ b/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
@@ -100,8 +100,13 @@ export default function IncidentInfoChipDetails({
       {role === "admin" &&
         headerActionNode &&
         createPortal(
-          <Button variant="default" size="sm" onClick={handleAdd}>
-            <PlusIcon className="size-4" />
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleAdd}
+            aria-label="Add new incident"
+          >
+            <PlusIcon className="size-4" aria-hidden="true" />
           </Button>,
           headerActionNode
         )}

--- a/frontend/src/app/staff/_components/shared/sidebar/Sidebar.tsx
+++ b/frontend/src/app/staff/_components/shared/sidebar/Sidebar.tsx
@@ -1,8 +1,12 @@
 "use client";
 import { useSidebar } from "@/app/staff/_components/shared/sidebar/SidebarContext";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { XIcon } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 
 function Sidebar() {
   const {
@@ -15,42 +19,38 @@ function Sidebar() {
   } = useSidebar();
 
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        className={cn(
-          "fixed inset-0 bg-modal-overlay z-40 transition-opacity duration-300",
-          isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
-        )}
-        onClick={closeSidebar}
-      />
-
-      {/* Sidebar */}
-      <div
-        className={cn(
-          "fixed top-0 right-0 h-full w-full max-w-[25em] bg-card shadow-lg z-50 flex flex-col transform transition-transform duration-300 ease-in-out",
-          isOpen ? "translate-x-0" : "translate-x-full"
-        )}
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) closeSidebar();
+      }}
+    >
+      <SheetContent
+        side="right"
+        // Radix wires aria-describedby automatically when a SheetDescription
+        // is rendered; opt out explicitly when there is no description so it
+        // doesn't warn about a dangling reference.
+        {...(description ? {} : { "aria-describedby": undefined })}
+        className="w-full max-w-[25em] gap-0 bg-card p-0 sm:max-w-[25em]"
       >
-        {/* Header — stays visible because only the content area below scrolls */}
-        <div className="bg-card px-6 pt-6 pb-2 mb-2">
-          <Button className="bg-card hover:bg-card pb-6" onClick={closeSidebar}>
-            <XIcon className="text-muted-foreground size-6 -m-8" />
-          </Button>
-          {title && (
-            <div className="flex items-center justify-between">
-              <h2 className="subhead-title text-foreground">{title}</h2>
-              <div ref={setHeaderActionNode} />
-            </div>
-          )}
+        <SheetHeader className="mb-2 gap-0 px-6 pb-2 pt-6">
+          {/* pr leaves room for the built-in close button (top-right) */}
+          <div className="flex items-center justify-between pr-8">
+            <SheetTitle className="subhead-title text-foreground">
+              {title ?? ""}
+            </SheetTitle>
+            <div ref={setHeaderActionNode} />
+          </div>
           {description && (
-            <p className="text-sm text-muted-foreground">{description}</p>
+            <SheetDescription className="text-sm text-muted-foreground">
+              {description}
+            </SheetDescription>
           )}
-        </div>
+        </SheetHeader>
         {/* Scrollable content portal target */}
-        <div ref={setBodyNode} className="overflow-y-auto flex-1 px-6 pb-6" />
-      </div>
-    </>
+        <div ref={setBodyNode} className="flex-1 overflow-y-auto px-6 pb-6" />
+      </SheetContent>
+    </Sheet>
   );
 }
 

--- a/frontend/src/app/staff/_components/shared/sidebar/Sidebar.tsx
+++ b/frontend/src/app/staff/_components/shared/sidebar/Sidebar.tsx
@@ -33,9 +33,8 @@ function Sidebar() {
         {...(description ? {} : { "aria-describedby": undefined })}
         className="w-full max-w-[25em] gap-0 bg-card p-0 sm:max-w-[25em]"
       >
-        <SheetHeader className="mb-2 gap-0 px-6 pb-2 pt-6">
-          {/* pr leaves room for the built-in close button (top-right) */}
-          <div className="flex items-center justify-between pr-8">
+        <SheetHeader className="mb-2 gap-0 px-6 pb-2 pt-12">
+          <div className="flex items-center justify-between">
             <SheetTitle className="subhead-title text-foreground">
               {title ?? ""}
             </SheetTitle>

--- a/frontend/src/app/staff/_components/student/StudentTableForm.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTableForm.tsx
@@ -114,7 +114,7 @@ export default function StudentTableForm({
                   <FormControl>
                     <Input
                       {...field}
-                      placeholder="123456789"
+                      placeholder="730456789"
                       disabled={isPIDEditMode}
                       title={ssoTitle}
                       autoComplete="off"
@@ -315,7 +315,7 @@ export default function StudentTableForm({
               )}
             />
 
-            <div className="space-y-3">
+            <div className="space-y-3 *:w-full">
               {submissionError && (
                 <div
                   className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"

--- a/frontend/src/app/staff/_components/student/StudentTableForm.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTableForm.tsx
@@ -1,34 +1,21 @@
 "use client";
 
-import AddressSearch from "@/components/AddressSearch";
-import DatePicker from "@/components/DatePicker";
-import { Button } from "@/components/ui/button";
-import { FieldGroup, FieldSet } from "@/components/ui/field";
+import { FormShell } from "@/components/form/FormShell";
 import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
+  AddressField,
+  DateField,
+  PhoneField,
+  SelectField,
+  TextField,
+} from "@/components/form/fields";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { ResidenceDto } from "@/lib/api/student/student.types";
-import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
+import { phoneNumberSchema } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
 import { Info } from "lucide-react";
@@ -93,7 +80,6 @@ export default function StudentTableForm({
       residence_place_id: editData?.residence_place_id ?? null,
     },
   });
-  const isSubmitting = form.formState.isSubmitting;
 
   const isPIDEditMode = !!editData;
   const ssoTitle = isPIDEditMode
@@ -101,236 +87,110 @@ export default function StudentTableForm({
     : undefined;
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
-        <FieldGroup>
-          <FieldSet>
-            <FormField
-              control={form.control}
-              name="pid"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>PID</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="730456789"
-                      disabled={isPIDEditMode}
-                      title={ssoTitle}
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <FormShell
+      form={form}
+      onSubmit={onSubmit}
+      submitLabel="Save Changes"
+      submissionError={submissionError}
+    >
+      <TextField
+        control={form.control}
+        name="pid"
+        label="PID"
+        placeholder="123456789"
+        disabled={isPIDEditMode}
+        title={ssoTitle}
+        autoComplete="off"
+      />
+      <TextField
+        control={form.control}
+        name="first_name"
+        label="First name"
+        placeholder="John"
+        disabled={isPIDEditMode}
+        title={ssoTitle}
+        autoComplete="off"
+      />
+      <TextField
+        control={form.control}
+        name="last_name"
+        label="Last name"
+        placeholder="Doe"
+        disabled={isPIDEditMode}
+        title={ssoTitle}
+        autoComplete="off"
+      />
+      <TextField
+        control={form.control}
+        name="email"
+        label="Email"
+        type="email"
+        placeholder="student@unc.edu"
+        disabled={isPIDEditMode}
+        title={ssoTitle}
+        autoComplete="off"
+      />
+      <TextField
+        control={form.control}
+        name="onyen"
+        label="Onyen"
+        placeholder="johndoe"
+        disabled={isPIDEditMode}
+        title={ssoTitle}
+        autoComplete="off"
+      />
 
-            <FormField
-              control={form.control}
-              name="first_name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>First name</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="John"
-                      disabled={isPIDEditMode}
-                      title={ssoTitle}
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <PhoneField
+        control={form.control}
+        name="phone_number"
+        label="Phone Number"
+      />
 
-            <FormField
-              control={form.control}
-              name="last_name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Last name</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="Doe"
-                      disabled={isPIDEditMode}
-                      title={ssoTitle}
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <SelectField
+        control={form.control}
+        name="contact_preference"
+        label="Contact Preference"
+        placeholder="Select preference"
+        options={[
+          { value: "call", label: "Call" },
+          { value: "text", label: "Text" },
+        ]}
+      />
 
-            <FormField
-              control={form.control}
-              name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Email</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="email"
-                      placeholder="student@unc.edu"
-                      disabled={isPIDEditMode}
-                      title={ssoTitle}
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <AddressField
+        control={form.control}
+        name="residence_place_id"
+        label="Residence Address"
+        placeholder="Search for student's residence..."
+        initialSelection={initialResidenceSelection}
+        getStoredValue={(address) => address?.google_place_id ?? null}
+        description="Leave blank to remove the student's current residence."
+      />
 
-            <FormField
-              control={form.control}
-              name="onyen"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Onyen</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="johndoe"
-                      disabled={isPIDEditMode}
-                      title={ssoTitle}
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="phone_number"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Phone Number</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="tel"
-                      placeholder="(123) 456-7890"
-                      value={formatPhoneNumberInput(field.value ?? "")}
-                      onChange={(e) =>
-                        field.onChange(
-                          e.target.value.replace(/\D/g, "").slice(0, 10)
-                        )
-                      }
-                      maxLength={14}
-                      autoComplete="off"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="contact_preference"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Contact Preference</FormLabel>
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select preference" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="call">Call</SelectItem>
-                      <SelectItem value="text">Text</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="residence_place_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Residence Address</FormLabel>
-                  <FormControl>
-                    <AddressSearch
-                      initialSelection={initialResidenceSelection}
-                      onSelect={(address) =>
-                        field.onChange(address?.google_place_id ?? null)
-                      }
-                      placeholder="Search for student's residence..."
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Leave blank to remove the student&apos;s current residence.
-                  </FormDescription>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="last_registered"
-              render={({ field, fieldState }) => (
-                <FormItem>
-                  <FormLabel className="flex items-center gap-1">
-                    Last Registered
-                    <HoverCard>
-                      <HoverCardTrigger asChild>
-                        <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
-                      </HoverCardTrigger>
-                      <HoverCardContent className="max-w-64">
-                        A student is considered registered if they have a last
-                        registered date within the current academic year.
-                      </HoverCardContent>
-                    </HoverCard>
-                  </FormLabel>
-                  <FormControl>
-                    <DatePicker
-                      value={field.value}
-                      onChange={field.onChange}
-                      aria-invalid={fieldState.invalid}
-                      disabled={(date) =>
-                        isAfter(
-                          startOfDay(date),
-                          addBusinessDays(startOfDay(new Date()), 0)
-                        )
-                      }
-                      clearable
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Leave blank if student is not registered.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="space-y-3 *:w-full">
-              {submissionError && (
-                <div
-                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                  role="alert"
-                >
-                  {submissionError}
-                </div>
-              )}
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Submitting..." : "Save Changes"}
-              </Button>
-            </div>
-          </FieldSet>
-        </FieldGroup>
-      </form>
-    </Form>
+      <DateField
+        control={form.control}
+        name="last_registered"
+        labelClassName="flex items-center gap-1"
+        label={
+          <>
+            Last Registered
+            <HoverCard>
+              <HoverCardTrigger asChild>
+                <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
+              </HoverCardTrigger>
+              <HoverCardContent className="max-w-64">
+                A student is considered registered if they have a last
+                registered date within the current academic year.
+              </HoverCardContent>
+            </HoverCard>
+          </>
+        }
+        description="Leave blank if student is not registered."
+        clearable
+        disabled={(date) =>
+          isAfter(startOfDay(date), addBusinessDays(startOfDay(new Date()), 0))
+        }
+      />
+    </FormShell>
   );
 }

--- a/frontend/src/app/staff/_components/student/StudentTableForm.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTableForm.tsx
@@ -3,14 +3,16 @@
 import AddressSearch from "@/components/AddressSearch";
 import DatePicker from "@/components/DatePicker";
 import { Button } from "@/components/ui/button";
+import { FieldGroup, FieldSet } from "@/components/ui/field";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldSet,
-} from "@/components/ui/field";
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   HoverCard,
   HoverCardContent,
@@ -27,9 +29,10 @@ import {
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { ResidenceDto } from "@/lib/api/student/student.types";
 import { formatPhoneNumberInput, phoneNumberSchema } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, isAfter, startOfDay } from "date-fns";
 import { Info } from "lucide-react";
-import { useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 export const studentTableFormSchema = z.object({
@@ -71,265 +74,263 @@ export default function StudentTableForm({
         }
       : null;
 
-  const [formData, setFormData] = useState<Partial<StudentTableFormValues>>({
-    pid: editData?.pid ?? "",
-    first_name: editData?.first_name ?? "",
-    last_name: editData?.last_name ?? "",
-    email: editData?.email ?? "",
-    onyen: editData?.onyen ?? "",
-    phone_number: editData?.phone_number ?? "",
-    contact_preference: editData?.contact_preference ?? undefined,
-    last_registered: editData?.last_registered ?? null,
-    residence: editData?.residence ?? null,
-    residence_place_id: editData?.residence_place_id ?? null,
+  const form = useForm<
+    z.input<typeof studentTableFormSchema>,
+    unknown,
+    StudentTableFormValues
+  >({
+    resolver: zodResolver(studentTableFormSchema),
+    defaultValues: {
+      pid: editData?.pid ?? "",
+      first_name: editData?.first_name ?? "",
+      last_name: editData?.last_name ?? "",
+      email: editData?.email ?? "",
+      onyen: editData?.onyen ?? "",
+      phone_number: editData?.phone_number ?? "",
+      contact_preference: editData?.contact_preference ?? undefined,
+      last_registered: editData?.last_registered ?? null,
+      residence: editData?.residence ?? null,
+      residence_place_id: editData?.residence_place_id ?? null,
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setErrors({});
-
-    const result = studentTableFormSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await onSubmit(result.data);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const updateField = <K extends keyof StudentTableFormValues>(
-    field: K,
-    value: StudentTableFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[field];
-        return newErrors;
-      });
-    }
-  };
+  const isSubmitting = form.formState.isSubmitting;
 
   const isPIDEditMode = !!editData;
+  const ssoTitle = isPIDEditMode
+    ? "This field is managed by UNC SSO"
+    : undefined;
+
   return (
-    <form onSubmit={handleSubmit}>
-      <FieldGroup>
-        <FieldSet>
-          <Field data-invalid={!!errors.pid}>
-            <FieldLabel htmlFor="pid">PID</FieldLabel>
-            <Input
-              id="first-name"
-              placeholder="123456789"
-              value={formData.pid}
-              onChange={(e) => updateField("pid", e.target.value)}
-              aria-invalid={!!errors.pid}
-              disabled={isPIDEditMode}
-              title={
-                isPIDEditMode ? "This field is managed by UNC SSO" : undefined
-              }
-              autoComplete="off"
-            />
-            {errors.pid && <FieldError>{errors.pid}</FieldError>}
-          </Field>
-
-          <Field data-invalid={!!errors.first_name}>
-            <FieldLabel htmlFor="first-name">First name</FieldLabel>
-            <Input
-              id="first-name"
-              placeholder="John"
-              value={formData.first_name}
-              onChange={(e) => updateField("first_name", e.target.value)}
-              aria-invalid={!!errors.first_name}
-              disabled={isPIDEditMode}
-              title={
-                isPIDEditMode ? "This field is managed by UNC SSO" : undefined
-              }
-              autoComplete="off"
-            />
-            {errors.first_name && <FieldError>{errors.first_name}</FieldError>}
-          </Field>
-
-          <Field data-invalid={!!errors.last_name}>
-            <FieldLabel htmlFor="last-name">Last name</FieldLabel>
-            <Input
-              id="last-name"
-              placeholder="Doe"
-              value={formData.last_name}
-              onChange={(e) => updateField("last_name", e.target.value)}
-              aria-invalid={!!errors.last_name}
-              disabled={isPIDEditMode}
-              title={
-                isPIDEditMode ? "This field is managed by UNC SSO" : undefined
-              }
-              autoComplete="off"
-            />
-            {errors.last_name && <FieldError>{errors.last_name}</FieldError>}
-          </Field>
-
-          <Field data-invalid={!!errors.email}>
-            <FieldLabel htmlFor="email">Email</FieldLabel>
-            <Input
-              id="email"
-              type="email"
-              placeholder="student@unc.edu"
-              value={formData.email}
-              onChange={(e) => updateField("email", e.target.value)}
-              aria-invalid={!!errors.email}
-              disabled={isPIDEditMode}
-              title={
-                isPIDEditMode ? "This field is managed by UNC SSO" : undefined
-              }
-              autoComplete="off"
-            />
-            {errors.email && <FieldError>{errors.email}</FieldError>}
-          </Field>
-
-          <Field data-invalid={!!errors.onyen}>
-            <FieldLabel htmlFor="onyen">Onyen</FieldLabel>
-            <Input
-              id="onyen"
-              placeholder="johndoe"
-              value={formData.onyen}
-              onChange={(e) => updateField("onyen", e.target.value)}
-              aria-invalid={!!errors.onyen}
-              disabled={isPIDEditMode}
-              title={
-                isPIDEditMode ? "This field is managed by UNC SSO" : undefined
-              }
-              autoComplete="off"
-            />
-            {errors.onyen && <FieldError>{errors.onyen}</FieldError>}
-          </Field>
-
-          <Field data-invalid={!!errors.phone_number}>
-            <FieldLabel htmlFor="phone-number">Phone Number</FieldLabel>
-            <Input
-              id="phone-number"
-              type="tel"
-              placeholder="(123) 456-7890"
-              value={formatPhoneNumberInput(
-                (formData.phone_number as string) || ""
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FieldGroup>
+          <FieldSet>
+            <FormField
+              control={form.control}
+              name="pid"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>PID</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="123456789"
+                      disabled={isPIDEditMode}
+                      title={ssoTitle}
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-              onChange={(e) => {
-                const digitsOnly = e.target.value
-                  .replace(/\D/g, "")
-                  .slice(0, 10);
-                updateField("phone_number", digitsOnly);
-              }}
-              maxLength={14}
-              autoComplete="off"
             />
-            {errors.phone_number && (
-              <FieldError>{errors.phone_number}</FieldError>
-            )}
-          </Field>
 
-          <Field data-invalid={!!errors.contact_preference}>
-            <FieldLabel htmlFor="contact-preference">
-              Contact Preference
-            </FieldLabel>
-            <Select
-              value={formData.contact_preference}
-              onValueChange={(value) =>
-                updateField("contact_preference", value as "call" | "text")
-              }
-            >
-              <SelectTrigger id="contact-two-preference">
-                <SelectValue placeholder="Select preference" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="call">Call</SelectItem>
-                <SelectItem value="text">Text</SelectItem>
-              </SelectContent>
-            </Select>
-            {errors.contact_preference && (
-              <FieldError>{errors.contact_preference}</FieldError>
-            )}
-          </Field>
-
-          <Field>
-            <FieldLabel>Residence Address</FieldLabel>
-            <AddressSearch
-              initialSelection={initialResidenceSelection}
-              onSelect={(address) =>
-                updateField(
-                  "residence_place_id",
-                  address?.google_place_id ?? null
-                )
-              }
-              placeholder="Search for student's residence..."
+            <FormField
+              control={form.control}
+              name="first_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>First name</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="John"
+                      disabled={isPIDEditMode}
+                      title={ssoTitle}
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            <FieldDescription>
-              Leave blank to remove the student&apos;s current residence.
-            </FieldDescription>
-          </Field>
 
-          <Field data-invalid={!!errors.last_registered}>
-            <FieldLabel
-              htmlFor="party-date"
-              className="flex items-center gap-1"
-            >
-              Last Registered
-              <HoverCard>
-                <HoverCardTrigger asChild>
-                  <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-w-64">
-                  A student is considered registered if they have a last
-                  registered date within the current academic year.
-                </HoverCardContent>
-              </HoverCard>
-            </FieldLabel>
-            <DatePicker
-              id="last-registered"
-              value={formData.last_registered}
-              onChange={(date) => updateField("last_registered", date)}
-              disabled={(date) =>
-                isAfter(
-                  startOfDay(date),
-                  addBusinessDays(startOfDay(new Date()), 0)
-                )
-              }
-              clearable
+            <FormField
+              control={form.control}
+              name="last_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Last name</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="Doe"
+                      disabled={isPIDEditMode}
+                      title={ssoTitle}
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            <FieldDescription>
-              Leave blank if student is not registered.
-            </FieldDescription>
-            {errors.last_registered && (
-              <FieldError>{errors.last_registered}</FieldError>
-            )}
-          </Field>
 
-          <Field orientation="vertical" className="space-y-3">
-            {submissionError && (
-              <div
-                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                role="alert"
-              >
-                {submissionError}
-              </div>
-            )}
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Submitting..." : "Save Changes"}
-            </Button>
-          </Field>
-        </FieldSet>
-      </FieldGroup>
-    </form>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder="student@unc.edu"
+                      disabled={isPIDEditMode}
+                      title={ssoTitle}
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="onyen"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Onyen</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="johndoe"
+                      disabled={isPIDEditMode}
+                      title={ssoTitle}
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="phone_number"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Phone Number</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="tel"
+                      placeholder="(123) 456-7890"
+                      value={formatPhoneNumberInput(field.value ?? "")}
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value.replace(/\D/g, "").slice(0, 10)
+                        )
+                      }
+                      maxLength={14}
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="contact_preference"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Contact Preference</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select preference" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="call">Call</SelectItem>
+                      <SelectItem value="text">Text</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="residence_place_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Residence Address</FormLabel>
+                  <FormControl>
+                    <AddressSearch
+                      initialSelection={initialResidenceSelection}
+                      onSelect={(address) =>
+                        field.onChange(address?.google_place_id ?? null)
+                      }
+                      placeholder="Search for student's residence..."
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Leave blank to remove the student&apos;s current residence.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="last_registered"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel className="flex items-center gap-1">
+                    Last Registered
+                    <HoverCard>
+                      <HoverCardTrigger asChild>
+                        <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground ml-1" />
+                      </HoverCardTrigger>
+                      <HoverCardContent className="max-w-64">
+                        A student is considered registered if they have a last
+                        registered date within the current academic year.
+                      </HoverCardContent>
+                    </HoverCard>
+                  </FormLabel>
+                  <FormControl>
+                    <DatePicker
+                      value={field.value}
+                      onChange={field.onChange}
+                      aria-invalid={fieldState.invalid}
+                      disabled={(date) =>
+                        isAfter(
+                          startOfDay(date),
+                          addBusinessDays(startOfDay(new Date()), 0)
+                        )
+                      }
+                      clearable
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Leave blank if student is not registered.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="space-y-3">
+              {submissionError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Submitting..." : "Save Changes"}
+              </Button>
+            </div>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/components/AddressSearch.tsx
+++ b/frontend/src/components/AddressSearch.tsx
@@ -376,7 +376,11 @@ export default function AddressSearch({
       )}
 
       {internalError && (
-        <p className="mt-2 text-sm text-destructive" role="alert">
+        <p
+          id="address-error"
+          className="mt-2 text-sm text-destructive"
+          role="alert"
+        >
           {internalError}
         </p>
       )}

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -51,6 +51,7 @@ export default function DatePicker({
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false);
   const [lastClosedAt, setLastClosedAt] = React.useState(0);
+  const openedFromInput = React.useRef(false);
   const [inputValue, setInputValue] = React.useState(
     value ? format(value, dateFormat) : ""
   );
@@ -86,6 +87,7 @@ export default function DatePicker({
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "ArrowDown" || e.key === "Enter") {
       e.preventDefault();
+      openedFromInput.current = true;
       setOpen(true);
     }
   }
@@ -99,7 +101,10 @@ export default function DatePicker({
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
         onClick={() => {
-          if (Date.now() - lastClosedAt > 150) setOpen(true);
+          if (Date.now() - lastClosedAt > 150) {
+            openedFromInput.current = true;
+            setOpen(true);
+          }
         }}
         autoComplete="off"
         placeholder={placeholder}
@@ -140,7 +145,12 @@ export default function DatePicker({
           <PopoverContent
             className={cn("w-auto p-0", popoverContentClassName)}
             align="end"
-            onOpenAutoFocus={(e) => e.preventDefault()}
+            onOpenAutoFocus={(e) => {
+              if (openedFromInput.current) {
+                openedFromInput.current = false;
+                e.preventDefault();
+              }
+            }}
           >
             <Calendar
               mode="single"

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -19,7 +19,7 @@ export default function Footer() {
   const showContact = isStudentAreaPath(pathname ?? "");
 
   return (
-    <div
+    <footer
       className={`${variants[VARIANT]} px-6 py-2 flex justify-between items-center text-xs shrink-0`}
     >
       {showContact ? (
@@ -38,6 +38,6 @@ export default function Footer() {
       <span className="flex items-center gap-1">
         Made with <Heart className="size-3 fill-current" /> by CS+SG
       </span>
-    </div>
+    </footer>
   );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -42,7 +42,7 @@ export default function Header({ className }: { className?: string }) {
   const email = currentPrincipal?.email ?? session?.user?.email ?? null;
 
   return (
-    <div
+    <header
       className={cn(
         "bg-primary h-(--app-header-height) px-6 w-full flex justify-between items-center",
         className
@@ -97,6 +97,6 @@ export default function Header({ className }: { className?: string }) {
           </DropdownMenuContent>
         </DropdownMenu>
       ) : null}
-    </div>
+    </header>
   );
 }

--- a/frontend/src/components/IncidentDialog.tsx
+++ b/frontend/src/components/IncidentDialog.tsx
@@ -8,6 +8,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -27,8 +36,9 @@ import {
 } from "@/lib/api/incident/incident.types";
 import { LocationDto } from "@/lib/api/location/location.types";
 import { cn } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
-import { useState } from "react";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 const incidentSchema = z.object({
@@ -70,51 +80,23 @@ export default function IncidentDialog({
 }: IncidentDialogProps) {
   const defaultDatetime = incident?.incident_datetime ?? new Date();
 
-  const [formData, setFormData] = useState<IncidentFormValues>({
-    severity: incident?.severity ?? defaultSeverity,
-    date: defaultDatetime,
-    time: format(defaultDatetime, "HH:mm"),
-    description: incident?.description ?? "",
-    reference_id: incident?.reference_id ?? undefined,
+  const form = useForm<IncidentFormValues>({
+    resolver: zodResolver(incidentSchema),
+    defaultValues: {
+      severity: incident?.severity ?? defaultSeverity,
+      date: defaultDatetime,
+      time: format(defaultDatetime, "HH:mm"),
+      description: incident?.description ?? "",
+      reference_id: incident?.reference_id ?? undefined,
+    },
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
 
-  const updateField = <K extends keyof IncidentFormValues>(
-    field: K,
-    value: IncidentFormValues[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => {
-        const next = { ...prev };
-        delete next[field];
-        return next;
-      });
-    }
-  };
-
-  const handleSubmit = (event: React.SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const result = incidentSchema.safeParse(formData);
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      result.error.issues.forEach((issue) => {
-        if (issue.path[0]) {
-          fieldErrors[issue.path[0].toString()] = issue.message;
-        }
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    const { date, time, severity, description, reference_id } = result.data;
+  const handleValid = (data: IncidentFormValues) => {
+    const { date, time, severity, description, reference_id } = data;
     const [hours, minutes] = time.split(":").map(Number);
     const incident_datetime = new Date(date);
     incident_datetime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
 
-    setErrors({});
     onSubmit({
       location_place_id: locationPlaceId ?? location?.google_place_id ?? "",
       incident_datetime,
@@ -124,7 +106,7 @@ export default function IncidentDialog({
     });
   };
 
-  const severityLabel = INCIDENT_SEVERITY_LABELS[formData.severity];
+  const severityLabel = INCIDENT_SEVERITY_LABELS[form.watch("severity")];
   const title =
     mode === "edit" ? `Edit ${severityLabel}` : `Add ${severityLabel}`;
 
@@ -139,101 +121,128 @@ export default function IncidentDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form className="space-y-4" onSubmit={handleSubmit}>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="incident-address">Selected Address</Label>
-            <Input
-              id="incident-address"
-              value={location?.formatted_address || formattedAddress || ""}
-              disabled
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
+        <Form {...form}>
+          <form className="space-y-4" onSubmit={form.handleSubmit(handleValid)}>
             <div className="flex flex-col gap-2">
-              <Label htmlFor="incident-type">Incident Type</Label>
-              <Select
-                value={formData.severity}
-                onValueChange={(v) =>
-                  updateField("severity", v as IncidentSeverity)
-                }
-              >
-                <SelectTrigger id="incident-type" className="w-full">
-                  <SelectValue placeholder="Enter incident type" />
-                </SelectTrigger>
-                <SelectContent>
-                  {INCIDENT_SEVERITIES.map((s) => (
-                    <SelectItem key={s} value={s}>
-                      {INCIDENT_SEVERITY_LABELS[s]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="incident-reference-id">Reference ID</Label>
+              <Label htmlFor="incident-address">Selected Address</Label>
               <Input
-                id="incident-reference-id"
-                value={formData.reference_id ?? ""}
-                onChange={(e) =>
-                  updateField("reference_id", e.target.value || undefined)
-                }
-                placeholder="Optional"
+                id="incident-address"
+                value={location?.formatted_address || formattedAddress || ""}
+                disabled
               />
             </div>
 
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="incident-date">Date</Label>
-              <DatePicker
-                id="incident-date"
-                value={formData.date}
-                onChange={(date) => updateField("date", date ?? new Date())}
-                placeholder="Pick a date"
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="severity"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Incident Type</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Enter incident type" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {INCIDENT_SEVERITIES.map((s) => (
+                          <SelectItem key={s} value={s}>
+                            {INCIDENT_SEVERITY_LABELS[s]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-              {errors.date && (
-                <p className="text-sm text-destructive">{errors.date}</p>
-              )}
+
+              <FormField
+                control={form.control}
+                name="reference_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Reference ID</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(e.target.value || undefined)
+                        }
+                        placeholder="Optional"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="date"
+                render={({ field, fieldState }) => (
+                  <FormItem>
+                    <FormLabel>Date</FormLabel>
+                    <FormControl>
+                      <DatePicker
+                        value={field.value}
+                        onChange={(date) => field.onChange(date ?? new Date())}
+                        aria-invalid={fieldState.invalid}
+                        placeholder="Pick a date"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="time"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Incident Time</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="time" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
 
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="incident-time">Incident Time</Label>
-              <Input
-                id="incident-time"
-                type="time"
-                value={formData.time}
-                onChange={(e) => updateField("time", e.target.value)}
-              />
-              {errors.time && (
-                <p className="text-sm text-destructive">{errors.time}</p>
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      rows={4}
+                      className={cn(
+                        "shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20"
+                      )}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Optional details about the incident.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="incident-description">Description</Label>
-            <Textarea
-              id="incident-description"
-              rows={4}
-              value={formData.description}
-              className={cn(
-                "shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20"
-              )}
-              onChange={(event) =>
-                updateField("description", event.target.value)
-              }
             />
-            <p className="text-sm text-muted-foreground">
-              Optional details about the incident.
-            </p>
-          </div>
 
-          <div className="flex justify-center gap-2">
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Saving changes..." : "Save Changes"}
-            </Button>
-          </div>
-        </form>
+            <div className="flex justify-center gap-2">
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving changes..." : "Save Changes"}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/IncidentDialog.tsx
+++ b/frontend/src/components/IncidentDialog.tsx
@@ -1,32 +1,20 @@
 "use client";
 
-import DatePicker from "@/components/DatePicker";
-import { Button } from "@/components/ui/button";
+import { FormShell } from "@/components/form/FormShell";
+import {
+  DateField,
+  SelectField,
+  TextField,
+  TextareaField,
+} from "@/components/form/fields";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import {
   INCIDENT_SEVERITIES,
   INCIDENT_SEVERITY_LABELS,
@@ -35,7 +23,6 @@ import {
   NestedIncidentDto,
 } from "@/lib/api/incident/incident.types";
 import { LocationDto } from "@/lib/api/location/location.types";
-import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
 import { useForm } from "react-hook-form";
@@ -102,7 +89,7 @@ export default function IncidentDialog({
       incident_datetime,
       description,
       severity,
-      reference_id: reference_id ?? null,
+      reference_id: reference_id || null,
     });
   };
 
@@ -121,128 +108,67 @@ export default function IncidentDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <Form {...form}>
-          <form className="space-y-4" onSubmit={form.handleSubmit(handleValid)}>
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="incident-address">Selected Address</Label>
-              <Input
-                id="incident-address"
-                value={location?.formatted_address || formattedAddress || ""}
-                disabled
-              />
-            </div>
+        <FormShell
+          form={form}
+          onSubmit={handleValid}
+          submitLabel="Save Changes"
+          pendingLabel="Saving changes..."
+          pending={isSubmitting}
+          submitClassName="self-center"
+        >
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="incident-address">Selected Address</Label>
+            <Input
+              id="incident-address"
+              value={location?.formatted_address || formattedAddress || ""}
+              disabled
+            />
+          </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <FormField
-                control={form.control}
-                name="severity"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Incident Type</FormLabel>
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Enter incident type" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {INCIDENT_SEVERITIES.map((s) => (
-                          <SelectItem key={s} value={s}>
-                            {INCIDENT_SEVERITY_LABELS[s]}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="reference_id"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Reference ID</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        value={field.value ?? ""}
-                        onChange={(e) =>
-                          field.onChange(e.target.value || undefined)
-                        }
-                        placeholder="Optional"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="date"
-                render={({ field, fieldState }) => (
-                  <FormItem>
-                    <FormLabel>Date</FormLabel>
-                    <FormControl>
-                      <DatePicker
-                        value={field.value}
-                        onChange={(date) => field.onChange(date ?? new Date())}
-                        aria-invalid={fieldState.invalid}
-                        placeholder="Pick a date"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="time"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Incident Time</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="time" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <FormField
+          <div className="grid grid-cols-2 gap-4">
+            <SelectField
               control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Description</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      rows={4}
-                      className={cn(
-                        "shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20"
-                      )}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Optional details about the incident.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
+              name="severity"
+              label="Incident Type"
+              triggerClassName="w-full"
+              placeholder="Enter incident type"
+              options={INCIDENT_SEVERITIES.map((s) => ({
+                value: s,
+                label: INCIDENT_SEVERITY_LABELS[s],
+              }))}
             />
 
-            <div className="flex justify-center gap-2">
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Saving changes..." : "Save Changes"}
-              </Button>
-            </div>
-          </form>
-        </Form>
+            <TextField
+              control={form.control}
+              name="reference_id"
+              label="Reference ID"
+              placeholder="Optional"
+            />
+
+            <DateField
+              control={form.control}
+              name="date"
+              label="Date"
+              placeholder="Pick a date"
+            />
+
+            <TextField
+              control={form.control}
+              name="time"
+              label="Incident Time"
+              type="time"
+            />
+          </div>
+
+          <TextareaField
+            control={form.control}
+            name="description"
+            label="Description"
+            rows={4}
+            textareaClassName="shadow-xs input-shadow transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:ring-destructive/20"
+            description="Optional details about the incident."
+          />
+        </FormShell>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/PaginationControls.tsx
+++ b/frontend/src/components/PaginationControls.tsx
@@ -71,12 +71,13 @@ export default function PaginationControls({
         className
       )}
     >
-      <div className="hidden @lg:flex items-center justify-start min-w-0">
+      <div className="flex items-center justify-start min-w-0">
         {isLoading ? (
-          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-4 w-22" />
         ) : (
           <span className="text-sm text-muted-foreground whitespace-nowrap">
-            Results {rangeStart} - {rangeEnd} of {totalCount}
+            <span className="hidden @xl:inline">Results </span>
+            {rangeStart} - {rangeEnd} of {totalCount}
           </span>
         )}
       </div>
@@ -97,6 +98,7 @@ export default function PaginationControls({
                     ? "pointer-events-none opacity-50"
                     : "cursor-pointer"
                 )}
+                labelClassName="hidden @lg:block"
               />
             </PaginationItem>
             {isLoading ? (
@@ -167,6 +169,7 @@ export default function PaginationControls({
                     ? "pointer-events-none opacity-50"
                     : "cursor-pointer"
                 )}
+                labelClassName="hidden @lg:block"
               />
             </PaginationItem>
           </PaginationContent>
@@ -174,7 +177,7 @@ export default function PaginationControls({
       </div>
 
       <div className="flex items-center justify-end gap-2">
-        <span className="hidden @md:inline text-sm text-muted-foreground whitespace-nowrap">
+        <span className="hidden @xl:inline text-sm text-muted-foreground whitespace-nowrap">
           Rows per page:
         </span>
         {isLoading ? (

--- a/frontend/src/components/form/FormShell.tsx
+++ b/frontend/src/components/form/FormShell.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { SubmitButton } from "@/components/form/SubmitButton";
+import { FieldGroup, FieldSet } from "@/components/ui/field";
+import { Form } from "@/components/ui/form";
+import type {
+  FieldValues,
+  SubmitHandler,
+  UseFormReturn,
+} from "react-hook-form";
+
+type FormShellProps<
+  TFieldValues extends FieldValues,
+  TContext,
+  TTransformed extends FieldValues,
+> = {
+  form: UseFormReturn<TFieldValues, TContext, TTransformed>;
+  onSubmit: SubmitHandler<TTransformed>;
+  children: React.ReactNode;
+  submitLabel: string;
+  pendingLabel?: string;
+  /** Server-side error banner rendered above the submit button when set. */
+  submissionError?: string | null;
+  /** Override the in-progress flag (defaults to form.formState.isSubmitting). */
+  pending?: boolean;
+  /**
+   * className for the submit button. Defaults to full width (the submit row is a
+   * flex column, so the button stretches). Pass e.g. "self-center" for a
+   * natural-width, centered button.
+   */
+  submitClassName?: string;
+};
+
+/**
+ * Standard shell for the staff table forms (and any form with the same chrome):
+ * the Form provider, the <form> element wired to handleSubmit, the
+ * FieldGroup/FieldSet layout wrapper, an optional error banner, and a submit
+ * button. Fields are passed as children; layout within them stays in the form.
+ */
+export function FormShell<
+  TFieldValues extends FieldValues,
+  TContext,
+  TTransformed extends FieldValues,
+>({
+  form,
+  onSubmit,
+  children,
+  submitLabel,
+  pendingLabel,
+  submissionError,
+  pending,
+  submitClassName,
+}: FormShellProps<TFieldValues, TContext, TTransformed>) {
+  const isPending = pending ?? form.formState.isSubmitting;
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FieldGroup>
+          <FieldSet>
+            {children}
+
+            <div className="flex flex-col gap-3">
+              {submissionError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {submissionError}
+                </div>
+              )}
+              <SubmitButton
+                pending={isPending}
+                label={submitLabel}
+                pendingLabel={pendingLabel}
+                className={submitClassName}
+              />
+            </div>
+          </FieldSet>
+        </FieldGroup>
+      </form>
+    </Form>
+  );
+}

--- a/frontend/src/components/form/SubmitButton.tsx
+++ b/frontend/src/components/form/SubmitButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+type SubmitButtonProps = React.ComponentProps<typeof Button> & {
+  /** Whether a submit is in progress (disables + swaps the label). */
+  pending?: boolean;
+  label: React.ReactNode;
+  pendingLabel?: React.ReactNode;
+};
+
+/**
+ * A submit button that swaps its label and disables itself while a submit is in
+ * progress. `pending` is passed explicitly so it works both with
+ * react-hook-form's `formState.isSubmitting` and with externally-owned mutation
+ * state (e.g. a parent's `mutation.isPending`). Sizing/alignment is the
+ * caller's job via `className`.
+ */
+export function SubmitButton({
+  pending = false,
+  label,
+  pendingLabel = "Submitting...",
+  disabled,
+  ...props
+}: SubmitButtonProps) {
+  return (
+    <Button type="submit" {...props} disabled={pending || disabled}>
+      {pending ? pendingLabel : label}
+    </Button>
+  );
+}

--- a/frontend/src/components/form/fields.tsx
+++ b/frontend/src/components/form/fields.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import AddressSearch from "@/components/AddressSearch";
+import DatePicker from "@/components/DatePicker";
+import { Button } from "@/components/ui/button";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { AutocompleteResult } from "@/lib/api/location/location.types";
+import { cn, formatPhoneNumberInput } from "@/lib/utils";
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+import type { Control, FieldPath, FieldValues } from "react-hook-form";
+
+/**
+ * App-specific form field components built on top of the shadcn `Form`
+ * primitives + react-hook-form. Each wraps the
+ * FormField -> FormItem -> FormLabel -> FormControl -> FormMessage chain so
+ * the label/spacing/error styling lives in one place. Pass `control` and a
+ * typed `name`; layout stays in the consuming form. For anything these don't
+ * cover, drop down to a raw <FormField> (the escape hatch).
+ */
+
+/** Props shared by every field: how it binds + how the surrounding chrome looks. */
+type BaseFieldProps<T extends FieldValues> = {
+  control: Control<T>;
+  name: FieldPath<T>;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  /** className for the FormItem (layout: width, grid span, gap overrides). */
+  className?: string;
+  /** className for the FormLabel. */
+  labelClassName?: string;
+  /** className for the FormDescription. */
+  descriptionClassName?: string;
+};
+
+// -- TextField ---------------------------------------------------------------
+
+type TextFieldProps<T extends FieldValues> = BaseFieldProps<T> & {
+  inputClassName?: string;
+} & Omit<
+    React.ComponentProps<typeof Input>,
+    "name" | "value" | "defaultValue" | "onChange" | "onBlur" | "className"
+  >;
+
+export function TextField<T extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  className,
+  labelClassName,
+  descriptionClassName,
+  inputClassName,
+  ...inputProps
+}: TextFieldProps<T>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={className}>
+          <FormLabel className={labelClassName}>{label}</FormLabel>
+          <FormControl>
+            <Input
+              {...inputProps}
+              name={field.name}
+              ref={field.ref}
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              value={(field.value as string | undefined) ?? ""}
+              className={inputClassName}
+            />
+          </FormControl>
+          {description && (
+            <FormDescription className={descriptionClassName}>
+              {description}
+            </FormDescription>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+// -- PhoneField --------------------------------------------------------------
+
+type PhoneFieldProps<T extends FieldValues> = BaseFieldProps<T> & {
+  placeholder?: string;
+  disabled?: boolean;
+  inputClassName?: string;
+};
+
+export function PhoneField<T extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  className,
+  labelClassName,
+  descriptionClassName,
+  inputClassName,
+  placeholder = "(123) 456-7890",
+  disabled,
+}: PhoneFieldProps<T>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={className}>
+          <FormLabel className={labelClassName}>{label}</FormLabel>
+          <FormControl>
+            <Input
+              type="tel"
+              placeholder={placeholder}
+              disabled={disabled}
+              maxLength={14}
+              autoComplete="off"
+              name={field.name}
+              ref={field.ref}
+              onBlur={field.onBlur}
+              value={formatPhoneNumberInput((field.value as string) ?? "")}
+              onChange={(e) =>
+                field.onChange(e.target.value.replace(/\D/g, "").slice(0, 10))
+              }
+              className={inputClassName}
+            />
+          </FormControl>
+          {description && (
+            <FormDescription className={descriptionClassName}>
+              {description}
+            </FormDescription>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+// -- PasswordField -----------------------------------------------------------
+
+type PasswordFieldProps<T extends FieldValues> = BaseFieldProps<T> & {
+  autoComplete?: string;
+  inputClassName?: string;
+};
+
+export function PasswordField<T extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  className,
+  labelClassName,
+  descriptionClassName,
+  inputClassName,
+  autoComplete,
+}: PasswordFieldProps<T>) {
+  const [show, setShow] = useState(false);
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={className}>
+          <FormLabel className={labelClassName}>{label}</FormLabel>
+          <div className="relative">
+            <FormControl>
+              <Input
+                type={show ? "text" : "password"}
+                autoComplete={autoComplete}
+                name={field.name}
+                ref={field.ref}
+                onBlur={field.onBlur}
+                onChange={field.onChange}
+                value={(field.value as string | undefined) ?? ""}
+                className={cn("pr-10", inputClassName)}
+              />
+            </FormControl>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => setShow((v) => !v)}
+              className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              aria-label={show ? "Hide password" : "Show password"}
+            >
+              {show ? (
+                <EyeOff className="size-4" />
+              ) : (
+                <Eye className="size-4" />
+              )}
+            </Button>
+          </div>
+          {description && (
+            <FormDescription className={descriptionClassName}>
+              {description}
+            </FormDescription>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+// -- TextareaField -----------------------------------------------------------
+
+type TextareaFieldProps<T extends FieldValues> = BaseFieldProps<T> & {
+  textareaClassName?: string;
+} & Omit<
+    React.ComponentProps<typeof Textarea>,
+    "name" | "value" | "defaultValue" | "onChange" | "onBlur" | "className"
+  >;
+
+export function TextareaField<T extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  className,
+  labelClassName,
+  descriptionClassName,
+  textareaClassName,
+  ...textareaProps
+}: TextareaFieldProps<T>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={className}>
+          <FormLabel className={labelClassName}>{label}</FormLabel>
+          <FormControl>
+            <Textarea
+              {...textareaProps}
+              name={field.name}
+              ref={field.ref}
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              value={(field.value as string | undefined) ?? ""}
+              className={textareaClassName}
+            />
+          </FormControl>
+          {description && (
+            <FormDescription className={descriptionClassName}>
+              {description}
+            </FormDescription>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+// -- SelectField -------------------------------------------------------------
+
+type SelectFieldProps<T extends FieldValues> = BaseFieldProps<T> & {
+  options: ReadonlyArray<{ value: string; label: string }>;
+  placeholder?: string;
+  disabled?: boolean;
+  triggerClassName?: string;
+  itemClassName?: string;
+  /** title attr on the trigger (e.g. disabled-field explanation). */
+  triggerTitle?: string;
+};
+
+export function SelectField<T extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  className,
+  labelClassName,
+  descriptionClassName,
+  triggerClassName,
+  itemClassName,
+  triggerTitle,
+  options,
+  placeholder,
+  disabled,
+}: SelectFieldProps<T>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={className}>
+          <FormLabel className={labelClassName}>{label}</FormLabel>
+          <Select
+            value={field.value as string | undefined}
+            onValueChange={field.onChange}
+            disabled={disabled}
+          >
+            <FormControl>
+              <SelectTrigger className={triggerClassName} title={triggerTitle}>
+                <SelectValue placeholder={placeholder} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem
+                  key={option.value}
+                  value={option.value}
+                  className={itemClassName}
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {description && (
+            <FormDescription className={descriptionClassName}>
+              {description}
+            </FormDescription>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+// -- DateField ---------------------------------------------------------------
+
+type DateFieldProps<T extends FieldValues> = BaseFieldProps<T> &
+  Omit<
+    React.ComponentProps<typeof DatePicker>,
+    "value" | "onChange" | "aria-invalid"
+  >;
+
+export function DateField<T extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  className,
+  labelClassName,
+  descriptionClassName,
+  ...datePickerProps
+}: DateFieldProps<T>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => (
+        <FormItem className={className}>
+          <FormLabel className={labelClassName}>{label}</FormLabel>
+          <FormControl>
+            <DatePicker
+              {...datePickerProps}
+              value={(field.value as Date | null | undefined) ?? null}
+              onChange={field.onChange}
+              aria-invalid={fieldState.invalid}
+            />
+          </FormControl>
+          {description && (
+            <FormDescription className={descriptionClassName}>
+              {description}
+            </FormDescription>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+// -- AddressField ------------------------------------------------------------
+
+type AddressFieldProps<T extends FieldValues> = BaseFieldProps<T> & {
+  /**
+   * Derives the value stored in the bound field from the selected address.
+   * Defaults to the formatted address string.
+   */
+  getStoredValue?: (address: AutocompleteResult | null) => unknown;
+  /** Extra side-effect on select, e.g. setting a companion placeId field. */
+  onSelect?: (address: AutocompleteResult | null) => void;
+} & Omit<
+    React.ComponentProps<typeof AddressSearch>,
+    "onSelect" | "error" | "id"
+  >;
+
+export function AddressField<T extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  className,
+  labelClassName,
+  descriptionClassName,
+  getStoredValue,
+  onSelect,
+  value,
+  ...addressProps
+}: AddressFieldProps<T>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        // When the bound field holds the formatted address (default), use it as
+        // the search input's display value. When it holds something else (e.g. a
+        // place_id via getStoredValue), rely on the explicit `value`/initialSelection.
+        const displayValue =
+          value ?? (getStoredValue ? undefined : (field.value as string));
+        return (
+          <FormItem className={className}>
+            <FormLabel className={labelClassName}>{label}</FormLabel>
+            <FormControl>
+              <AddressSearch
+                {...addressProps}
+                value={displayValue}
+                error={fieldState.error?.message}
+                onSelect={(address) => {
+                  field.onChange(
+                    getStoredValue
+                      ? getStoredValue(address)
+                      : (address?.formatted_address ?? "")
+                  );
+                  onSelect?.(address);
+                }}
+              />
+            </FormControl>
+            {description && (
+              <FormDescription className={descriptionClassName}>
+                {description}
+              </FormDescription>
+            )}
+            <FormMessage />
+          </FormItem>
+        );
+      }}
+    />
+  );
+}

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -79,7 +79,10 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
     <FormItemContext.Provider value={{ id }}>
       <div
         data-slot="form-item"
-        className={cn("grid gap-2", className)}
+        className={cn(
+          "flex w-full flex-col gap-3 *:w-full [&>.sr-only]:w-auto",
+          className
+        )}
         {...props}
       />
     </FormItemContext.Provider>

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -101,17 +101,30 @@ function PaginationLast({
 function PaginationPrevious({
   className,
   text = "Previous",
+  showLabel,
+  labelClassName,
   ...props
-}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+}: React.ComponentProps<typeof PaginationLink> & {
+  text?: string;
+  showLabel?: boolean;
+  labelClassName?: string;
+}) {
+  const labelClass =
+    labelClassName ??
+    (showLabel === undefined
+      ? "hidden sm:block"
+      : showLabel
+        ? undefined
+        : "hidden");
   return (
     <PaginationLink
       aria-label="Go to previous page"
-      size="default"
-      className={cn("pl-1.5!", className)}
+      size={showLabel === false ? "icon" : "default"}
+      className={cn(showLabel !== false && "pl-1.5!", className)}
       {...props}
     >
       <ChevronLeftIcon data-icon="inline-start" className="cn-rtl-flip" />
-      <span className="hidden sm:block">{text}</span>
+      <span className={labelClass}>{text}</span>
     </PaginationLink>
   );
 }
@@ -119,16 +132,29 @@ function PaginationPrevious({
 function PaginationNext({
   className,
   text = "Next",
+  showLabel,
+  labelClassName,
   ...props
-}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+}: React.ComponentProps<typeof PaginationLink> & {
+  text?: string;
+  showLabel?: boolean;
+  labelClassName?: string;
+}) {
+  const labelClass =
+    labelClassName ??
+    (showLabel === undefined
+      ? "hidden sm:block"
+      : showLabel
+        ? undefined
+        : "hidden");
   return (
     <PaginationLink
       aria-label="Go to next page"
-      size="default"
-      className={cn("pr-1.5!", className)}
+      size={showLabel === false ? "icon" : "default"}
+      className={cn(showLabel !== false && "pr-1.5!", className)}
       {...props}
     >
-      <span className="hidden sm:block">{text}</span>
+      <span className={labelClass}>{text}</span>
       <ChevronRightIcon data-icon="inline-end" className="cn-rtl-flip" />
     </PaginationLink>
   );

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -101,30 +101,21 @@ function PaginationLast({
 function PaginationPrevious({
   className,
   text = "Previous",
-  showLabel,
-  labelClassName,
+  labelClassName = "hidden sm:block",
   ...props
 }: React.ComponentProps<typeof PaginationLink> & {
   text?: string;
-  showLabel?: boolean;
   labelClassName?: string;
 }) {
-  const labelClass =
-    labelClassName ??
-    (showLabel === undefined
-      ? "hidden sm:block"
-      : showLabel
-        ? undefined
-        : "hidden");
   return (
     <PaginationLink
       aria-label="Go to previous page"
-      size={showLabel === false ? "icon" : "default"}
-      className={cn(showLabel !== false && "pl-1.5!", className)}
+      size="default"
+      className={cn("pl-1.5!", className)}
       {...props}
     >
       <ChevronLeftIcon data-icon="inline-start" className="cn-rtl-flip" />
-      <span className={labelClass}>{text}</span>
+      <span className={labelClassName}>{text}</span>
     </PaginationLink>
   );
 }
@@ -132,29 +123,20 @@ function PaginationPrevious({
 function PaginationNext({
   className,
   text = "Next",
-  showLabel,
-  labelClassName,
+  labelClassName = "hidden sm:block",
   ...props
 }: React.ComponentProps<typeof PaginationLink> & {
   text?: string;
-  showLabel?: boolean;
   labelClassName?: string;
 }) {
-  const labelClass =
-    labelClassName ??
-    (showLabel === undefined
-      ? "hidden sm:block"
-      : showLabel
-        ? undefined
-        : "hidden");
   return (
     <PaginationLink
       aria-label="Go to next page"
-      size={showLabel === false ? "icon" : "default"}
-      className={cn(showLabel !== false && "pr-1.5!", className)}
+      size="default"
+      className={cn("pr-1.5!", className)}
       {...props}
     >
-      <span className={labelClass}>{text}</span>
+      <span className={labelClassName}>{text}</span>
       <ChevronRightIcon data-icon="inline-end" className="cn-rtl-flip" />
     </PaginationLink>
   );

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -71,8 +71,8 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-5 left-5 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-5" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>


### PR DESCRIPTION
Comprehensive accessibility improvements across the frontend ahead of production deployment.

Changes:

- Migrated all forms to React Hook Form (RHF) + shadcn `Form` components, which provide built-in `aria-describedby` wiring between fields and their error messages (#431)
- Rebuilt the detail sidebar on Radix `Sheet` (via shadcn), gaining keyboard-trap, focus management, and `role="dialog"` semantics for free (#266)
- Added `aria-label`, `aria-labelledby`, `aria-describedby`, and `aria-hidden` attributes throughout the app where missing
- Replaced raw `<button>` elements with shadcn `<Button>` to ensure consistent accessible button behavior (#441)
- Fixed nested `<main>` landmark issues — each page now has exactly one `<main>` region (#430)
- Added proper region labels to landmark elements (header, nav, main, footer)
- Tuned pagination layout on the police page — fixed overlapping text and container query breakpoints (#443)
- Extracted shared `FormShell`, `SubmitButton`, and field components to reduce duplication across form pages

Closes #266
Closes #430
Closes #431
Closes #441
Closes #443