### PR TITLE
feat: migrate frontend to React Compiler

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { FlatCompat } from "@eslint/eslintrc";
+import noManualMemo from "eslint-plugin-react-no-manual-memo";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -11,6 +12,14 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    plugins: { "react-no-manual-memo": noManualMemo },
+    rules: {
+      "react-no-manual-memo/no-hook-memo": "warn",
+      "react-no-manual-memo/no-component-memo": "warn",
+      "react-no-manual-memo/no-custom-memo-hook": "warn",
+    },
+  },
   {
     ignores: [
       "node_modules/**",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,6 +6,7 @@ import "./src/lib/config/env.client";
 const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["saml2-js"],
+  reactCompiler: true,
   turbopack: {
     root: process.cwd(),
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,6 +55,7 @@
         "baseline-browser-mapping": "^2.9.19",
         "eslint": "^9",
         "eslint-config-next": "15.5.9",
+        "eslint-plugin-react-no-manual-memo": "^1.0.4",
         "prettier": "^3.7.4",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
@@ -7003,6 +7004,19 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-no-manual-memo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-no-manual-memo/-/eslint-plugin-react-no-manual-memo-1.0.4.tgz",
+      "integrity": "sha512-KMtuaB9GpnLelRLwnrm+nl534LuyR9LMOrisfSYlgwqhrHKKbQlycAiwZTmsrTNj5VV1mUyI361ROFLEk+b6DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.45.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@vis.gl/react-google-maps": "^1.6.1",
         "axios": "^1.12.2",
+        "babel-plugin-react-compiler": "^1.0.0",
         "chrono-node": "^2.9.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5598,6 +5599,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/balanced-match": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@vis.gl/react-google-maps": "^1.6.1",
     "axios": "^1.12.2",
+    "babel-plugin-react-compiler": "^1.0.0",
     "chrono-node": "^2.9.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "baseline-browser-mapping": "^2.9.19",
     "eslint": "^9",
     "eslint-config-next": "15.5.9",
+    "eslint-plugin-react-no-manual-memo": "^1.0.4",
     "prettier": "^3.7.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",

--- a/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
+++ b/frontend/src/app/(student)/_components/PartyRegistrationForm.tsx
@@ -20,7 +20,6 @@ import {
 import { Field, FieldGroup, FieldLabel, FieldSet } from "@/components/ui/field";
 import { Form } from "@/components/ui/form";
 import { Skeleton } from "@/components/ui/skeleton";
-import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import {
   PARTY_RULE_MESSAGES,
@@ -182,7 +181,6 @@ export interface PartyFormInitialValues {
 
 interface PartyRegistrationFormProps {
   onSubmit: (data: PartyFormValues) => void | Promise<void>;
-  locationService?: LocationService;
   initialValues?: PartyFormInitialValues;
   /** The authenticated student */
   student?: StudentDto | null;
@@ -198,7 +196,6 @@ const DEFAULT_CONTACT_PREFERENCE: "call" | "text" = "text";
 
 export default function PartyRegistrationForm({
   onSubmit,
-  locationService = new LocationService(),
   initialValues,
   student,
   submissionError,
@@ -359,7 +356,6 @@ export default function PartyRegistrationForm({
                     label="Party Address"
                     labelClassName="content-bold"
                     placeholder="Search for the party address..."
-                    locationService={locationService}
                     initialSelection={initialValues?.location}
                     value={form.watch("location")?.formatted_address}
                     getStoredValue={(address) => address ?? undefined}

--- a/frontend/src/app/(student)/_components/tracker/RegistrationIncidentCard.tsx
+++ b/frontend/src/app/(student)/_components/tracker/RegistrationIncidentCard.tsx
@@ -3,17 +3,13 @@ import {
   NestedIncidentDto,
 } from "@/lib/api/incident/incident.types";
 import { formatTime } from "@/lib/utils";
-import { memo } from "react";
 
 type Props = {
   date: string;
   incidents: NestedIncidentDto[];
 };
 
-const RegistrationIncidentCard = memo(function RegistrationIncidentCard({
-  date,
-  incidents,
-}: Props) {
+function RegistrationIncidentCard({ date, incidents }: Props) {
   return (
     <div className="px-4 py-4 border-b border-gray-200 rounded-none">
       <div>
@@ -32,6 +28,6 @@ const RegistrationIncidentCard = memo(function RegistrationIncidentCard({
       </div>
     </div>
   );
-});
+}
 
 export default RegistrationIncidentCard;

--- a/frontend/src/app/(student)/_components/tracker/RegistrationPartyCard.tsx
+++ b/frontend/src/app/(student)/_components/tracker/RegistrationPartyCard.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/lib/utils";
 import { format } from "date-fns/format";
 import { Ban, Mail, MoreVertical, Pencil, Phone } from "lucide-react";
-import { memo } from "react";
 
 type Props = {
   party: PartyDto;
@@ -28,7 +27,7 @@ type Props = {
   onDelete: (party: PartyDto) => void;
 };
 
-const RegistrationPartyCard = memo(function RegistrationPartyCard({
+function RegistrationPartyCard({
   party,
   showActions,
   showAddress,
@@ -138,6 +137,6 @@ const RegistrationPartyCard = memo(function RegistrationPartyCard({
       </div>
     </div>
   );
-});
+}
 
 export default RegistrationPartyCard;

--- a/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
+++ b/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
@@ -17,12 +17,58 @@ import { isFromThisSchoolYear } from "@/lib/utils";
 import { format } from "date-fns/format";
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import RegistrationIncidentCard from "./RegistrationIncidentCard";
 import RegistrationPartyCard from "./RegistrationPartyCard";
 
 const EMPTY_CLASS =
   "flex h-full items-center justify-center px-12 text-center content-sub text-base!";
+
+function splitParties(parties: PartyDto[]): {
+  activeParties: PartyDto[];
+  pastParties: PartyDto[];
+} {
+  const now = new Date();
+  const active: PartyDto[] = [];
+  const past: PartyDto[] = [];
+
+  parties.forEach((party) => {
+    const partyDate = new Date(party.party_datetime);
+    const twelveHoursAfterParty = new Date(
+      partyDate.getTime() + 12 * 60 * 60 * 1000
+    );
+    if (now > twelveHoursAfterParty) {
+      past.push(party);
+    } else {
+      active.push(party);
+    }
+  });
+
+  active.sort(
+    (a, b) =>
+      Math.abs(new Date(a.party_datetime).getTime() - now.getTime()) -
+      Math.abs(new Date(b.party_datetime).getTime() - now.getTime())
+  );
+  past.sort(
+    (a, b) =>
+      new Date(b.party_datetime).getTime() -
+      new Date(a.party_datetime).getTime()
+  );
+
+  return { activeParties: active, pastParties: past };
+}
+
+function groupIncidentsByDate(
+  incidents: NestedIncidentDto[]
+): [string, NestedIncidentDto[]][] {
+  const groups: Record<string, NestedIncidentDto[]> = {};
+  incidents.forEach((incident) => {
+    const dateKey = format(incident.incident_datetime, "MM/dd/yyyy");
+    if (!groups[dateKey]) groups[dateKey] = [];
+    groups[dateKey].push(incident);
+  });
+  return Object.entries(groups);
+}
 const TAB_CONTENT_CLASS = "h-full w-full overflow-y-auto rounded-md bg-card";
 
 function PartiesLoading() {
@@ -71,74 +117,20 @@ export default function RegistrationTracker(): React.JSX.Element {
       ? "Complete the Party Smart Course to register a party"
       : undefined;
 
-  const { activeParties, pastParties } = useMemo(() => {
-    const parties = partiesQuery.data ?? [];
-    const now = new Date();
-    const active: PartyDto[] = [];
-    const past: PartyDto[] = [];
-
-    parties.forEach((party) => {
-      const partyDate = new Date(party.party_datetime);
-      const twelveHoursAfterParty = new Date(
-        partyDate.getTime() + 12 * 60 * 60 * 1000
-      );
-
-      if (now > twelveHoursAfterParty) {
-        past.push(party);
-      } else {
-        active.push(party);
-      }
-    });
-
-    active.sort(
-      (a, b) =>
-        Math.abs(new Date(a.party_datetime).getTime() - now.getTime()) -
-        Math.abs(new Date(b.party_datetime).getTime() - now.getTime())
-    );
-    past.sort(
-      (a, b) =>
-        new Date(b.party_datetime).getTime() -
-        new Date(a.party_datetime).getTime()
-    );
-
-    return { activeParties: active, pastParties: past };
-  }, [partiesQuery.data]);
+  const { activeParties, pastParties } = splitParties(partiesQuery.data ?? []);
 
   const hasNoParties = (partiesQuery.data?.length ?? 0) === 0;
   const showPartySmartPrompt = hasNoParties && !courseCompleted;
 
-  const handleEditParty = useCallback(
-    (party: PartyDto) => setEditParty(party),
-    []
+  const sortedIncidents = [
+    ...(student?.residence?.location.incidents ?? []),
+  ].sort(
+    (a, b) =>
+      new Date(b.incident_datetime).getTime() -
+      new Date(a.incident_datetime).getTime()
   );
-  const handleDeleteParty = useCallback(
-    (party: PartyDto) => setDeleteParty(party),
-    []
-  );
 
-  const sortedIncidents = useMemo(() => {
-    const incidents: NestedIncidentDto[] =
-      student?.residence?.location.incidents ?? [];
-    return [...incidents].sort(
-      (a, b) =>
-        new Date(b.incident_datetime).getTime() -
-        new Date(a.incident_datetime).getTime()
-    );
-  }, [student?.residence?.location.incidents]);
-
-  const groupedIncidents = useMemo(() => {
-    const groups: Record<string, NestedIncidentDto[]> = {};
-
-    sortedIncidents.forEach((incident) => {
-      const dateKey = format(incident.incident_datetime, "MM/dd/yyyy");
-      if (!groups[dateKey]) {
-        groups[dateKey] = [];
-      }
-      groups[dateKey].push(incident);
-    });
-
-    return Object.entries(groups);
-  }, [sortedIncidents]);
+  const groupedIncidents = groupIncidentsByDate(sortedIncidents);
 
   const tabs: Array<{
     value: TabValue;
@@ -163,8 +155,8 @@ export default function RegistrationTracker(): React.JSX.Element {
               showActions
               residenceLocationId={residenceLocationId}
               isPartiesPending={isPartiesPending}
-              onEdit={handleEditParty}
-              onDelete={handleDeleteParty}
+              onEdit={setEditParty}
+              onDelete={setDeleteParty}
             />
           ))
         ),
@@ -183,8 +175,8 @@ export default function RegistrationTracker(): React.JSX.Element {
               showAddress
               residenceLocationId={residenceLocationId}
               isPartiesPending={isPartiesPending}
-              onEdit={handleEditParty}
-              onDelete={handleDeleteParty}
+              onEdit={setEditParty}
+              onDelete={setDeleteParty}
             />
           ))
         ),

--- a/frontend/src/app/police/_components/EmbeddedMap.tsx
+++ b/frontend/src/app/police/_components/EmbeddedMap.tsx
@@ -13,7 +13,7 @@ import {
   useMap,
 } from "@vis.gl/react-google-maps";
 import { format } from "date-fns";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 type Poi = {
   key: string;
@@ -35,31 +35,29 @@ const EmbeddedMap = ({
   exactMatch,
   onSelect,
 }: EmbeddedMapProps) => {
-  const locations = useMemo(
-    () =>
-      parties && parties.length > 0
-        ? parties.map((party) => ({
-            key: String(party.id),
-            location: {
-              lat: party.location.latitude,
-              lng: party.location.longitude,
-            },
-            party,
-          }))
-        : [],
-    [parties]
-  );
+  const locations =
+    parties && parties.length > 0
+      ? parties.map((party) => ({
+          key: String(party.id),
+          location: {
+            lat: party.location.latitude,
+            lng: party.location.longitude,
+          },
+          party,
+        }))
+      : [];
 
   const activePoiKey =
     activeParty?.id !== undefined ? String(activeParty.id) : undefined;
 
-  const exactMatchPoiKey = useMemo(() => {
-    if (!exactMatch?.google_place_id || !parties) return undefined;
-    const match = parties.find(
-      (p) => p.location.google_place_id === exactMatch.google_place_id
-    );
-    return match ? String(match.id) : undefined;
-  }, [exactMatch?.google_place_id, parties]);
+  const exactMatchPoiMatch = exactMatch?.google_place_id
+    ? parties?.find(
+        (p) => p.location.google_place_id === exactMatch.google_place_id
+      )
+    : undefined;
+  const exactMatchPoiKey = exactMatchPoiMatch
+    ? String(exactMatchPoiMatch.id)
+    : undefined;
   const defaultZoom = center ? 17 : 14;
   const mapCenter =
     center ||
@@ -70,13 +68,9 @@ const EmbeddedMap = ({
   const API_KEY = clientEnv.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   const mapKey = center ? `${center.lat}-${center.lng}` : "default";
 
-  // Stabilize reference so the circle effect doesn't re-fire when the parent
-  // passes a new inline object with the same lat/lng values.
-  const searchCenter = useMemo(
-    () => (center ? { lat: center.lat, lng: center.lng } : undefined),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [center?.lat, center?.lng]
-  );
+  const searchCenter = center
+    ? { lat: center.lat, lng: center.lng }
+    : undefined;
 
   const exactMatchKey = exactMatch?.google_place_id;
 
@@ -198,7 +192,7 @@ const PoiMarkers = ({
     };
   }, [map, searchCenter]);
 
-  const handleClick = useCallback(
+  const handleClick =
     (poi: (typeof pois)[0]) => (ev: google.maps.MapMouseEvent) => {
       if (!map || !ev.latLng) return;
       map.panTo(ev.latLng);
@@ -208,16 +202,14 @@ const PoiMarkers = ({
       if (poi.party && onSelect) {
         onSelect(poi.party);
       }
-    },
-    [map, onSelect]
-  );
+    };
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     setSelectedPoi(null);
     if (onSelect) {
       onSelect(null);
     }
-  }, [onSelect]);
+  };
 
   return (
     <>

--- a/frontend/src/app/police/_components/PartyCard.tsx
+++ b/frontend/src/app/police/_components/PartyCard.tsx
@@ -153,7 +153,7 @@ function PartyCard({
                 {formatTime(data.party.party_datetime)}
               </p>
             ) : (
-              <p className="content text-muted-foreground text-sm italic">
+              <p className="content text-muted-foreground text-sm italic pb-1">
                 No party registered at this location
               </p>
             )}

--- a/frontend/src/app/police/_components/PartyCard.tsx
+++ b/frontend/src/app/police/_components/PartyCard.tsx
@@ -34,7 +34,6 @@ import {
 } from "@/lib/utils";
 import { format } from "date-fns";
 import { AlertTriangle, EllipsisVertical, ExternalLink } from "lucide-react";
-import { memo } from "react";
 
 const INCIDENT_MENU_ITEMS: {
   severity: IncidentSeverity;
@@ -71,7 +70,7 @@ interface PartyCardProps {
   onOpenIncidentDialog: (severity: IncidentSeverity) => void;
 }
 
-const PartyCard = memo(function PartyCard({
+function PartyCard({
   data,
   onClick,
   isActive,
@@ -256,6 +255,6 @@ const PartyCard = memo(function PartyCard({
       </div>
     </article>
   );
-});
+}
 
 export default PartyCard;

--- a/frontend/src/app/police/_components/PartyList.tsx
+++ b/frontend/src/app/police/_components/PartyList.tsx
@@ -2,14 +2,11 @@
 
 import IncidentDialog from "@/components/IncidentDialog";
 import { useSnackbar } from "@/contexts/SnackbarContext";
-import type {
-  IncidentCreateDto,
-  IncidentSeverity,
-} from "@/lib/api/incident/incident.types";
+import type { IncidentSeverity } from "@/lib/api/incident/incident.types";
 import { ExactMatchDto, PartyPoliceDto } from "@/lib/api/party/party.types";
 import { usePoliceCreateIncident } from "@/lib/api/party/police-party.queries";
 import { getErrorMessage } from "@/lib/errors";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import PartyCard, { PartyCardData } from "./PartyCard";
 
 interface PartyListProps {
@@ -44,21 +41,14 @@ const PartyList = ({
     },
   });
 
-  const openIncidentDialog = useCallback(
-    (data: PartyCardData, severity: IncidentSeverity) => {
-      setSelectedData(data);
-      setIncidentType(severity);
-      setIncidentDialogOpen(true);
-    },
-    []
-  );
-
-  const handleSubmit = useCallback(
-    (data: IncidentCreateDto) => {
-      createIncidentMutation.mutate(data);
-    },
-    [createIncidentMutation]
-  );
+  const openIncidentDialog = (
+    data: PartyCardData,
+    severity: IncidentSeverity
+  ) => {
+    setSelectedData(data);
+    setIncidentType(severity);
+    setIncidentDialogOpen(true);
+  };
 
   useEffect(() => {
     if (!activeParty || !listRef.current) return;
@@ -175,7 +165,7 @@ const PartyList = ({
         formattedAddress={
           selectedData?.hasParty ? undefined : selectedData?.formattedAddress
         }
-        onSubmit={handleSubmit}
+        onSubmit={createIncidentMutation.mutate}
         isSubmitting={createIncidentMutation.isPending}
         key={dialogKey}
       />

--- a/frontend/src/app/police/admin/_components/PoliceAccountsTable.tsx
+++ b/frontend/src/app/police/admin/_components/PoliceAccountsTable.tsx
@@ -10,6 +10,7 @@ import {
   deleteAction,
   editAction,
 } from "@/app/staff/_components/shared/table/rowActions";
+import { useServerTableState } from "@/app/staff/_components/shared/table/useServerTableState";
 import { useSnackbar } from "@/contexts/SnackbarContext";
 import {
   useDeletePoliceAccount,
@@ -22,7 +23,6 @@ import { getErrorMessage } from "@/lib/errors";
 import { formatRoleLabel } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { useSession } from "next-auth/react";
-import { useMemo } from "react";
 
 export default function PoliceAccountsTable() {
   const { data: session } = useSession();
@@ -84,45 +84,48 @@ export default function PoliceAccountsTable() {
     });
   };
 
-  const columns: ColumnDef<PoliceAccountDto>[] = useMemo(
-    () => [
-      {
-        accessorKey: "email",
-        header: "Email",
-        enableColumnFilter: true,
-        meta: { filter: { type: "text", backendField: "email" } },
-      },
-      {
-        accessorKey: "role",
-        header: "Role",
-        enableColumnFilter: true,
-        meta: { filter: { type: "text", backendField: "role" } },
-        cell: ({ row }) =>
-          formatRoleLabel(row.getValue("role") as PoliceAccountDto["role"]),
-      },
-      {
-        accessorKey: "is_verified",
-        header: "Verified",
-        enableColumnFilter: true,
-        meta: {
-          filter: {
-            type: "select",
-            backendField: "is_verified",
-            selectOptions: ["true", "false"],
-          },
+  const columns: ColumnDef<PoliceAccountDto>[] = [
+    {
+      accessorKey: "email",
+      header: "Email",
+      enableColumnFilter: true,
+      meta: { filter: { type: "text", backendField: "email" } },
+    },
+    {
+      accessorKey: "role",
+      header: "Role",
+      enableColumnFilter: true,
+      meta: { filter: { type: "text", backendField: "role" } },
+      cell: ({ row }) =>
+        formatRoleLabel(row.getValue("role") as PoliceAccountDto["role"]),
+    },
+    {
+      accessorKey: "is_verified",
+      header: "Verified",
+      enableColumnFilter: true,
+      meta: {
+        filter: {
+          type: "select",
+          backendField: "is_verified",
+          selectOptions: ["true", "false"],
         },
-        cell: ({ row }) => (row.original.is_verified ? "Yes" : "No"),
       },
-    ],
-    []
-  );
+      cell: ({ row }) => (row.original.is_verified ? "Yes" : "No"),
+    },
+  ];
+
+  const serverTableState = useServerTableState({
+    columns,
+    pageSizeStorageKey: "police-accounts",
+  });
+  const query = usePoliceAccountsPaginated(serverTableState.serverParams);
 
   return (
     <>
       <TableTemplate
-        useQuery={usePoliceAccountsPaginated}
+        query={query}
+        serverTableState={serverTableState}
         columns={columns}
-        pageSizeStorageKey="police-accounts"
         rowActions={[
           editAction<PoliceAccountDto>({ onClick: openEdit }),
           deleteAction<PoliceAccountDto>({

--- a/frontend/src/app/police/page.tsx
+++ b/frontend/src/app/police/page.tsx
@@ -10,7 +10,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { SkeletonText } from "@/components/ui/skeleton";
-import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { PartyPoliceDto } from "@/lib/api/party/party.types";
 import {
@@ -23,13 +22,90 @@ import { startOfDay } from "date-fns";
 import { Filter, Shield } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import AdvancedPartySearch, {
   AdvancedPartyFilters,
 } from "./_components/AdvancedPartySearch";
 
-const locationService = new LocationService();
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+
+function normalizeStr(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizePhone(value: string): string {
+  return value.replace(/\D/g, "");
+}
+
+function toMinutes(time: string): number | null {
+  const [h, m] = time.split(":").map(Number);
+  if (Number.isNaN(h) || Number.isNaN(m)) return null;
+  return h * 60 + m;
+}
+
+function filterParties(
+  parties: PartyPoliceDto[],
+  filters: AdvancedPartyFilters
+): PartyPoliceDto[] {
+  return parties.filter((party) => {
+    const contactOneName = `${party.contact_one.first_name} ${party.contact_one.last_name}`;
+    const contactTwoName = `${party.contact_two.first_name} ${party.contact_two.last_name}`;
+
+    if (filters.name) {
+      const nameQuery = normalizeStr(filters.name);
+      const matchesName =
+        normalizeStr(contactOneName).includes(nameQuery) ||
+        normalizeStr(contactTwoName).includes(nameQuery);
+      if (!matchesName) return false;
+    }
+
+    if (filters.phone) {
+      const phoneQuery = normalizePhone(filters.phone);
+      const matchesPhone =
+        normalizePhone(party.contact_one.phone_number ?? "").includes(
+          phoneQuery
+        ) ||
+        normalizePhone(party.contact_two.phone_number ?? "").includes(
+          phoneQuery
+        );
+      if (!matchesPhone) return false;
+    }
+
+    if (filters.contactPreference) {
+      const preference = filters.contactPreference;
+      const matchesPreference =
+        party.contact_one.contact_preference === preference ||
+        party.contact_two.contact_preference === preference;
+      if (!matchesPreference) return false;
+    }
+
+    if (filters.severity) {
+      const hasSeverity = party.location.incidents.some(
+        (incident) => incident.severity === filters.severity
+      );
+      if (!hasSeverity) return false;
+    }
+
+    if (filters.startTime) {
+      const filterTimeMinutes = toMinutes(filters.startTime);
+      if (filterTimeMinutes === null) return false;
+
+      const partyTimeMinutes =
+        party.party_datetime.getHours() * 60 +
+        party.party_datetime.getMinutes();
+
+      if (filters.timeFilterType === "before") {
+        if (!(partyTimeMinutes < filterTimeMinutes)) return false;
+      } else if (filters.timeFilterType === "after") {
+        if (!(partyTimeMinutes > filterTimeMinutes)) return false;
+      } else {
+        if (partyTimeMinutes !== filterTimeMinutes) return false;
+      }
+    }
+
+    return true;
+  });
+}
 
 export default function PolicePage() {
   const { data: session } = useSession();
@@ -83,94 +159,16 @@ export default function PolicePage() {
     (isAddressSearchActive ? isFetchingNearby : isFetchingAll);
 
   // Use nearby list if address search is active, otherwise use all parties
-  const baseParties = useMemo(() => activeParties ?? [], [activeParties]);
+  const baseParties = activeParties ?? [];
 
-  const filteredParties = useMemo(() => {
-    function normalize(value: string): string {
-      return value.trim().toLowerCase();
-    }
-
-    function normalizePhone(value: string): string {
-      return value.replace(/\D/g, "");
-    }
-
-    function toMinutes(time: string): number | null {
-      const [h, m] = time.split(":").map(Number);
-      if (Number.isNaN(h) || Number.isNaN(m)) return null;
-      return h * 60 + m;
-    }
-
-    return baseParties.filter((party) => {
-      const contactOneName = `${party.contact_one.first_name} ${party.contact_one.last_name}`;
-      const contactTwoName = `${party.contact_two.first_name} ${party.contact_two.last_name}`;
-
-      if (advancedFilters.name) {
-        const nameQuery = normalize(advancedFilters.name);
-        const matchesName =
-          normalize(contactOneName).includes(nameQuery) ||
-          normalize(contactTwoName).includes(nameQuery);
-        if (!matchesName) return false;
-      }
-
-      if (advancedFilters.phone) {
-        const phoneQuery = normalizePhone(advancedFilters.phone);
-        const matchesPhone =
-          normalizePhone(party.contact_one.phone_number ?? "").includes(
-            phoneQuery
-          ) ||
-          normalizePhone(party.contact_two.phone_number ?? "").includes(
-            phoneQuery
-          );
-        if (!matchesPhone) return false;
-      }
-
-      if (advancedFilters.contactPreference) {
-        const preference = advancedFilters.contactPreference;
-        const matchesPreference =
-          party.contact_one.contact_preference === preference ||
-          party.contact_two.contact_preference === preference;
-        if (!matchesPreference) return false;
-      }
-
-      if (advancedFilters.severity) {
-        const hasSeverity = party.location.incidents.some(
-          (incident) => incident.severity === advancedFilters.severity
-        );
-        if (!hasSeverity) return false;
-      }
-
-      if (advancedFilters.startTime) {
-        const filterTimeMinutes = toMinutes(advancedFilters.startTime);
-        if (filterTimeMinutes === null) return false;
-
-        const partyTimeMinutes =
-          party.party_datetime.getHours() * 60 +
-          party.party_datetime.getMinutes();
-
-        if (advancedFilters.timeFilterType === "before") {
-          if (!(partyTimeMinutes < filterTimeMinutes)) return false;
-        } else if (advancedFilters.timeFilterType === "after") {
-          if (!(partyTimeMinutes > filterTimeMinutes)) return false;
-        } else {
-          if (partyTimeMinutes !== filterTimeMinutes) return false;
-        }
-      }
-
-      return true;
-    });
-  }, [advancedFilters, baseParties]);
+  const filteredParties = filterParties(baseParties, advancedFilters);
 
   // Include exact match party in map pins even though it's excluded from the nearby list
   const exactMatchParty = nearbyData?.exact_match?.party;
-  const mapParties = useMemo(() => {
-    if (!exactMatchParty) return filteredParties;
-    const alreadyIncluded = filteredParties.some(
-      (p) => p.id === exactMatchParty.id
-    );
-    return alreadyIncluded
-      ? filteredParties
-      : [exactMatchParty, ...filteredParties];
-  }, [filteredParties, exactMatchParty]);
+  const mapParties =
+    exactMatchParty && !filteredParties.some((p) => p.id === exactMatchParty.id)
+      ? [exactMatchParty, ...filteredParties]
+      : filteredParties;
 
   // Reset to first page when the party list changes (filters/date range updated)
   useEffect(() => {
@@ -233,7 +231,6 @@ export default function PolicePage() {
                 value={searchAddress?.formatted_address || ""}
                 onSelect={setSearchAddress}
                 placeholder="Search by address..."
-                locationService={locationService}
               />
             </div>
             <div className="flex flex-col gap-2 order-1 sm:order-2">

--- a/frontend/src/app/staff/_components/account/AccountTable.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTable.tsx
@@ -32,6 +32,7 @@ import {
   deleteAction,
   editAction,
 } from "../shared/table/rowActions";
+import { useServerTableState } from "../shared/table/useServerTableState";
 import AccountTableForm, { accountTableFormSchema } from "./AccountTableForm";
 import PoliceAccountTableForm, {
   type PoliceAccountFormValues,
@@ -260,13 +261,19 @@ export const AccountTable = () => {
     },
   ];
 
+  const serverTableState = useServerTableState({
+    columns,
+    pageSizeStorageKey: "staff-accounts",
+  });
+  const query = useAggregateAccounts(serverTableState.serverParams);
+
   return (
     <>
       <TableTemplate
-        useQuery={useAggregateAccounts}
+        query={query}
+        serverTableState={serverTableState}
         columns={columns}
         createAction={{ label: "New Invite", fn: openCreate }}
-        pageSizeStorageKey="staff-accounts"
         rowActions={[
           editAction<AggregateAccountDto>({
             onClick: handleEdit,

--- a/frontend/src/app/staff/_components/account/AccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTableForm.tsx
@@ -39,7 +39,7 @@ export default function AccountTableForm({
     <FormShell
       form={form}
       onSubmit={onSubmit}
-      submitLabel="Send Invite"
+      submitLabel={isEditMode ? "Save Changes" : "Send Invite"}
       submissionError={submissionError}
     >
       <TextField

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -25,6 +25,7 @@ import { InfoChip } from "../shared/sidebar/InfoChip";
 import { useFormSidebarState } from "../shared/sidebar/useFormSidebarState";
 import { TableTemplate } from "../shared/table/TableTemplate";
 import { deleteAction, editAction } from "../shared/table/rowActions";
+import { useServerTableState } from "../shared/table/useServerTableState";
 import { IncidentSeverityCountsHeader } from "./IncidentSeverityCountsHeader";
 import IncidentTableForm from "./IncidentTableForm";
 
@@ -186,13 +187,19 @@ export const IncidentTable = () => {
     },
   ];
 
+  const serverTableState = useServerTableState({
+    columns,
+    pageSizeStorageKey: "staff-incidents",
+  });
+  const query = useIncidents(serverTableState.serverParams);
+
   return (
     <>
       <TableTemplate
-        useQuery={useIncidents}
+        query={query}
+        serverTableState={serverTableState}
         columns={columns}
         createAction={{ label: "New Incident", fn: openCreate }}
-        pageSizeStorageKey="staff-incidents"
         rowActions={[
           editAction<IncidentDto>({ onClick: openEdit }),
           deleteAction<IncidentDto>({
@@ -204,7 +211,7 @@ export const IncidentTable = () => {
           }),
         ]}
         exportMutation={exportMutation}
-        headerSlot={(query) => (
+        headerSlot={
           <IncidentSeverityCountsHeader
             counts={
               (query.data as PaginatedIncidentsResponse | undefined)
@@ -212,7 +219,7 @@ export const IncidentTable = () => {
             }
             isLoading={query.isLoading || query.isFetching}
           />
-        )}
+        }
       />
       <FormSidebar
         mode={mode}

--- a/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
+++ b/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
@@ -16,14 +16,14 @@ import { formatTime } from "@/lib/utils";
 import { format } from "date-fns";
 import { ChevronDown, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useSession } from "next-auth/react";
-import { memo } from "react";
 
 type IncidentSidebarCardProps = {
   incidents: NestedIncidentDto;
   onDeleteIncidentAction: (incidentId: number) => void;
   onEditIncidentAction: (incident: NestedIncidentDto) => void;
 };
-const IncidentSidebarCard = memo(function IncidentSidebarCard({
+
+function IncidentSidebarCard({
   incidents,
   onDeleteIncidentAction,
   onEditIncidentAction,
@@ -92,6 +92,6 @@ const IncidentSidebarCard = memo(function IncidentSidebarCard({
       </Collapsible>
     </div>
   );
-});
+}
 
 export default IncidentSidebarCard;

--- a/frontend/src/app/staff/_components/location/LocationTable.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTable.tsx
@@ -18,6 +18,7 @@ import { InfoChip } from "../shared/sidebar/InfoChip";
 import { useFormSidebarState } from "../shared/sidebar/useFormSidebarState";
 import { TableTemplate } from "../shared/table/TableTemplate";
 import { deleteAction, editAction } from "../shared/table/rowActions";
+import { useServerTableState } from "../shared/table/useServerTableState";
 import LocationTableForm from "./LocationTableForm";
 
 const LOCATION_ERROR_OPTIONS = {
@@ -133,13 +134,19 @@ export const LocationTable = () => {
       },
     },
   ];
+  const serverTableState = useServerTableState({
+    columns,
+    pageSizeStorageKey: "staff-locations",
+  });
+  const query = useLocations(serverTableState.serverParams);
+
   return (
     <>
       <TableTemplate
-        useQuery={useLocations}
+        query={query}
+        serverTableState={serverTableState}
         columns={columns}
         createAction={{ label: "New Location", fn: openCreate }}
-        pageSizeStorageKey="staff-locations"
         rowActions={[
           editAction<LocationDto>({ onClick: openEdit }),
           deleteAction<LocationDto>({

--- a/frontend/src/app/staff/_components/party/PartyTable.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTable.tsx
@@ -33,6 +33,7 @@ import { InfoChip } from "../shared/sidebar/InfoChip";
 import { useFormSidebarState } from "../shared/sidebar/useFormSidebarState";
 import { TableTemplate } from "../shared/table/TableTemplate";
 import { type RowAction, editAction } from "../shared/table/rowActions";
+import { useServerTableState } from "../shared/table/useServerTableState";
 import PartyTableForm, { PartyTableFormValues } from "./PartyTableForm";
 
 const PARTY_ERROR_OPTIONS = {
@@ -261,13 +262,19 @@ export const PartyTable = () => {
     },
   ];
 
+  const serverTableState = useServerTableState({
+    columns,
+    pageSizeStorageKey: "staff-parties",
+  });
+  const query = useAdminParties(serverTableState.serverParams);
+
   return (
     <>
       <TableTemplate
-        useQuery={useAdminParties}
+        query={query}
+        serverTableState={serverTableState}
         columns={columns}
         createAction={{ label: "New Party", fn: openCreate }}
-        pageSizeStorageKey="staff-parties"
         rowActions={[
           editAction<PartyDto>({ onClick: openEdit }),
           {

--- a/frontend/src/app/staff/_components/party/PartyTableForm.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTableForm.tsx
@@ -22,7 +22,6 @@ import { phoneNumberSchema } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { addBusinessDays, format, isAfter, startOfDay } from "date-fns";
 import { useSession } from "next-auth/react";
-import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 
@@ -86,10 +85,7 @@ export default function PartyTableForm({
   const { data: session } = useSession();
   const isAdmin = session?.role === "admin";
 
-  const partyTableFormSchema = useMemo(
-    () => createPartyTableFormSchema(isAdmin),
-    [isAdmin]
-  );
+  const partyTableFormSchema = createPartyTableFormSchema(isAdmin);
 
   const form = useForm<PartyTableFormInput, unknown, PartyTableFormValues>({
     resolver: zodResolver(partyTableFormSchema),

--- a/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
+++ b/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
@@ -1,8 +1,8 @@
 import IncidentDialog from "@/components/IncidentDialog";
 import { Button } from "@/components/ui/button";
-import { useCreateIncident } from "@/lib/api/incident/incident.queries";
 import { IncidentCreateDto } from "@/lib/api/incident/incident.types";
 import {
+  useCreateIncidentInLocation,
   useDeleteIncidentInLocation,
   useUpdateIncidentInLocation,
 } from "@/lib/api/location/location.queries";
@@ -52,7 +52,7 @@ export default function IncidentInfoChipDetails({
     deleteMutation.mutate(confirmStateDelete);
   };
 
-  const createMutation = useCreateIncident({
+  const createMutation = useCreateIncidentInLocation({
     onSuccess: () => {
       setModalState(null);
     },
@@ -96,16 +96,22 @@ export default function IncidentInfoChipDetails({
           headerActionNode
         )}
       <div>
-        {incidents.map((incident) => (
-          <IncidentSidebarCard
-            incidents={incident}
-            key={incident.id}
-            onDeleteIncidentAction={setConfirmStateDelete}
-            onEditIncidentAction={(incident: NestedIncidentDto) => {
-              setModalState({ mode: "edit", incident });
-            }}
-          />
-        ))}
+        {incidents.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            No incidents
+          </p>
+        ) : (
+          incidents.map((incident) => (
+            <IncidentSidebarCard
+              incidents={incident}
+              key={incident.id}
+              onDeleteIncidentAction={setConfirmStateDelete}
+              onEditIncidentAction={(incident: NestedIncidentDto) => {
+                setModalState({ mode: "edit", incident });
+              }}
+            />
+          ))
+        )}
       </div>
       <ConfirmDialog
         open={confirmStateDelete !== null}

--- a/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
+++ b/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
@@ -64,8 +64,6 @@ export default function IncidentInfoChipDetails({
     },
   });
 
-  const handleCreateIncident = createMutation.mutate;
-
   const handleEditIncident = (data: IncidentCreateDto) => {
     if (modalState?.mode !== "edit") return;
     updateMutation.mutate({
@@ -138,7 +136,7 @@ export default function IncidentInfoChipDetails({
         onSubmit={
           modalState?.mode === "edit"
             ? handleEditIncident
-            : handleCreateIncident
+            : createMutation.mutate
         }
         location={location}
       />

--- a/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
+++ b/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/lib/api/location/location.types";
 import { PlusIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { createPortal } from "react-dom";
 import IncidentSidebarCard from "../../location/IncidentSidebarCard";
 import { ConfirmDialog } from "../dialog/ConfirmDialog";
@@ -41,10 +41,6 @@ export default function IncidentInfoChipDetails({
     null
   );
 
-  const requestDelete = useCallback((incidentId: number) => {
-    setConfirmStateDelete(incidentId);
-  }, []);
-
   const deleteMutation = useDeleteIncidentInLocation({
     onSuccess: () => {
       setConfirmStateDelete(null);
@@ -55,15 +51,6 @@ export default function IncidentInfoChipDetails({
     if (confirmStateDelete === null) return;
     deleteMutation.mutate(confirmStateDelete);
   };
-
-  const handleEdit = useCallback((incident: NestedIncidentDto) => {
-    setModalState({ mode: "edit", incident });
-  }, []);
-
-  const handleAdd = () => {
-    setModalState({ mode: "create" });
-  };
-  const closeModal = () => setModalState(null);
 
   const createMutation = useCreateIncident({
     onSuccess: () => {
@@ -77,9 +64,7 @@ export default function IncidentInfoChipDetails({
     },
   });
 
-  const handleCreateIncident = (data: IncidentCreateDto) => {
-    createMutation.mutate(data);
-  };
+  const handleCreateIncident = createMutation.mutate;
 
   const handleEditIncident = (data: IncidentCreateDto) => {
     if (modalState?.mode !== "edit") return;
@@ -103,7 +88,9 @@ export default function IncidentInfoChipDetails({
           <Button
             variant="default"
             size="sm"
-            onClick={handleAdd}
+            onClick={() => {
+              setModalState({ mode: "create" });
+            }}
             aria-label="Add new incident"
           >
             <PlusIcon className="size-4" aria-hidden="true" />
@@ -115,8 +102,10 @@ export default function IncidentInfoChipDetails({
           <IncidentSidebarCard
             incidents={incident}
             key={incident.id}
-            onDeleteIncidentAction={requestDelete}
-            onEditIncidentAction={handleEdit}
+            onDeleteIncidentAction={setConfirmStateDelete}
+            onEditIncidentAction={(incident: NestedIncidentDto) => {
+              setModalState({ mode: "edit", incident });
+            }}
           />
         ))}
       </div>
@@ -142,7 +131,7 @@ export default function IncidentInfoChipDetails({
         }
         open={modalState !== null}
         onOpenChange={(open) => {
-          if (!open) closeModal();
+          if (!open) setModalState(null);
         }}
         mode={modalState?.mode ?? "create"}
         incident={modalState?.mode === "edit" ? modalState.incident : undefined}

--- a/frontend/src/app/staff/_components/shared/sidebar/Sidebar.tsx
+++ b/frontend/src/app/staff/_components/shared/sidebar/Sidebar.tsx
@@ -32,6 +32,17 @@ function Sidebar() {
         // doesn't warn about a dangling reference.
         {...(description ? {} : { "aria-describedby": undefined })}
         className="w-full max-w-[25em] gap-0 bg-card p-0 sm:max-w-[25em]"
+        onInteractOutside={(e) => {
+          // Radix portals (Popover, Select, DatePicker, etc.) render outside the
+          // Sheet's DOM but are logically inside it. Prevent them from closing the sheet.
+          if (
+            (e.target as Element | null)?.closest(
+              "[data-radix-popper-content-wrapper]"
+            )
+          ) {
+            e.preventDefault();
+          }
+        }}
       >
         <SheetHeader className="mb-2 gap-0 px-6 pb-2 pt-12">
           <div className="flex items-center justify-between">

--- a/frontend/src/app/staff/_components/shared/sidebar/SidebarContent.tsx
+++ b/frontend/src/app/staff/_components/shared/sidebar/SidebarContent.tsx
@@ -41,8 +41,8 @@ export function SidebarContent({
       closeSidebar();
       activeSidebarKeyRef.current = null;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, sidebarKey, title, description]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedKey is intentionally excluded; the ref pattern handles stale reads without re-running on every key change
+  }, [open, sidebarKey, title, description, openSidebar, closeSidebar]);
 
   // On unmount while active, close the chrome
   useEffect(() => {
@@ -54,8 +54,7 @@ export function SidebarContent({
         closeSidebar();
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [closeSidebar]);
 
   // Keep a ref to the latest selectedKey so the unmount cleanup can read it
   const selectedKeyRef = useRef(selectedKey);

--- a/frontend/src/app/staff/_components/shared/sidebar/SidebarContent.tsx
+++ b/frontend/src/app/staff/_components/shared/sidebar/SidebarContent.tsx
@@ -54,7 +54,8 @@ export function SidebarContent({
         closeSidebar();
       }
     };
-  }, [closeSidebar]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only cleanup; closeSidebar is intentionally excluded (unstable reference, would run cleanup on every context re-render)
+  }, []);
 
   // Keep a ref to the latest selectedKey so the unmount cleanup can read it
   const selectedKeyRef = useRef(selectedKey);

--- a/frontend/src/app/staff/_components/shared/sidebar/SidebarContext.tsx
+++ b/frontend/src/app/staff/_components/shared/sidebar/SidebarContext.tsx
@@ -1,11 +1,5 @@
 "use client";
-import {
-  ReactNode,
-  createContext,
-  useCallback,
-  useContext,
-  useState,
-} from "react";
+import { ReactNode, createContext, useContext, useState } from "react";
 
 type SidebarContextType = {
   isOpen: boolean;
@@ -36,22 +30,19 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
     null
   );
 
-  const openSidebar = useCallback(
-    (key: string, title: string, description: string) => {
-      setSelectedKey(key);
-      setTitle(title);
-      setDescription(description);
-      setIsOpen(true);
-    },
-    []
-  );
+  const openSidebar = (key: string, title: string, description: string) => {
+    setSelectedKey(key);
+    setTitle(title);
+    setDescription(description);
+    setIsOpen(true);
+  };
 
-  const closeSidebar = useCallback(() => {
+  const closeSidebar = () => {
     setIsOpen(false);
     setSelectedKey(null);
     setTitle(null);
     setDescription(null);
-  }, []);
+  };
 
   return (
     <SidebarContext.Provider

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -36,7 +36,7 @@ import {
 } from "@tanstack/react-table";
 import { Download, Loader2, MoreHorizontal, Plus } from "lucide-react";
 import { useSession } from "next-auth/react";
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { ConfirmDialog } from "../dialog/ConfirmDialog";
 import { SidebarContent } from "../sidebar/SidebarContent";
 import { useSidebar } from "../sidebar/SidebarContext";
@@ -93,6 +93,7 @@ export function TableTemplate<T extends object>({
   headerSlot,
   rowActions,
 }: TableProps<T>) {
+  "use no memo";
   const data = query.data?.items ?? [];
   const { isLoading, isFetching } = query;
   const error = query.error as Error | null;
@@ -131,65 +132,69 @@ export function TableTemplate<T extends object>({
   const showActionsColumn =
     hasManagePermission && (rowActions?.length ?? 0) > 0;
 
-  const handleActionClick = (action: RowAction<T>, rowId: string, row: T) => {
-    if (action.selectRow) {
-      setRowSelection({ [rowId]: true });
-    }
-    if (action.confirm) {
-      setPendingConfirm({ action, row });
-    } else {
-      action.onClick(row);
-    }
-  };
+  // eslint-disable-next-line react-no-manual-memo/no-hook-memo -- TanStack Table requires stable column references; new array identity each render causes internal state resets and infinite update loops
+  const columnsWithActions: ColumnDef<T, unknown>[] = useMemo(() => {
+    const baseColumns = columns.map((column) =>
+      column.meta?.filter
+        ? { ...column, filterFn: serverFilterPassthrough }
+        : column
+    );
+    if (!showActionsColumn) return baseColumns;
 
-  const baseColumns = columns.map((column) =>
-    column.meta?.filter
-      ? { ...column, filterFn: serverFilterPassthrough }
-      : column
-  );
-  const columnsWithActions: ColumnDef<T, unknown>[] = showActionsColumn
-    ? [
-        ...baseColumns,
-        {
-          id: "actions",
-          enableSorting: false,
-          enableColumnFilter: false,
-          cell: ({ row }) => {
-            const visibleActions =
-              rowActions?.filter(
-                (action) => !action.isVisible || action.isVisible(row.original)
-              ) ?? [];
-            if (visibleActions.length === 0) return null;
-            return (
-              <div className="flex justify-end">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm" className="size-8 p-0">
-                      <MoreHorizontal className="size-4" />
-                      <span className="sr-only">Open menu</span>
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    {visibleActions.map((action) => (
-                      <DropdownMenuItem
-                        key={action.label}
-                        onClick={() =>
-                          handleActionClick(action, row.id, row.original)
-                        }
-                        variant={action.variant}
-                      >
-                        {action.icon}
-                        {action.label}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          },
+    const handleActionClick = (action: RowAction<T>, rowId: string, row: T) => {
+      if (action.selectRow) setRowSelection({ [rowId]: true });
+      if (action.confirm) setPendingConfirm({ action, row });
+      else action.onClick(row);
+    };
+
+    return [
+      ...baseColumns,
+      {
+        id: "actions",
+        enableSorting: false,
+        enableColumnFilter: false,
+        cell: ({ row }) => {
+          const visibleActions =
+            rowActions?.filter(
+              (action) => !action.isVisible || action.isVisible(row.original)
+            ) ?? [];
+          if (visibleActions.length === 0) return null;
+          return (
+            <div className="flex justify-end">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" className="size-8 p-0">
+                    <MoreHorizontal className="size-4" />
+                    <span className="sr-only">Open menu</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {visibleActions.map((action) => (
+                    <DropdownMenuItem
+                      key={action.label}
+                      onClick={() =>
+                        handleActionClick(action, row.id, row.original)
+                      }
+                      variant={action.variant}
+                    >
+                      {action.icon}
+                      {action.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          );
         },
-      ]
-    : baseColumns;
+      },
+    ];
+  }, [
+    columns,
+    showActionsColumn,
+    rowActions,
+    setRowSelection,
+    setPendingConfirm,
+  ]);
 
   const table = useReactTable({
     data: displayData,

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+/* eslint-disable react-no-manual-memo/no-hook-memo -- "use no memo" opts this file out of React Compiler; all manual memos here are load-bearing */
 import PaginationControls from "@/components/PaginationControls";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -36,7 +36,14 @@ import {
 } from "@tanstack/react-table";
 import { Download, Loader2, MoreHorizontal, Plus } from "lucide-react";
 import { useSession } from "next-auth/react";
-import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ConfirmDialog } from "../dialog/ConfirmDialog";
 import { SidebarContent } from "../sidebar/SidebarContent";
 import { useSidebar } from "../sidebar/SidebarContext";
@@ -117,6 +124,10 @@ export function TableTemplate<T extends object>({
   const sampleRowRef = useRef<HTMLTableRowElement | null>(null);
   const syncServerSorting = serverTableState.actions.syncServerSorting;
 
+  const handleFilterSidebarOpenChange = useCallback((open: boolean) => {
+    if (!open) setFilterSidebar(null);
+  }, []);
+
   useEffect(() => {
     if (!isOpen && Object.keys(rowSelection).length > 0) {
       setRowSelection({});
@@ -132,7 +143,6 @@ export function TableTemplate<T extends object>({
   const showActionsColumn =
     hasManagePermission && (rowActions?.length ?? 0) > 0;
 
-  // eslint-disable-next-line react-no-manual-memo/no-hook-memo -- TanStack Table requires stable column references; new array identity each render causes internal state resets and infinite update loops
   const columnsWithActions: ColumnDef<T, unknown>[] = useMemo(() => {
     const baseColumns = columns.map((column) =>
       column.meta?.filter
@@ -509,7 +519,7 @@ export function TableTemplate<T extends object>({
       {/* Filter Sidebar */}
       <SidebarContent
         open={filterSidebar !== null}
-        onOpenChange={(o) => !o && setFilterSidebar(null)}
+        onOpenChange={handleFilterSidebarOpenChange}
         sidebarKey={
           filterSidebar ? `filter-${filterSidebar.columnId}` : "filter"
         }

--- a/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
+++ b/frontend/src/app/staff/_components/shared/table/TableTemplate.tsx
@@ -22,7 +22,6 @@ import {
 import {
   ColumnFilterMeta,
   ListQueryParams,
-  ServerTableParams,
   buildServerTableParams,
 } from "@/lib/api/shared/query-params";
 import { getErrorMessage } from "@/lib/errors";
@@ -37,14 +36,7 @@ import {
 } from "@tanstack/react-table";
 import { Download, Loader2, MoreHorizontal, Plus } from "lucide-react";
 import { useSession } from "next-auth/react";
-import {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { ConfirmDialog } from "../dialog/ConfirmDialog";
 import { SidebarContent } from "../sidebar/SidebarContent";
 import { useSidebar } from "../sidebar/SidebarContext";
@@ -52,7 +44,7 @@ import { ColumnHeader } from "./ColumnHeader";
 import { FilterInput } from "./FilterInput";
 import { RowAction } from "./rowActions";
 import { useMeasuredFillerRows } from "./useMeasuredFillerRows";
-import { useServerTableState } from "./useServerTableState";
+import { UseServerTableStateResult } from "./useServerTableState";
 
 type FilterSidebarState = {
   columnId: string;
@@ -79,13 +71,13 @@ export type ExportMutation = {
 };
 
 export type TableProps<T> = {
-  useQuery: (params: ServerTableParams) => TableQuery<T>;
+  query: TableQuery<T>;
+  serverTableState: UseServerTableStateResult;
   columns: ColumnDef<T, unknown>[];
   createAction?: { label: string; fn: () => void };
   exportMutation?: ExportMutation;
   headerSlot?: ReactNode | ((query: TableQuery<T>) => ReactNode);
   rowActions?: RowAction<T>[];
-  pageSizeStorageKey?: string;
 };
 
 const serverFilterPassthrough = () => true;
@@ -93,19 +85,14 @@ const serverFilterPassthrough = () => true;
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
 export function TableTemplate<T extends object>({
-  useQuery,
+  query,
+  serverTableState,
   columns,
   createAction,
   exportMutation,
   headerSlot,
   rowActions,
-  pageSizeStorageKey,
 }: TableProps<T>) {
-  const serverTableState = useServerTableState({
-    columns,
-    pageSizeStorageKey,
-  });
-  const query = useQuery(serverTableState.serverParams);
   const data = query.data?.items ?? [];
   const { isLoading, isFetching } = query;
   const error = query.error as Error | null;
@@ -144,69 +131,65 @@ export function TableTemplate<T extends object>({
   const showActionsColumn =
     hasManagePermission && (rowActions?.length ?? 0) > 0;
 
-  const handleActionClick = useCallback(
-    (action: RowAction<T>, rowId: string, row: T) => {
-      if (action.selectRow) {
-        setRowSelection({ [rowId]: true });
-      }
-      if (action.confirm) {
-        setPendingConfirm({ action, row });
-      } else {
-        action.onClick(row);
-      }
-    },
-    []
-  );
+  const handleActionClick = (action: RowAction<T>, rowId: string, row: T) => {
+    if (action.selectRow) {
+      setRowSelection({ [rowId]: true });
+    }
+    if (action.confirm) {
+      setPendingConfirm({ action, row });
+    } else {
+      action.onClick(row);
+    }
+  };
 
-  const columnsWithActions = useMemo(() => {
-    const baseColumns = columns.map((column) =>
-      column.meta?.filter
-        ? { ...column, filterFn: serverFilterPassthrough }
-        : column
-    );
-    if (!showActionsColumn) return baseColumns;
-    return [
-      ...baseColumns,
-      {
-        id: "actions",
-        enableSorting: false,
-        enableColumnFilter: false,
-        cell: ({ row }) => {
-          const visibleActions =
-            rowActions?.filter(
-              (action) => !action.isVisible || action.isVisible(row.original)
-            ) ?? [];
-          if (visibleActions.length === 0) return null;
-          return (
-            <div className="flex justify-end">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm" className="size-8 p-0">
-                    <MoreHorizontal className="size-4" />
-                    <span className="sr-only">Open menu</span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {visibleActions.map((action) => (
-                    <DropdownMenuItem
-                      key={action.label}
-                      onClick={() =>
-                        handleActionClick(action, row.id, row.original)
-                      }
-                      variant={action.variant}
-                    >
-                      {action.icon}
-                      {action.label}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          );
+  const baseColumns = columns.map((column) =>
+    column.meta?.filter
+      ? { ...column, filterFn: serverFilterPassthrough }
+      : column
+  );
+  const columnsWithActions: ColumnDef<T, unknown>[] = showActionsColumn
+    ? [
+        ...baseColumns,
+        {
+          id: "actions",
+          enableSorting: false,
+          enableColumnFilter: false,
+          cell: ({ row }) => {
+            const visibleActions =
+              rowActions?.filter(
+                (action) => !action.isVisible || action.isVisible(row.original)
+              ) ?? [];
+            if (visibleActions.length === 0) return null;
+            return (
+              <div className="flex justify-end">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="size-8 p-0">
+                      <MoreHorizontal className="size-4" />
+                      <span className="sr-only">Open menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {visibleActions.map((action) => (
+                      <DropdownMenuItem
+                        key={action.label}
+                        onClick={() =>
+                          handleActionClick(action, row.id, row.original)
+                        }
+                        variant={action.variant}
+                      >
+                        {action.icon}
+                        {action.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          },
         },
-      },
-    ];
-  }, [columns, showActionsColumn, rowActions, handleActionClick]);
+      ]
+    : baseColumns;
 
   const table = useReactTable({
     data: displayData,

--- a/frontend/src/app/staff/_components/shared/table/useServerTableState.ts
+++ b/frontend/src/app/staff/_components/shared/table/useServerTableState.ts
@@ -19,10 +19,23 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
+
+function buildColumnFilterMap<T>(
+  columns: ColumnDef<T, unknown>[]
+): ServerColumnMap {
+  const map: ServerColumnMap = {};
+  for (const col of columns) {
+    const id = col.id ?? (col as { accessorKey?: string }).accessorKey;
+    const filterMeta = col.meta?.filter as ColumnFilterMeta | undefined;
+    if (id && filterMeta) {
+      map[String(id)] = filterMeta;
+    }
+  }
+  return map;
+}
 
 function areSortingStatesEqual(a: SortingState, b: SortingState) {
   if (a.length !== b.length) return false;
@@ -58,7 +71,7 @@ type UseServerTableStateArgs<T> = {
   pageSizeStorageKey?: string;
 };
 
-type UseServerTableStateResult = {
+export type UseServerTableStateResult = {
   serverParams: ServerTableParams;
   columnFilterMap: ServerColumnMap;
   tableState: {
@@ -93,17 +106,7 @@ export function useServerTableState<T>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState<string>("");
 
-  const columnFilterMap = useMemo((): ServerColumnMap => {
-    const map: ServerColumnMap = {};
-    for (const col of columns) {
-      const id = col.id ?? (col as { accessorKey?: string }).accessorKey;
-      const filterMeta = col.meta?.filter as ColumnFilterMeta | undefined;
-      if (id && filterMeta) {
-        map[String(id)] = filterMeta;
-      }
-    }
-    return map;
-  }, [columns]);
+  const columnFilterMap = buildColumnFilterMap(columns);
 
   const paginationRef = useRef(pagination);
   const sortingRef = useRef(sorting);
@@ -112,6 +115,7 @@ export function useServerTableState<T>({
   const filterDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // eslint-disable-next-line react-no-manual-memo/no-hook-memo -- needed as a stable effect dep; compiler skips custom hooks with manual memos
   const updateServerParams = useCallback(
     ({
       pageIndex = paginationRef.current.pageIndex,
@@ -190,27 +194,27 @@ export function useServerTableState<T>({
     };
   }, [globalFilter, updateServerParams]);
 
-  const onSortingChange = useCallback<OnChangeFn<SortingState>>((updater) => {
+  const onSortingChange: OnChangeFn<SortingState> = (updater) => {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
     setSorting((prev) =>
       typeof updater === "function" ? updater(prev) : updater
     );
-  }, []);
+  };
 
-  const syncServerSorting = useCallback(
-    (serverSortBy?: string, serverSortOrder?: "asc" | "desc") => {
-      const columnId = Object.entries(columnFilterMap).find(
-        ([, config]) => config.backendField === serverSortBy
-      )?.[0];
-      if (!columnId) return;
+  const syncServerSorting = (
+    serverSortBy?: string,
+    serverSortOrder?: "asc" | "desc"
+  ) => {
+    const columnId = Object.entries(columnFilterMap).find(
+      ([, config]) => config.backendField === serverSortBy
+    )?.[0];
+    if (!columnId) return;
 
-      const nextSorting = [{ id: columnId, desc: serverSortOrder === "desc" }];
-      setSorting((prev) =>
-        areSortingStatesEqual(prev, nextSorting) ? prev : nextSorting
-      );
-    },
-    [columnFilterMap]
-  );
+    const nextSorting = [{ id: columnId, desc: serverSortOrder === "desc" }];
+    setSorting((prev) =>
+      areSortingStatesEqual(prev, nextSorting) ? prev : nextSorting
+    );
+  };
 
   return {
     serverParams,

--- a/frontend/src/app/staff/_components/shared/table/useServerTableState.ts
+++ b/frontend/src/app/staff/_components/shared/table/useServerTableState.ts
@@ -106,7 +106,17 @@ export function useServerTableState<T>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState<string>("");
 
-  const columnFilterMap = buildColumnFilterMap(columns);
+  const columnFilterMapRef = useRef<ServerColumnMap>(
+    buildColumnFilterMap(columns)
+  );
+  const newColumnFilterMap = buildColumnFilterMap(columns);
+  if (
+    JSON.stringify(newColumnFilterMap) !==
+    JSON.stringify(columnFilterMapRef.current)
+  ) {
+    columnFilterMapRef.current = newColumnFilterMap;
+  }
+  const columnFilterMap = columnFilterMapRef.current;
 
   const paginationRef = useRef(pagination);
   const sortingRef = useRef(sorting);

--- a/frontend/src/app/staff/_components/shared/table/useServerTableState.ts
+++ b/frontend/src/app/staff/_components/shared/table/useServerTableState.ts
@@ -211,20 +211,21 @@ export function useServerTableState<T>({
     );
   };
 
-  const syncServerSorting = (
-    serverSortBy?: string,
-    serverSortOrder?: "asc" | "desc"
-  ) => {
-    const columnId = Object.entries(columnFilterMap).find(
-      ([, config]) => config.backendField === serverSortBy
-    )?.[0];
-    if (!columnId) return;
+  // eslint-disable-next-line react-no-manual-memo/no-hook-memo -- stable ref needed as effect dep in TableTemplate; unstable reference causes stale query.data to overwrite user sort selection
+  const syncServerSorting = useCallback(
+    (serverSortBy?: string, serverSortOrder?: "asc" | "desc") => {
+      const columnId = Object.entries(columnFilterMap).find(
+        ([, config]) => config.backendField === serverSortBy
+      )?.[0];
+      if (!columnId) return;
 
-    const nextSorting = [{ id: columnId, desc: serverSortOrder === "desc" }];
-    setSorting((prev) =>
-      areSortingStatesEqual(prev, nextSorting) ? prev : nextSorting
-    );
-  };
+      const nextSorting = [{ id: columnId, desc: serverSortOrder === "desc" }];
+      setSorting((prev) =>
+        areSortingStatesEqual(prev, nextSorting) ? prev : nextSorting
+      );
+    },
+    [columnFilterMap]
+  );
 
   return {
     serverParams,

--- a/frontend/src/app/staff/_components/student/StudentTable.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTable.tsx
@@ -19,6 +19,7 @@ import { InfoChip } from "../shared/sidebar/InfoChip";
 import { useFormSidebarState } from "../shared/sidebar/useFormSidebarState";
 import { TableTemplate } from "../shared/table/TableTemplate";
 import { deleteAction, editAction } from "../shared/table/rowActions";
+import { useServerTableState } from "../shared/table/useServerTableState";
 import StudentTableForm from "./StudentTableForm";
 
 const STUDENT_ERROR_OPTIONS = {
@@ -190,12 +191,18 @@ export const StudentTable = () => {
     },
   ];
 
+  const serverTableState = useServerTableState({
+    columns,
+    pageSizeStorageKey: "staff-students",
+  });
+  const query = useStudents(serverTableState.serverParams);
+
   return (
     <>
       <TableTemplate
-        useQuery={useStudents}
+        query={query}
+        serverTableState={serverTableState}
         columns={columns}
-        pageSizeStorageKey="staff-students"
         rowActions={[
           editAction<StudentDto>({ onClick: openEdit }),
           deleteAction<StudentDto>({

--- a/frontend/src/components/AddressSearch.tsx
+++ b/frontend/src/components/AddressSearch.tsx
@@ -18,7 +18,9 @@ import { LocationService } from "@/lib/api/location/location.service";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import { cn } from "@/lib/utils";
 import { CheckIcon, Loader2Icon, MapPinIcon, XIcon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+const locationService = new LocationService();
 
 interface AddressSearchProps {
   value?: string;
@@ -27,7 +29,6 @@ interface AddressSearchProps {
   placeholder?: string;
   className?: string;
   disabled?: boolean;
-  locationService?: LocationService;
   error?: string;
   chapelHillOnly?: boolean;
   id?: string;
@@ -44,16 +45,10 @@ export default function AddressSearch({
   placeholder = "Search for an address...",
   className,
   disabled = false,
-  locationService,
   error: externalError,
   chapelHillOnly = false,
   id,
 }: AddressSearchProps) {
-  const resolvedLocationService = useMemo(
-    () => locationService ?? new LocationService(),
-    [locationService]
-  );
-
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState(
     initialSelection?.formatted_address ?? value
@@ -112,8 +107,7 @@ export default function AddressSearch({
       setInternalError(null);
 
       try {
-        const results =
-          await resolvedLocationService.autocompleteAddress(trimmedInput);
+        const results = await locationService.autocompleteAddress(trimmedInput);
         setSuggestions(
           chapelHillOnly
             ? results.filter((r) =>
@@ -145,7 +139,7 @@ export default function AddressSearch({
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [searchTerm, resolvedLocationService, selectedAddress, chapelHillOnly]);
+  }, [searchTerm, selectedAddress, chapelHillOnly]);
 
   /**
    * Handle address selection from dropdown

--- a/frontend/src/components/StudentSearch.tsx
+++ b/frontend/src/components/StudentSearch.tsx
@@ -117,6 +117,7 @@ export default function StudentSearch({
   const initialMatchedFieldName = initialSelection?.matched_field_name ?? "";
   const initialMatchedFieldValue = initialSelection?.matched_field_value ?? "";
 
+  // eslint-disable-next-line react-no-manual-memo/no-hook-memo -- compiler skips this component; useMemo provides reference stability for the effect dep below
   const normalizedInitialSelection = useMemo(
     () =>
       initialStudentId === null
@@ -143,8 +144,7 @@ export default function StudentSearch({
     if (value && !initialSelection) {
       setSearchTerm(value);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  }, [initialSelection, value]);
 
   useEffect(() => {
     if (normalizedInitialSelection) {

--- a/frontend/src/components/ui/field.tsx
+++ b/frontend/src/components/ui/field.tsx
@@ -4,7 +4,6 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
-import { useMemo } from "react";
 
 function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (
@@ -182,6 +181,28 @@ function FieldSeparator({
   );
 }
 
+function resolveFieldErrorContent(
+  children: React.ReactNode,
+  errors: Array<{ message?: string } | undefined> | undefined
+): React.ReactNode {
+  if (children) return children;
+  if (!errors?.length) return null;
+
+  const uniqueErrors = [
+    ...new Map(errors.map((error) => [error?.message, error])).values(),
+  ];
+
+  if (uniqueErrors.length === 1) return uniqueErrors[0]?.message;
+
+  return (
+    <ul className="ml-4 flex list-disc flex-col gap-1">
+      {uniqueErrors.map(
+        (error, index) => error?.message && <li key={index}>{error.message}</li>
+      )}
+    </ul>
+  );
+}
+
 function FieldError({
   className,
   children,
@@ -190,32 +211,7 @@ function FieldError({
 }: React.ComponentProps<"div"> & {
   errors?: Array<{ message?: string } | undefined>;
 }) {
-  const content = useMemo(() => {
-    if (children) {
-      return children;
-    }
-
-    if (!errors?.length) {
-      return null;
-    }
-
-    const uniqueErrors = [
-      ...new Map(errors.map((error) => [error?.message, error])).values(),
-    ];
-
-    if (uniqueErrors?.length == 1) {
-      return uniqueErrors[0]?.message;
-    }
-
-    return (
-      <ul className="ml-4 flex list-disc flex-col gap-1">
-        {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
-        )}
-      </ul>
-    );
-  }, [children, errors]);
+  const content = resolveFieldErrorContent(children, errors);
 
   if (!content) {
     return null;

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -54,7 +54,11 @@ function PaginationLink({
       asChild
       variant={isActive ? "outline" : "ghost"}
       size={size}
-      className={cn(isActive && "card-shadow", className)}
+      className={cn(
+        isActive && "card-shadow",
+        !isActive && "hover:bg-primary/5",
+        className
+      )}
     >
       <a
         aria-current={isActive ? "page" : undefined}

--- a/frontend/src/lib/api/location/location.queries.ts
+++ b/frontend/src/lib/api/location/location.queries.ts
@@ -1,9 +1,13 @@
 import {
   UpdateIncidentVars,
+  useCreateIncident,
   useDeleteIncident,
   useUpdateIncident,
 } from "@/lib/api/incident/incident.queries";
-import { IncidentDto } from "@/lib/api/incident/incident.types";
+import {
+  IncidentCreateDto,
+  IncidentDto,
+} from "@/lib/api/incident/incident.types";
 import { ListQueryParams } from "@/lib/api/shared/query-params";
 import { OptimisticMutationOptions, PaginatedResponse } from "@/lib/shared";
 import {
@@ -98,6 +102,20 @@ type LocationsSnapshot = [
   QueryKey,
   PaginatedResponse<LocationDto> | undefined,
 ][];
+
+export function useCreateIncidentInLocation(
+  options?: OptimisticMutationOptions<IncidentDto, Error, IncidentCreateDto>
+) {
+  const queryClient = useQueryClient();
+
+  return useCreateIncident({
+    ...options,
+    onSuccess: (...params) => {
+      queryClient.invalidateQueries({ queryKey: LOCATIONS_KEY });
+      options?.onSuccess?.(...params);
+    },
+  });
+}
 
 export function useUpdateIncidentInLocation(
   options?: OptimisticMutationOptions<


### PR DESCRIPTION
Enable React Compiler on the Next.js 16 / React 19 frontend and clean up all now-redundant manual memoization.

## Changes

- Enable `reactCompiler: true` in `next.config.ts` (stable API in Next.js 16)
- Add `eslint-plugin-react-no-manual-memo` as a permanent lint rule to catch future `useMemo`/`useCallback`/`React.memo` written out of habit; configure `--fix-type problem,layout` in the ESLint pre-commit hook so its suggestion fixes never auto-apply
- Remove redundant manual memoization from 25+ components and hooks; two legitimate exceptions kept with inline comments
- Refactor `TableTemplate` to receive `query`/`serverTableState` as props instead of a `useQuery` hook — fixes a hook-as-value React rules violation and moves data fetching to each table's parent component
- Remove `locationService` DI prop from `AddressSearch` and both callers; replaced with a module-level singleton
- Replace IIFE-style derived values introduced by ESLint auto-fix with named module-level helper functions and inline expressions

## TableTemplate and React Compiler

`TableTemplate` opts out of the compiler via `"use no memo"` — TanStack Table's `useReactTable()` returns a mutable table instance with methods the compiler can't safely reason about, causing either stale UI or infinite update loops (tracked in facebook/react#33057 and TanStack/table#6137).

Because the compiler doesn't optimize `TableTemplate`, all memoization inside it is manual. This surfaced several stability issues that had to be fixed explicitly:

- **`columnsWithActions`** — kept as a manual `useMemo`. Without it, `useReactTable` receives a new column array every render, which resets internal table state and causes re-render loops. A file-level `eslint-disable` covers the no-manual-memo warnings for the whole file.
- **`syncServerSorting`** — wrapped in `useCallback` in `useServerTableState`. Without a stable reference, the effect in `TableTemplate` that syncs sort state from server responses would re-fire on every render, overwriting the user's in-flight sort selection with stale `query.data` and sometimes triggering a maximum update depth error.
- **`handleFilterSidebarOpenChange`** — wrapped in `useCallback` so `SidebarContent`'s external-close detection effect doesn't fire on every `TableTemplate` render.
- **`openSidebar`/`closeSidebar` in `SidebarContext`** — reverted to be excluded from `SidebarContent`'s `useLayoutEffect` deps (they were incorrectly added during migration). Because `SidebarContext` doesn't use `useCallback`, these are new references every render; including them caused the layout effect to re-run on every context state change.

## Other fixes bundled in this branch

- **Sidebar popover dismissal** — clicking a `Popover`, `Select`, or `DatePicker` inside a form sidebar was closing the sidebar. Root cause: the form content is portaled into the Sheet's DOM body node but is not in the Sheet's React component tree, so Radix can't track the popover as a child layer of the Dialog. Fixed by adding an `onInteractOutside` guard on `SheetContent` that prevents closure when the click target is inside `[data-radix-popper-content-wrapper]`.
- **`useCreateIncidentInLocation`** — creating an incident from the location sidebar sent a 201 but showed no UI change. `useCreateIncident` only invalidated `INCIDENTS_KEY`; the sidebar data comes from `LOCATIONS_KEY` (nested incidents on location objects). Added `useCreateIncidentInLocation` to `location.queries.ts` following the same pattern as the existing update/delete wrappers.
- **Column sorting revert** — sorting a column would immediately revert to the previous sort. Same root cause as above: `syncServerSorting` was an unstable reference, causing the sync effect to re-fire with stale `query.data` sort values before the new response arrived.

Closes #434