### PR TITLE
feat: add default for NEXT_PUBLIC_COURSE_LINK and update deploy docs

### DIFF
--- a/deploy/.env.prod.template
+++ b/deploy/.env.prod.template
@@ -58,20 +58,17 @@ GOOGLE_MAPS_API_KEY=
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 NEXT_PUBLIC_GOOGLE_MAP_ID=
 
-# ── App content ───────────────────────────────────────────────────────────────
-# Public-facing URL of the Party Smart course / scheduling page. Required.
-NEXT_PUBLIC_COURSE_LINK=
-
 # ── App config (all optional) ─────────────────────────────────────────────────
 # Shared vars — single value read by both the backend and the frontend build.
+# NEXT_PUBLIC_COURSE_LINK= (defaults to https://go.unc.edu/PartySmartClass)
 # NEXT_PUBLIC_CONTACT_EMAIL=
 # NEXT_PUBLIC_CHPD_EMAIL_DOMAIN=
 # NEXT_PUBLIC_PARTY_SEARCH_RADIUS_MILES=
 # NEXT_PUBLIC_ACADEMIC_YEAR_SWITCH_DATE=
 # NEXT_PUBLIC_PARTY_MIN_LEAD_HOURS=
 # NEXT_PUBLIC_PARTY_MAX_LEAD_DAYS=
-# NEXT_PUBLIC_POLICE_VERIFICATION_RESEND_COOLDOWN_SECONDS=
 # OCSL_WEBSITE_URL=
+# NEXT_PUBLIC_POLICE_VERIFICATION_RESEND_COOLDOWN_SECONDS=
 # EMAIL_VERIFICATION_TOKEN_EXPIRE_HOURS=
 # INVITE_TOKEN_EXPIRY_HOURS=
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -206,6 +206,26 @@ deploy:
 
 ---
 
+## OCSL Configuration Checklist
+
+The following variables are OCSL-owned — confirm their values with OCSL before
+deploying. Most have built-in defaults (see `backend/src/core/config.py` and
+`frontend/src/lib/config/env.client.ts`); set them explicitly only if the
+default is wrong.
+
+| Variable | Notes |
+|---|---|
+| `OCSL_WEBSITE_URL` | OCSL's public website URL, linked in the app footer |
+| `NEXT_PUBLIC_COURSE_LINK` | Link where students can schedule the Party Smart course |
+| `NEXT_PUBLIC_CONTACT_EMAIL` | Contact email displayed in the app |
+| `NEXT_PUBLIC_CHPD_EMAIL_DOMAIN` | Expected email domain for police officers during signup |
+| `NEXT_PUBLIC_ACADEMIC_YEAR_SWITCH_DATE` | MM-DD date when the academic year rolls over |
+| `NEXT_PUBLIC_PARTY_MIN_LEAD_HOURS` | Minimum hours of advance notice required to register a party |
+| `NEXT_PUBLIC_PARTY_MAX_LEAD_DAYS` | Maximum days in advance a party can be registered |
+| `NEXT_PUBLIC_PARTY_SEARCH_RADIUS_MILES` | Radius used to cluster nearby parties on the map |
+
+---
+
 ## Deploy Checklist
 
 ### First deploy

--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -81,7 +81,7 @@ NEXT_PUBLIC_GOOGLE_MAP_ID=REPLACE_ME
 # Public-facing URL of the Party Smart course / scheduling page. Required.
 # Used for the "Schedule a meeting" link shown to students who haven't completed
 # the course.
-NEXT_PUBLIC_COURSE_LINK=REPLACE_ME
+NEXT_PUBLIC_COURSE_LINK=https://go.unc.edu/PartySmartClass
 
 # Contact email shown in the footer, auth error page, and address-hardship copy.
 # Also read by the backend as the Reply-To header on outgoing emails — set once

--- a/frontend/src/lib/config/env.client.ts
+++ b/frontend/src/lib/config/env.client.ts
@@ -49,7 +49,10 @@ const schema = z.object({
     emptyToUndefined,
     z.email().default("offcampus@unc.edu")
   ),
-  NEXT_PUBLIC_COURSE_LINK: z.url(),
+  NEXT_PUBLIC_COURSE_LINK: z.preprocess(
+    emptyToUndefined,
+    z.url().default("https://go.unc.edu/PartySmartClass")
+  ),
   NEXT_PUBLIC_PARTY_MIN_LEAD_HOURS: z.preprocess(
     emptyToUndefined,
     z.coerce.number().int().positive().default(24)


### PR DESCRIPTION
Sets `https://go.unc.edu/PartySmartClass` as the built-in default for `NEXT_PUBLIC_COURSE_LINK` so the app works out of the box without requiring the value to be explicitly set on every deploy.

Changes:

- Added `emptyToUndefined` + `.default("https://go.unc.edu/PartySmartClass")` to `NEXT_PUBLIC_COURSE_LINK` in `env.client.ts`
- Updated `frontend/.env.template` to show the actual default URL instead of `REPLACE_ME`
- Updated `deploy/.env.prod.template` to comment out `NEXT_PUBLIC_COURSE_LINK` (now optional, matching the pattern of other defaulted vars) and noted the default in its comment
- Added an OCSL Configuration Checklist section to `deploy/README.md` listing the vars IT should confirm with OCSL before deploying

Closes #445