### PR TITLE
feat: migrate from programmatic autofill to html form autofill

### DIFF
--- a/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
@@ -453,6 +453,7 @@ export default function PartyRegistrationForm({
                   labelClassName="content-bold"
                   inputClassName="content"
                   placeholder=""
+                  autoComplete="section-contact-two given-name"
                 />
 
                 <TextField
@@ -462,6 +463,7 @@ export default function PartyRegistrationForm({
                   labelClassName="content-bold"
                   inputClassName="content"
                   placeholder=""
+                  autoComplete="section-contact-two family-name"
                 />
               </div>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
@@ -471,6 +473,7 @@ export default function PartyRegistrationForm({
                   label="Phone Number"
                   labelClassName="content-bold"
                   inputClassName="content"
+                  autoComplete="section-contact-two tel"
                 />
 
                 <SelectField
@@ -496,6 +499,7 @@ export default function PartyRegistrationForm({
                 inputClassName="content"
                 type="email"
                 placeholder="student@unc.edu"
+                autoComplete="section-contact-two email"
               />
             </div>
 

--- a/frontend/src/app/(student)/new-party/page.tsx
+++ b/frontend/src/app/(student)/new-party/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import PartyRegistrationForm, {
-  PartyFormInitialValues,
   PartyFormValues,
   partyFormValuesToDto,
 } from "@/app/(student)/_components/PartyRegistrationForm";
@@ -11,19 +10,17 @@ import { useRegisterParty } from "@/lib/api/party/party.queries";
 import { getPartyValidationError } from "@/lib/api/party/party.types";
 import {
   useCurrentStudent,
-  useMyParties,
   useUpdateStudent,
 } from "@/lib/api/student/student.queries";
 import { isFromThisSchoolYear } from "@/lib/utils";
 import { ArrowLeft, Info } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function RegistrationForm() {
   const registerPartyMutation = useRegisterParty();
   const updateStudentMutation = useUpdateStudent();
-  const partiesQuery = useMyParties();
   const studentQuery = useCurrentStudent();
   const router = useRouter();
   const { openSnackbar } = useSnackbar();
@@ -42,40 +39,6 @@ export default function RegistrationForm() {
     if (!isRedirectingBlockedStudent) return;
     router.replace("/");
   }, [isRedirectingBlockedStudent, router]);
-
-  /**
-   * Get initial values from the student's most recent party (if they have one).
-   * Prefills second contact information to save time for repeat registrations.
-   */
-  const initialValues: PartyFormInitialValues | undefined = useMemo(() => {
-    if (!partiesQuery.data || partiesQuery.data.length === 0) {
-      return undefined;
-    }
-
-    // Sort parties by date (most recent first) and get the latest
-    const sortedParties = [...partiesQuery.data].sort(
-      (a, b) =>
-        new Date(b.party_datetime).getTime() -
-        new Date(a.party_datetime).getTime()
-    );
-    const lastParty = sortedParties[0];
-
-    if (!lastParty.contact_two) {
-      return undefined;
-    }
-
-    return {
-      location: {
-        formatted_address: lastParty.location.formatted_address,
-        google_place_id: lastParty.location.google_place_id,
-      },
-      secondContactFirstName: lastParty.contact_two.first_name,
-      secondContactLastName: lastParty.contact_two.last_name,
-      phoneNumber: lastParty.contact_two.phone_number,
-      contactPreference: lastParty.contact_two.contact_preference,
-      contactTwoEmail: lastParty.contact_two.email,
-    };
-  }, [partiesQuery.data]);
 
   const handleSubmit = async (values: PartyFormValues) => {
     setSubmissionError(null);
@@ -141,7 +104,6 @@ export default function RegistrationForm() {
 
               <PartyRegistrationForm
                 onSubmit={handleSubmit}
-                initialValues={initialValues}
                 student={studentQuery.data}
                 submissionError={submissionError}
               />

--- a/frontend/src/components/form/fields.tsx
+++ b/frontend/src/components/form/fields.tsx
@@ -105,6 +105,7 @@ type PhoneFieldProps<T extends FieldValues> = BaseFieldProps<T> & {
   placeholder?: string;
   disabled?: boolean;
   inputClassName?: string;
+  autoComplete?: string;
 };
 
 export function PhoneField<T extends FieldValues>({
@@ -118,6 +119,7 @@ export function PhoneField<T extends FieldValues>({
   inputClassName,
   placeholder = "(123) 456-7890",
   disabled,
+  autoComplete = "off",
 }: PhoneFieldProps<T>) {
   return (
     <FormField
@@ -132,7 +134,7 @@ export function PhoneField<T extends FieldValues>({
               placeholder={placeholder}
               disabled={disabled}
               maxLength={14}
-              autoComplete="off"
+              autoComplete={autoComplete}
               name={field.name}
               ref={field.ref}
               onBlur={field.onBlur}


### PR DESCRIPTION
Replaces the custom prefill logic that fetched a student's most recent party to prepopulate second contact fields. Instead, native HTML `autoComplete` attributes are used, letting the browser handle credential/contact suggestions for free.

Changes:

- Added `autoComplete` attributes (`section-contact-two given-name`, `family-name`, `tel`, `email`) to the second contact fields in `PartyRegistrationForm`
- Removed the `useMyParties` query, `initialValues` computation, and `PartyFormInitialValues` prop from the new-party page — no longer needed
- Made `autoComplete` a configurable prop on `PhoneField` (defaulting to `"off"`) so the second contact phone field can opt in

Closes #447