### PR TITLE
fix: contact two email notice, autocomplete, and address change bug

### DIFF
--- a/backend/src/modules/notification/notification_service.py
+++ b/backend/src/modules/notification/notification_service.py
@@ -111,18 +111,34 @@ class NotificationService:
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
         }
 
-    def _party_notification_html(self, party: PartyDto, recipient_name: str, email: str) -> str:
+    def _party_notification_html(
+        self, party: PartyDto, recipient_name: str, email: str, *, is_contact_two: bool = False
+    ) -> str:
         dt = party.party_datetime.astimezone(ZoneInfo("America/New_York")).strftime(
             "%B %-d, %Y at %-I:%M %p %Z"
         )
         management_url = self._management_url(email)
         c1 = party.contact_one
         c2 = party.contact_two
+        contact_two_notice = (
+            """
+            <p style="margin:0 0 16px 0;">
+                <strong>Please note:</strong> You are listed as the
+                <strong>secondary contact</strong>
+                for this registration. Being listed as a secondary contact does not mean you are
+                registered for Party Smart. If you wish to become a primary contact, you must
+                complete the required course and registration process independently.
+            </p>
+            """
+            if is_contact_two
+            else ""
+        )
         return f"""
             <p style="margin:0 0 12px 0;">Hi {escape(recipient_name)},</p>
             <p style="margin:0 0 16px 0;">
                 A party registration has been submitted with you listed as a contact.
             </p>
+            {contact_two_notice}
             <ul style="margin:0 0 16px 0;padding-left:20px;">
                 <li><strong>Address:</strong> {escape(party.location.formatted_address)}</li>
                 <li><strong>Date &amp; Time:</strong> {dt}</li>
@@ -134,12 +150,16 @@ class NotificationService:
             <p style="margin:24px 0 0 0;font-size:12px;color:#6b7280;">
                 <a href="{management_url}" style="color:#6b7280;">
                     Unsubscribe or manage your notifications here
-                </a>.
+                </a>
             </p>
         """
 
-    async def _send_party_notification(self, party: PartyDto, email: str, first_name: str) -> None:
-        html = self._party_notification_html(party, first_name, email)
+    async def _send_party_notification(
+        self, party: PartyDto, email: str, first_name: str, *, is_contact_two: bool = False
+    ) -> None:
+        html = self._party_notification_html(
+            party, first_name, email, is_contact_two=is_contact_two
+        )
         headers = self._list_unsubscribe_headers(email)
         await self.email_service.send_email(
             email, "Party registration confirmation", html, headers=headers
@@ -148,14 +168,16 @@ class NotificationService:
     async def notify_party_created(self, party: PartyDto) -> None:
         """Send party notification emails to both contacts. Failures are logged, not raised."""
         recipients = [
-            (party.contact_one.email, party.contact_one.first_name),
-            (party.contact_two.email, party.contact_two.first_name),
+            (party.contact_one.email, party.contact_one.first_name, False),
+            (party.contact_two.email, party.contact_two.first_name, True),
         ]
-        for email, first_name in recipients:
+        for email, first_name, is_contact_two in recipients:
             try:
                 if await self.is_unsubscribed(email):
                     continue
-                await self._send_party_notification(party, email, first_name)
+                await self._send_party_notification(
+                    party, email, first_name, is_contact_two=is_contact_two
+                )
             except Exception:
                 logger.exception("Failed to send party notification to %s", email)
 
@@ -165,6 +187,8 @@ class NotificationService:
         try:
             if await self.is_unsubscribed(email):
                 return
-            await self._send_party_notification(party, email, party.contact_two.first_name)
+            await self._send_party_notification(
+                party, email, party.contact_two.first_name, is_contact_two=True
+            )
         except Exception:
             logger.exception("Failed to send party notification to %s", email)

--- a/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
@@ -269,9 +269,12 @@ export default function PartyRegistrationForm({
   const pendingSubmitRef = useRef<PartyFormValues | null>(null);
 
   const handleValid = async (data: PartyFormValues) => {
+    const baselineGooglePlaceId =
+      initialValues?.location?.google_place_id ??
+      (validResidence ? student?.residence?.location.google_place_id : null);
     const locationChanged =
-      !initialValues?.location ||
-      data.location.google_place_id !== initialValues.location.google_place_id;
+      !baselineGooglePlaceId ||
+      data.location.google_place_id !== baselineGooglePlaceId;
 
     if (locationChanged) {
       pendingSubmitRef.current = data;
@@ -453,7 +456,7 @@ export default function PartyRegistrationForm({
                   labelClassName="content-bold"
                   inputClassName="content"
                   placeholder=""
-                  autoComplete="section-contact-two given-name"
+                  autoComplete="section-contact-two field-1"
                 />
 
                 <TextField
@@ -463,7 +466,7 @@ export default function PartyRegistrationForm({
                   labelClassName="content-bold"
                   inputClassName="content"
                   placeholder=""
-                  autoComplete="section-contact-two family-name"
+                  autoComplete="section-contact-two field-2"
                 />
               </div>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
@@ -473,7 +476,7 @@ export default function PartyRegistrationForm({
                   label="Phone Number"
                   labelClassName="content-bold"
                   inputClassName="content"
-                  autoComplete="section-contact-two tel"
+                  autoComplete="section-contact-two field-3"
                 />
 
                 <SelectField
@@ -499,7 +502,7 @@ export default function PartyRegistrationForm({
                 inputClassName="content"
                 type="email"
                 placeholder="student@unc.edu"
-                autoComplete="section-contact-two email"
+                autoComplete="section-contact-two field-4"
               />
             </div>
 


### PR DESCRIPTION
Fixes three issues with the party registration flow related to contact two handling.

Changes:

- Added a secondary contact notice to the email notification sent to contact two, clarifying they are not registered for Party Smart and must complete the process independently if they wish to become a primary contact
- Fixed contact two autocomplete attributes to use generic `field-N` tokens instead of semantic names (e.g. `given-name`, `family-name`) which were causing browsers to autofill contact one's info into contact two's fields
- Fixed address change confirmation dialog not triggering correctly when editing a party whose address was pre-filled from the student's residence — the baseline now prefers `initialValues.location.google_place_id` and falls back to the student's residence place ID

Closes #444