### PR TITLE
feat: snackbar promise toasts, exhaustive error handling, and route docs

### DIFF
--- a/backend/src/modules/account/account_router.py
+++ b/backend/src/modules/account/account_router.py
@@ -24,7 +24,15 @@ _OPENAPI_PARAMS = get_paginated_openapi_params(AccountService.QUERY_FIELDS)
 _AGGREGATE_OPENAPI_PARAMS = get_paginated_openapi_params(AccountService.AGGREGATE_QUERY_FIELDS)
 
 
-@account_router.get("", openapi_extra=_OPENAPI_PARAMS)
+@account_router.get(
+    "",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def list_accounts(
     params: ListQueryParams = parse_list_query_params(),
     account_service: AccountService = Depends(),
@@ -33,7 +41,14 @@ async def list_accounts(
     return await account_service.get_accounts_paginated(params)
 
 
-@account_router.post("", status_code=status.HTTP_204_NO_CONTENT)
+@account_router.post(
+    "",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        409: {"description": "An account or pending invite already exists for this email"},
+        500: {"description": "Failed to send the invitation email"},
+    },
+)
 async def create_account(
     data: CreateInviteDto,
     account_service: AccountService = Depends(),
@@ -42,7 +57,15 @@ async def create_account(
     await account_service.create_invite(data)
 
 
-@account_router.get("/aggregate", openapi_extra=_AGGREGATE_OPENAPI_PARAMS)
+@account_router.get(
+    "/aggregate",
+    openapi_extra=_AGGREGATE_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_aggregate_accounts(
     params: ListQueryParams = parse_list_query_params(),
     account_service: AccountService = Depends(),
@@ -51,7 +74,15 @@ async def get_aggregate_accounts(
     return await account_service.get_aggregate_accounts_paginated(params)
 
 
-@account_router.get("/csv", openapi_extra=_OPENAPI_PARAMS)
+@account_router.get(
+    "/csv",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_accounts_csv(
     params: ListQueryParams = parse_export_list_query_params(),
     account_service: AccountService = Depends(),
@@ -67,7 +98,15 @@ async def get_accounts_csv(
     )
 
 
-@account_router.get("/aggregate/csv", openapi_extra=_AGGREGATE_OPENAPI_PARAMS)
+@account_router.get(
+    "/aggregate/csv",
+    openapi_extra=_AGGREGATE_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_aggregate_accounts_csv(
     params: ListQueryParams = parse_export_list_query_params(),
     account_service: AccountService = Depends(),
@@ -85,7 +124,13 @@ async def get_aggregate_accounts_csv(
     )
 
 
-@account_router.delete("/invites/{invite_id}", status_code=status.HTTP_204_NO_CONTENT)
+@account_router.delete(
+    "/invites/{invite_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        404: {"description": "Invite token with the given id was not found"},
+    },
+)
 async def delete_invite(
     invite_id: int,
     account_service: AccountService = Depends(),
@@ -94,7 +139,14 @@ async def delete_invite(
     await account_service.delete_invite(invite_id)
 
 
-@account_router.post("/invites/{invite_id}/resend", status_code=status.HTTP_204_NO_CONTENT)
+@account_router.post(
+    "/invites/{invite_id}/resend",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        404: {"description": "Invite token with the given id was not found"},
+        500: {"description": "Failed to send the invitation email"},
+    },
+)
 async def resend_invite(
     invite_id: int,
     account_service: AccountService = Depends(),
@@ -103,7 +155,12 @@ async def resend_invite(
     await account_service.resend_invite(invite_id)
 
 
-@account_router.put("/{account_id}")
+@account_router.put(
+    "/{account_id}",
+    responses={
+        404: {"description": "Account with the given id was not found"},
+    },
+)
 async def update_account(
     account_id: int,
     data: AccountUpdateData,
@@ -113,7 +170,12 @@ async def update_account(
     return await account_service.update_account(account_id, data)
 
 
-@account_router.delete("/{account_id}")
+@account_router.delete(
+    "/{account_id}",
+    responses={
+        404: {"description": "Account with the given id was not found"},
+    },
+)
 async def delete_account(
     account_id: int,
     account_service: AccountService = Depends(),

--- a/backend/src/modules/auth/auth_router.py
+++ b/backend/src/modules/auth/auth_router.py
@@ -49,7 +49,14 @@ def verify_internal_secret(
         raise InvalidInternalSecretException()
 
 
-@router.post("/exchange")
+@router.post(
+    "/exchange",
+    responses={
+        400: {"description": "Both account_id and police_id were provided to token creation"},
+        403: {"description": "Invalid X-Internal-Secret or invite invalid/expired/role mismatch"},
+        409: {"description": "Account already exists with conflicting email, onyen, or PID"},
+    },
+)
 async def exchange_account_data_for_tokens(
     data: AccountData,
     account_service: AccountService = Depends(),
@@ -73,7 +80,14 @@ async def exchange_account_data_for_tokens(
     return await auth_service.exchange_for_tokens(account)
 
 
-@router.post("/police/signup", status_code=status.HTTP_204_NO_CONTENT)
+@router.post(
+    "/police/signup",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        400: {"description": "Email is not a valid CHPD domain address"},
+        409: {"description": "Email is already registered to a police account"},
+    },
+)
 async def police_signup(
     data: PoliceSignupDto,
     police_service: PoliceService = Depends(),
@@ -84,7 +98,10 @@ async def police_signup(
     await police_service.signup_police(data.email, data.password)
 
 
-@router.post("/police/retry-verification", status_code=status.HTTP_204_NO_CONTENT)
+@router.post(
+    "/police/retry-verification",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def police_retry_verification(
     data: RetryVerificationDto,
     police_service: PoliceService = Depends(),
@@ -95,7 +112,13 @@ async def police_retry_verification(
     await police_service.retry_verification(data.email)
 
 
-@router.post("/police/verify", status_code=status.HTTP_204_NO_CONTENT)
+@router.post(
+    "/police/verify",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        400: {"description": "Verification token is invalid or expired"},
+    },
+)
 async def police_verify_email(
     data: VerifyEmailDto,
     police_service: PoliceService = Depends(),
@@ -106,7 +129,13 @@ async def police_verify_email(
     await police_service.verify_police_email(data.token)
 
 
-@router.post("/police/login")
+@router.post(
+    "/police/login",
+    responses={
+        401: {"description": "Invalid email or password"},
+        403: {"description": "Invalid X-Internal-Secret header, or police email is not verified"},
+    },
+)
 async def police_login(
     credentials: PoliceCredentialsDto,
     police_service: PoliceService = Depends(),
@@ -127,7 +156,13 @@ async def police_login(
     return await auth_service.exchange_for_tokens(police)
 
 
-@router.post("/refresh")
+@router.post(
+    "/refresh",
+    responses={
+        403: {"description": "Invalid X-Internal-Secret header"},
+        404: {"description": "The account or police user for this token was not found"},
+    },
+)
 async def refresh_access_token(
     data: RefreshTokenDto,
     auth_service: AuthService = Depends(),

--- a/backend/src/modules/incident/incident_router.py
+++ b/backend/src/modules/incident/incident_router.py
@@ -30,6 +30,11 @@ _OPENAPI_PARAMS = get_paginated_openapi_params(IncidentService.QUERY_FIELDS)
     summary="Get all incidents (paginated)",
     description="Returns paginated incidents. Police, staff, or admin only.",
     openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
 )
 async def get_incidents_paginated(
     params: ListQueryParams = parse_list_query_params(),
@@ -39,7 +44,15 @@ async def get_incidents_paginated(
     return await incident_service.get_incidents_paginated(params)
 
 
-@incident_router.get("/incidents/csv", openapi_extra=_OPENAPI_PARAMS)
+@incident_router.get(
+    "/incidents/csv",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_incidents_csv(
     params: ListQueryParams = parse_export_list_query_params(),
     incident_service: IncidentService = Depends(),
@@ -77,6 +90,12 @@ async def get_incidents_by_location(
     status_code=status.HTTP_201_CREATED,
     summary="Create an incident",
     description="Creates a new incident, auto-creating the location if needed. Police or admin.",
+    responses={
+        400: {"description": "Invalid place ID format"},
+        404: {"description": "Place ID not found in Google Maps"},
+        409: {"description": "Location with the given place ID already exists"},
+        500: {"description": "Google Maps API request failed"},
+    },
 )
 async def create_incident(
     incident_data: IncidentCreateDto,
@@ -93,6 +112,12 @@ async def create_incident(
     status_code=status.HTTP_200_OK,
     summary="Update an incident",
     description="Updates an existing incident. Police or admin only.",
+    responses={
+        400: {"description": "Invalid place ID format"},
+        404: {"description": "Incident not found, or place ID not found in Google Maps"},
+        409: {"description": "Location conflict during location update"},
+        500: {"description": "Google Maps API request failed"},
+    },
 )
 async def update_incident(
     incident_id: int,
@@ -110,6 +135,9 @@ async def update_incident(
     status_code=status.HTTP_200_OK,
     summary="Delete an incident",
     description="Deletes an incident. Police or admin only.",
+    responses={
+        404: {"description": "Incident with the given id was not found"},
+    },
 )
 async def delete_incident(
     incident_id: int,

--- a/backend/src/modules/location/location_entity.py
+++ b/backend/src/modules/location/location_entity.py
@@ -51,6 +51,7 @@ class LocationEntity(MappedAsDataclass, EntityBase):
         back_populates="location",
         cascade="all, delete-orphan",
         lazy="selectin",  # Use selectin loading to avoid N+1 queries
+        order_by="IncidentEntity.incident_datetime.asc()",
         init=False,
     )
 

--- a/backend/src/modules/location/location_router.py
+++ b/backend/src/modules/location/location_router.py
@@ -32,6 +32,10 @@ _OPENAPI_PARAMS = get_paginated_openapi_params(LocationService.QUERY_FIELDS)
     status_code=status.HTTP_200_OK,
     summary="Autocomplete address search",
     description="Returns address suggestions based on user input using Google Maps Places API.",
+    responses={
+        400: {"description": "Invalid address input"},
+        500: {"description": "Google Maps API request failed"},
+    },
 )
 async def autocomplete_address(
     input_data: AutocompleteInput,
@@ -66,6 +70,11 @@ async def autocomplete_address(
     status_code=status.HTTP_200_OK,
     summary="Get place details from Google Maps place ID",
     description="Returns address details including coordinates for a given place ID.",
+    responses={
+        400: {"description": "Invalid place ID or malformed request"},
+        404: {"description": "Place not found for the given place ID"},
+        500: {"description": "Google Maps API request failed"},
+    },
 )
 async def get_place_details(
     place_id: str,
@@ -96,6 +105,11 @@ async def get_place_details(
     "",
     response_model=PaginatedLocationResponse,
     openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
 )
 async def get_locations(
     params: ListQueryParams = parse_list_query_params(),
@@ -108,7 +122,15 @@ async def get_locations(
     return await location_service.get_locations_paginated(params)
 
 
-@location_router.get("/csv", openapi_extra=_OPENAPI_PARAMS)
+@location_router.get(
+    "/csv",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_locations_csv(
     params: ListQueryParams = parse_export_list_query_params(),
     location_service: LocationService = Depends(),
@@ -124,7 +146,13 @@ async def get_locations_csv(
     )
 
 
-@location_router.get("/{location_id}", response_model=LocationDto)
+@location_router.get(
+    "/{location_id}",
+    response_model=LocationDto,
+    responses={
+        404: {"description": "Location not found"},
+    },
+)
 async def get_location(
     location_id: int,
     location_service: LocationService = Depends(),
@@ -133,7 +161,17 @@ async def get_location(
     return await location_service.get_location_by_id(location_id)
 
 
-@location_router.post("", status_code=201, response_model=LocationDto)
+@location_router.post(
+    "",
+    status_code=201,
+    response_model=LocationDto,
+    responses={
+        400: {"description": "Invalid Google place ID"},
+        404: {"description": "Place not found for the given place ID"},
+        409: {"description": "Location with this Google place ID already exists"},
+        500: {"description": "Google Maps API request failed"},
+    },
+)
 async def create_location(
     data: LocationCreate,
     location_service: LocationService = Depends(),
@@ -148,7 +186,16 @@ async def create_location(
     )
 
 
-@location_router.put("/{location_id}", response_model=LocationDto)
+@location_router.put(
+    "/{location_id}",
+    response_model=LocationDto,
+    responses={
+        400: {"description": "Invalid Google place ID"},
+        404: {"description": "Location not found, or place not found for the given place ID"},
+        409: {"description": "Location with this Google place ID already exists"},
+        500: {"description": "Google Maps API request failed"},
+    },
+)
 async def update_location(
     location_id: int,
     data: LocationCreate,
@@ -173,7 +220,13 @@ async def update_location(
     return await location_service.update_location(location_id, location_data)
 
 
-@location_router.delete("/{location_id}", response_model=LocationDto)
+@location_router.delete(
+    "/{location_id}",
+    response_model=LocationDto,
+    responses={
+        404: {"description": "Location not found"},
+    },
+)
 async def delete_location(
     location_id: int,
     location_service: LocationService = Depends(),

--- a/backend/src/modules/notification/notification_router.py
+++ b/backend/src/modules/notification/notification_router.py
@@ -6,7 +6,13 @@ from .notification_service import NotificationService
 notification_router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
 
-@notification_router.post("/unsubscribe", status_code=204)
+@notification_router.post(
+    "/unsubscribe",
+    status_code=204,
+    responses={
+        400: {"description": "Token is malformed or has an invalid signature"},
+    },
+)
 async def unsubscribe(
     body: UnsubscribeDto,
     notification_service: NotificationService = Depends(),
@@ -21,7 +27,13 @@ async def unsubscribe(
     await notification_service.unsubscribe(email)
 
 
-@notification_router.post("/unsubscribe/one-click", status_code=204)
+@notification_router.post(
+    "/unsubscribe/one-click",
+    status_code=204,
+    responses={
+        400: {"description": "Token is malformed or has an invalid signature"},
+    },
+)
 async def unsubscribe_one_click(
     token: str = Query(...),
     notification_service: NotificationService = Depends(),
@@ -34,7 +46,13 @@ async def unsubscribe_one_click(
     await notification_service.unsubscribe(email)
 
 
-@notification_router.post("/resubscribe", status_code=204)
+@notification_router.post(
+    "/resubscribe",
+    status_code=204,
+    responses={
+        400: {"description": "Token is malformed or has an invalid signature"},
+    },
+)
 async def resubscribe(
     body: ResubscribeDto,
     notification_service: NotificationService = Depends(),
@@ -47,7 +65,12 @@ async def resubscribe(
     await notification_service.resubscribe(email)
 
 
-@notification_router.get("/subscription-status")
+@notification_router.get(
+    "/subscription-status",
+    responses={
+        400: {"description": "Token is malformed or has an invalid signature"},
+    },
+)
 async def subscription_status(
     token: str = Query(...),
     notification_service: NotificationService = Depends(),

--- a/backend/src/modules/party/party_router.py
+++ b/backend/src/modules/party/party_router.py
@@ -30,13 +30,37 @@ from .party_model import (
     ProximitySearchResponse,
     StudentCreatePartyDto,
 )
-from .party_service import PartyService
+from .party_service import PartyRule, PartyService
 
 party_router = APIRouter(prefix="/api/parties", tags=["parties"])
 _OPENAPI_PARAMS = get_paginated_openapi_params(PartyService.QUERY_FIELDS)
+_PARTY_RULE_CODES = ", ".join(rule.value for rule in PartyRule)
 
 
-@party_router.post("", status_code=201)
+@party_router.post(
+    "",
+    status_code=201,
+    responses={
+        400: {
+            "description": f"Request validation failed. Possible rule codes: {_PARTY_RULE_CODES}"
+        },
+        404: {
+            "description": (
+                "The referenced contact student or Google Maps place was not found (admin only)"
+            )
+        },
+        409: {
+            "description": (
+                "A location with the same Google place ID already exists (rare race condition)"
+            )
+        },
+        500: {
+            "description": (
+                "Google Maps API request failed while resolving the location (admin only)"
+            )
+        },
+    },
+)
 async def create_party(
     party_data: CreatePartyDto,
     party_service: PartyService = Depends(),
@@ -74,7 +98,15 @@ async def create_party(
             raise ForbiddenException(detail="Invalid request type")
 
 
-@party_router.get("", openapi_extra=_OPENAPI_PARAMS)
+@party_router.get(
+    "",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def list_parties(
     params: ListQueryParams = parse_list_query_params(),
     party_service: PartyService = Depends(),
@@ -87,7 +119,21 @@ async def list_parties(
     )
 
 
-@party_router.get("/nearby")
+@party_router.get(
+    "/nearby",
+    responses={
+        400: {
+            "description": (
+                "Start date is after end date, or the provided place ID has an invalid format"
+            )
+        },
+        500: {
+            "description": (
+                "Google Maps API request failed while resolving the place ID to coordinates"
+            )
+        },
+    },
+)
 async def get_parties_nearby(
     place_id: str = Query(..., description="Google Maps place ID"),
     start_datetime: datetime = Query(
@@ -132,7 +178,15 @@ async def get_parties_nearby(
     return await party_service.get_proximity_search(place_id, start_datetime, end_datetime)
 
 
-@party_router.get("/csv", openapi_extra=_OPENAPI_PARAMS)
+@party_router.get(
+    "/csv",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_parties_csv(
     params: ListQueryParams = parse_export_list_query_params(),
     party_service: PartyService = Depends(),
@@ -163,7 +217,25 @@ async def get_parties_csv(
     )
 
 
-@party_router.put("/{party_id}")
+@party_router.put(
+    "/{party_id}",
+    responses={
+        400: {
+            "description": f"Request validation failed. Possible rule codes: {_PARTY_RULE_CODES}"
+        },
+        404: {"description": ("The party, contact student, or Google Maps place was not found")},
+        409: {
+            "description": (
+                "A location with the same Google place ID already exists (rare race condition)"
+            )
+        },
+        500: {
+            "description": (
+                "Google Maps API request failed while resolving the location (admin only)"
+            )
+        },
+    },
+)
 async def update_party(
     party_id: int,
     party_data: CreatePartyDto,
@@ -202,7 +274,12 @@ async def update_party(
             raise ForbiddenException(detail="Invalid request type")
 
 
-@party_router.get("/{party_id}")
+@party_router.get(
+    "/{party_id}",
+    responses={
+        404: {"description": "Party with the given ID was not found"},
+    },
+)
 async def get_party(
     party_id: int,
     party_service: PartyService = Depends(),
@@ -211,7 +288,18 @@ async def get_party(
     return await party_service.get_party_by_id(party_id)
 
 
-@party_router.post("/{party_id}/cancel")
+@party_router.post(
+    "/{party_id}/cancel",
+    responses={
+        400: {
+            "description": (
+                f"Validation failed: {PartyRule.PARTY_NOT_OWNED_BY_STUDENT.value} "
+                f"or {PartyRule.PARTY_IN_PAST.value}"
+            )
+        },
+        404: {"description": "Party with the given ID was not found"},
+    },
+)
 async def cancel_party(
     party_id: int,
     party_service: PartyService = Depends(),
@@ -227,7 +315,12 @@ async def cancel_party(
     return await party_service.cancel_party(party_id, student_id)
 
 
-@party_router.post("/{party_id}/restore")
+@party_router.post(
+    "/{party_id}/restore",
+    responses={
+        404: {"description": "Party with the given ID was not found"},
+    },
+)
 async def restore_party(
     party_id: int,
     party_service: PartyService = Depends(),

--- a/backend/src/modules/police/police_router.py
+++ b/backend/src/modules/police/police_router.py
@@ -19,7 +19,15 @@ police_router = APIRouter(prefix="/api/police", tags=["police"])
 _OPENAPI_PARAMS = get_paginated_openapi_params(PoliceService.QUERY_FIELDS)
 
 
-@police_router.get("", openapi_extra=_OPENAPI_PARAMS)
+@police_router.get(
+    "",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def list_police(
     params: ListQueryParams = parse_list_query_params(),
     police_service: PoliceService = Depends(),
@@ -28,7 +36,15 @@ async def list_police(
     return await police_service.get_police_paginated(params)
 
 
-@police_router.get("/csv", openapi_extra=_OPENAPI_PARAMS)
+@police_router.get(
+    "/csv",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_police_csv(
     params: ListQueryParams = parse_export_list_query_params(),
     police_service: PoliceService = Depends(),
@@ -43,7 +59,12 @@ async def get_police_csv(
     )
 
 
-@police_router.get("/{police_id}")
+@police_router.get(
+    "/{police_id}",
+    responses={
+        404: {"description": "Police account with the given ID was not found"},
+    },
+)
 async def get_police(
     police_id: int,
     police_service: PoliceService = Depends(),
@@ -52,7 +73,13 @@ async def get_police(
     return await police_service.get_police_by_id(police_id)
 
 
-@police_router.put("/{police_id}")
+@police_router.put(
+    "/{police_id}",
+    responses={
+        404: {"description": "Police account with the given ID was not found"},
+        409: {"description": "The new email address is already in use by another police account"},
+    },
+)
 async def update_police(
     police_id: int,
     data: PoliceAccountUpdate,
@@ -62,7 +89,13 @@ async def update_police(
     return await police_service.update_police(police_id, data.email, data.role, data.is_verified)
 
 
-@police_router.delete("/{police_id}")
+@police_router.delete(
+    "/{police_id}",
+    responses={
+        403: {"description": "Police admins cannot delete their own account"},
+        404: {"description": "Police account with the given ID was not found"},
+    },
+)
 async def delete_police(
     police_id: int,
     police_service: PoliceService = Depends(),

--- a/backend/src/modules/student/student_router.py
+++ b/backend/src/modules/student/student_router.py
@@ -30,7 +30,12 @@ student_router = APIRouter(prefix="/api/students", tags=["students"])
 _OPENAPI_PARAMS = get_paginated_openapi_params(StudentService.QUERY_FIELDS)
 
 
-@student_router.get("/me")
+@student_router.get(
+    "/me",
+    responses={
+        404: {"description": "Student profile not found for the authenticated account"},
+    },
+)
 async def get_me(
     student_service: StudentService = Depends(),
     user: AuthPrincipal = Depends(authenticate_by_role("student", "staff", "admin")),
@@ -38,7 +43,13 @@ async def get_me(
     return await student_service.get_student_me_dto(user.id)
 
 
-@student_router.put("/me")
+@student_router.put(
+    "/me",
+    responses={
+        404: {"description": "Account not found when creating student profile"},
+        409: {"description": "Phone number is already in use by another account"},
+    },
+)
 async def update_me(
     data: SelfUpdateStudentDto,
     student_service: StudentService = Depends(),
@@ -47,7 +58,15 @@ async def update_me(
     return await student_service.update_student_self(user.id, data)
 
 
-@student_router.put("/me/residence")
+@student_router.put(
+    "/me/residence",
+    responses={
+        400: {"description": "Residence has already been chosen for this academic year"},
+        404: {"description": "Student not found, or place ID not found in Google Maps"},
+        409: {"description": "Location with the given Google place ID already exists"},
+        500: {"description": "Google Maps API error (timeout, transport error, or API error)"},
+    },
+)
 async def update_my_residence(
     data: ResidenceUpdateDto,
     student_service: StudentService = Depends(),
@@ -64,7 +83,15 @@ async def get_my_parties(
     return await party_service.get_parties_by_contact(user.id)
 
 
-@student_router.get("", openapi_extra=_OPENAPI_PARAMS)
+@student_router.get(
+    "",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def list_students(
     params: ListQueryParams = parse_list_query_params(),
     student_service: StudentService = Depends(),
@@ -89,7 +116,15 @@ async def list_students(
     return await student_service.get_students_paginated(params)
 
 
-@student_router.get("/csv", openapi_extra=_OPENAPI_PARAMS)
+@student_router.get(
+    "/csv",
+    openapi_extra=_OPENAPI_PARAMS,
+    responses={
+        400: {
+            "description": "Invalid sort or filter parameter: unknown field or unsupported operator"
+        },
+    },
+)
 async def get_students_csv(
     params: ListQueryParams = parse_export_list_query_params(),
     student_service: StudentService = Depends(),
@@ -114,7 +149,12 @@ async def autocomplete_students(
     return await student_service.autocomplete_students(input_data.query)
 
 
-@student_router.get("/{student_id}")
+@student_router.get(
+    "/{student_id}",
+    responses={
+        404: {"description": "Student with the given id was not found"},
+    },
+)
 async def get_student(
     student_id: int,
     student_service: StudentService = Depends(),
@@ -123,7 +163,17 @@ async def get_student(
     return await student_service.get_student_by_id(student_id)
 
 
-@student_router.put("/{student_id}")
+@student_router.put(
+    "/{student_id}",
+    responses={
+        404: {
+            "description": "Student with the given id was not found, "
+            "or the provided residence place ID was not found"
+        },
+        409: {"description": "Phone number is already in use by another account"},
+        500: {"description": "Google Maps API error when fetching location details"},
+    },
+)
 async def update_student(
     student_id: int,
     data: StudentUpdateDto,
@@ -133,7 +183,12 @@ async def update_student(
     return await student_service.update_student(student_id, data)
 
 
-@student_router.delete("/{student_id}")
+@student_router.delete(
+    "/{student_id}",
+    responses={
+        404: {"description": "Student with the given id was not found"},
+    },
+)
 async def delete_student(
     student_id: int,
     student_service: StudentService = Depends(),
@@ -142,7 +197,13 @@ async def delete_student(
     return await student_service.delete_student(student_id)
 
 
-@student_router.patch("/{student_id}/is-registered")
+@student_router.patch(
+    "/{student_id}/is-registered",
+    responses={
+        404: {"description": "Student with the given id was not found"},
+        409: {"description": "Phone number is already in use by another account"},
+    },
+)
 async def update_is_registered(
     student_id: int,
     data: IsRegisteredUpdate,

--- a/backend/test/modules/location/location_service_test.py
+++ b/backend/test/modules/location/location_service_test.py
@@ -237,7 +237,7 @@ class TestLocationServiceWithIncidents:
         # Fetch the location
         fetched = await self.location_service.get_location_by_id(location.id)
 
-        # Verify incidents are included
+        # Verify incidents are included, ordered earliest-first by incident_datetime
         assert len(fetched.incidents) == 2
         self.incident_utils.assert_matches(fetched.incidents[0], incident1)
         self.incident_utils.assert_matches(fetched.incidents[1], incident2)

--- a/frontend/shared/mock_data.json
+++ b/frontend/shared/mock_data.json
@@ -48,7 +48,7 @@
       "onyen": "stevenmorrison",
       "residence": {
         "location_id": 1,
-        "residence_chosen_date": "NOW-400d"
+        "residence_chosen_date": "NOW-1d"
       }
     },
     {

--- a/frontend/src/app/(student)/_components/tracker/DeletePartyDialog.tsx
+++ b/frontend/src/app/(student)/_components/tracker/DeletePartyDialog.tsx
@@ -31,6 +31,7 @@ export function DeletePartyDialog({
   const handleCancel = async () => {
     try {
       await deletePartyMutation.mutateAsync(party.id);
+      openSnackbar("Party cancelled successfully", "success");
       onOpenChange(false);
     } catch {
       openSnackbar("Failed to cancel party", "error");

--- a/frontend/src/app/(student)/_components/tracker/EditPartyDialog.tsx
+++ b/frontend/src/app/(student)/_components/tracker/EditPartyDialog.tsx
@@ -58,6 +58,7 @@ export function EditPartyDialog({
         partyId: party.id,
         data: partyData,
       });
+      openSnackbar("Party updated successfully", "success");
       onOpenChange(false);
     } catch (error) {
       const validationError = getPartyValidationError(error);
@@ -69,8 +70,13 @@ export function EditPartyDialog({
     }
   };
 
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) setSubmissionError(null);
+    onOpenChange(nextOpen);
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Edit Party</DialogTitle>

--- a/frontend/src/app/(student)/new-party/page.tsx
+++ b/frontend/src/app/(student)/new-party/page.tsx
@@ -12,6 +12,7 @@ import {
   useCurrentStudent,
   useUpdateStudent,
 } from "@/lib/api/student/student.queries";
+import { getErrorMessage } from "@/lib/errors";
 import { isFromThisSchoolYear } from "@/lib/utils";
 import { ArrowLeft, Info } from "lucide-react";
 import Link from "next/link";
@@ -66,11 +67,17 @@ export default function RegistrationForm() {
       router.push("/");
     } catch (err) {
       const validationError = getPartyValidationError(err);
-      if (validationError) {
-        setSubmissionError(validationError.message);
-      } else {
-        openSnackbar("Failed to create party", "error");
-      }
+      setSubmissionError(
+        validationError
+          ? validationError.message
+          : getErrorMessage(err, {
+              status: {
+                409: "That phone number is already in use.",
+                400: "You've already set your residence for this academic year.",
+              },
+              fallback: "Failed to register your party. Please try again.",
+            })
+      );
     }
   };
 

--- a/frontend/src/app/(student)/profile/page.tsx
+++ b/frontend/src/app/(student)/profile/page.tsx
@@ -8,6 +8,7 @@ import { Card } from "@/components/ui/card";
 import { FieldGroup, FieldSet } from "@/components/ui/field";
 import { Form } from "@/components/ui/form";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useSnackbar } from "@/contexts/SnackbarContext";
 import { AutocompleteResult } from "@/lib/api/location/location.types";
 import {
   useCurrentStudent,
@@ -87,6 +88,7 @@ function StudentInfo() {
   const { data: student, isLoading, error } = useCurrentStudent();
   const updateStudentMutation = useUpdateStudent();
   const updateResidenceMutation = useUpdateResidence();
+  const { openSnackbar } = useSnackbar();
   const [isEditing, setIsEditing] = useState(false);
   const [locationPlaceId, setLocationPlaceId] = useState("");
   const [formattedAddress, setFormattedAddress] = useState("");
@@ -142,10 +144,19 @@ function StudentInfo() {
         });
       }
 
+      openSnackbar("Profile updated successfully", "success");
       setLocationPlaceId("");
       setIsEditing(false);
     } catch (error) {
-      setSubmitError(getErrorMessage(error));
+      setSubmitError(
+        getErrorMessage(error, {
+          status: {
+            409: "That phone number is already in use.",
+            400: "You've already set your residence for this academic year.",
+          },
+          fallback: "Failed to update your profile. Please try again.",
+        })
+      );
     }
   };
 

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -15,9 +15,13 @@ import {
   useSubscriptionStatus,
   useUnsubscribe,
 } from "@/lib/api/notification/notification.queries";
+import { getErrorMessage } from "@/lib/errors";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
+
+const INVALID_LINK_MESSAGE =
+  "This link is invalid or has expired. Please use the link from your most recent party registration email.";
 
 export default function NotificationsPage() {
   return (
@@ -37,7 +41,13 @@ function NotificationsContent() {
 
   const isSubscribed = data?.is_subscribed;
   const isMutating = unsubscribe.isPending || resubscribe.isPending;
-  const hasMutationError = unsubscribe.isError || resubscribe.isError;
+  const mutationError = unsubscribe.error ?? resubscribe.error;
+  const mutationErrorMessage = mutationError
+    ? getErrorMessage(mutationError, {
+        status: { 400: INVALID_LINK_MESSAGE },
+        fallback: "Something went wrong. Please try again.",
+      })
+    : null;
 
   return (
     <div className="flex h-full items-center justify-center px-4 py-6">
@@ -61,8 +71,7 @@ function NotificationsContent() {
         <CardContent className="px-10 pt-4 pb-8 flex flex-col gap-6">
           {!token || isError ? (
             <p className="text-sm text-destructive text-center">
-              This link is invalid or has expired. Please use the link from your
-              most recent party registration email.
+              {INVALID_LINK_MESSAGE}
             </p>
           ) : isLoading ? (
             <div className="flex flex-col gap-3">
@@ -76,9 +85,9 @@ function NotificationsContent() {
                   ? "You are currently receiving party registration emails."
                   : "You are not receiving party registration emails."}
               </p>
-              {hasMutationError && (
+              {mutationErrorMessage && (
                 <p className="text-sm text-destructive text-center">
-                  Something went wrong. Please try again.
+                  {mutationErrorMessage}
                 </p>
               )}
               {isSubscribed ? (

--- a/frontend/src/app/police/_components/PartyList.tsx
+++ b/frontend/src/app/police/_components/PartyList.tsx
@@ -2,7 +2,10 @@
 
 import IncidentDialog from "@/components/IncidentDialog";
 import { useSnackbar } from "@/contexts/SnackbarContext";
-import type { IncidentSeverity } from "@/lib/api/incident/incident.types";
+import type {
+  IncidentCreateDto,
+  IncidentSeverity,
+} from "@/lib/api/incident/incident.types";
 import { ExactMatchDto, PartyPoliceDto } from "@/lib/api/party/party.types";
 import { usePoliceCreateIncident } from "@/lib/api/party/police-party.queries";
 import { getErrorMessage } from "@/lib/errors";
@@ -27,19 +30,24 @@ const PartyList = ({
   const [incidentType, setIncidentType] =
     useState<IncidentSeverity>("in_person_warning");
   const [selectedData, setSelectedData] = useState<PartyCardData | null>(null);
-  const { openSnackbar } = useSnackbar();
+  const { snackbarPromise } = useSnackbar();
 
   const createIncidentMutation = usePoliceCreateIncident({
     onOptimisticUpdate: () => {
       setIncidentDialogOpen(false);
     },
-    onSuccess: () => {
-      openSnackbar("Incident created successfully", "success");
-    },
-    onError: (error) => {
-      openSnackbar(getErrorMessage(error), "error");
-    },
   });
+
+  const handleCreateIncident = (data: IncidentCreateDto) => {
+    snackbarPromise(createIncidentMutation.mutateAsync(data), {
+      loading: "Creating incident...",
+      success: "Incident created successfully",
+      error: (err) =>
+        getErrorMessage(err, {
+          fallback: "Failed to create the incident. Please try again.",
+        }),
+    });
+  };
 
   const openIncidentDialog = (
     data: PartyCardData,
@@ -165,7 +173,7 @@ const PartyList = ({
         formattedAddress={
           selectedData?.hasParty ? undefined : selectedData?.formattedAddress
         }
-        onSubmit={createIncidentMutation.mutate}
+        onSubmit={handleCreateIncident}
         isSubmitting={createIncidentMutation.isPending}
         key={dialogKey}
       />

--- a/frontend/src/app/police/admin/_components/PoliceAccountsTable.tsx
+++ b/frontend/src/app/police/admin/_components/PoliceAccountsTable.tsx
@@ -26,7 +26,7 @@ import { useSession } from "next-auth/react";
 
 export default function PoliceAccountsTable() {
   const { data: session } = useSession();
-  const { openSnackbar } = useSnackbar();
+  const { openSnackbar, snackbarPromise } = useSnackbar();
   const {
     mode,
     row,
@@ -43,7 +43,14 @@ export default function PoliceAccountsTable() {
 
   const updatePoliceAccountMutation = useUpdatePoliceAccount({
     onError: (error: Error) => {
-      setSubmissionError(getErrorMessage(error));
+      setSubmissionError(
+        getErrorMessage(error, {
+          status: {
+            409: "That email is already in use by another police account.",
+          },
+          fallback: "Failed to update police account.",
+        })
+      );
     },
     onSuccess: () => {
       openSnackbar("Police account updated successfully", "success");
@@ -51,14 +58,7 @@ export default function PoliceAccountsTable() {
     },
   });
 
-  const deletePoliceAccountMutation = useDeletePoliceAccount({
-    onSuccess: () => {
-      openSnackbar("Police account deleted successfully", "success");
-    },
-    onError: () => {
-      openSnackbar("Failed to delete police account.", "error");
-    },
-  });
+  const deletePoliceAccountMutation = useDeletePoliceAccount();
 
   const currentPoliceId = session?.id ? Number(session.id) : null;
 
@@ -67,7 +67,11 @@ export default function PoliceAccountsTable() {
       openSnackbar("You cannot delete your own account", "error");
       return;
     }
-    deletePoliceAccountMutation.mutate(row.id);
+    snackbarPromise(deletePoliceAccountMutation.mutateAsync(row.id), {
+      loading: "Deleting police account...",
+      success: "Police account deleted successfully",
+      error: "Failed to delete police account",
+    });
   };
 
   const handlePoliceEditSubmit = async (
@@ -151,6 +155,7 @@ export default function PoliceAccountsTable() {
               <PoliceAccountTableForm
                 onSubmit={(data) => handlePoliceEditSubmit(account.id, data)}
                 submissionError={submissionError}
+                isPending={updatePoliceAccountMutation.isPending}
                 editData={{
                   email: account.email,
                   role: account.role,

--- a/frontend/src/app/staff/_components/account/AccountTable.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTable.tsx
@@ -58,7 +58,9 @@ const ACCOUNT_STATUS_FILTER_OPTIONS = [
 const ACCOUNT_ERROR_OPTIONS = {
   status: {
     404: "Account not found",
+    409: "An account with this email already exists",
   },
+  fallback: "Failed to complete the account action. Please try again.",
 } as const;
 
 const POLICE_ACCOUNT_ERROR_OPTIONS = {
@@ -67,7 +69,7 @@ const POLICE_ACCOUNT_ERROR_OPTIONS = {
 } as const;
 
 export const AccountTable = () => {
-  const { openSnackbar } = useSnackbar();
+  const { openSnackbar, snackbarPromise } = useSnackbar();
   const { data: session } = useSession();
   const {
     mode,
@@ -111,39 +113,10 @@ export const AccountTable = () => {
     },
   });
 
-  const deleteAccountMutation = useDeleteAccount({
-    onError: (error: Error) => {
-      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
-      console.error("Failed to delete account:", message);
-      openSnackbar("Failed to delete account", "error");
-    },
-  });
-
-  const deletePoliceAccountMutation = useDeletePoliceAccount({
-    onError: (error: Error) => {
-      console.error("Failed to delete police account:", error);
-      openSnackbar("Failed to delete police account", "error");
-    },
-  });
-
-  const deleteInviteMutation = useDeleteInvite({
-    onError: (error: Error) => {
-      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
-      console.error("Failed to delete invite:", message);
-      openSnackbar("Failed to delete invite", "error");
-    },
-  });
-
-  const resendInviteMutation = useResendInvite({
-    onError: (error: Error) => {
-      const message = getErrorMessage(error, ACCOUNT_ERROR_OPTIONS);
-      console.error("Failed to resend invite:", message);
-      openSnackbar("Failed to resend invite", "error");
-    },
-    onSuccess: () => {
-      openSnackbar("Invite resent successfully", "success");
-    },
-  });
+  const deleteAccountMutation = useDeleteAccount();
+  const deletePoliceAccountMutation = useDeletePoliceAccount();
+  const deleteInviteMutation = useDeleteInvite();
+  const resendInviteMutation = useResendInvite();
 
   const handleEdit = (row: AggregateAccountDto) => {
     if (row.status === "invited") return;
@@ -152,11 +125,23 @@ export const AccountTable = () => {
 
   const handleDelete = (row: AggregateAccountDto) => {
     if (row.status === "invited") {
-      deleteInviteMutation.mutate(row.source_id);
+      snackbarPromise(deleteInviteMutation.mutateAsync(row.source_id), {
+        loading: "Deleting invite...",
+        success: "Invite deleted successfully",
+        error: (err) => getErrorMessage(err, ACCOUNT_ERROR_OPTIONS),
+      });
     } else if (isPoliceRow(row)) {
-      deletePoliceAccountMutation.mutate(row.source_id);
+      snackbarPromise(deletePoliceAccountMutation.mutateAsync(row.source_id), {
+        loading: "Deleting police account...",
+        success: "Police account deleted successfully",
+        error: "Failed to delete police account",
+      });
     } else {
-      deleteAccountMutation.mutate(row.source_id);
+      snackbarPromise(deleteAccountMutation.mutateAsync(row.source_id), {
+        loading: "Deleting account...",
+        success: "Account deleted successfully",
+        error: (err) => getErrorMessage(err, ACCOUNT_ERROR_OPTIONS),
+      });
     }
   };
 
@@ -281,7 +266,12 @@ export const AccountTable = () => {
           }),
           {
             label: "Resend invite",
-            onClick: (row) => resendInviteMutation.mutate(row.source_id),
+            onClick: (row) =>
+              snackbarPromise(resendInviteMutation.mutateAsync(row.source_id), {
+                loading: "Resending invite...",
+                success: "Invite resent successfully",
+                error: (err) => getErrorMessage(err, ACCOUNT_ERROR_OPTIONS),
+              }),
             icon: <Send className="mr-2 size-4" />,
             isVisible: (row) => row.status === "invited",
           } satisfies RowAction<AggregateAccountDto>,
@@ -315,6 +305,7 @@ export const AccountTable = () => {
               <AccountTableForm
                 onSubmit={handleAccountCreateSubmit}
                 submissionError={submissionError}
+                isPending={createAccountMutation.isPending}
               />
             ),
           },
@@ -336,6 +327,7 @@ export const AccountTable = () => {
                     handlePoliceEditSubmit(account.source_id, data)
                   }
                   submissionError={submissionError}
+                  isPending={updatePoliceAccountMutation.isPending}
                   editData={{
                     email: account.email,
                     role: account.role as PoliceRole,
@@ -349,6 +341,7 @@ export const AccountTable = () => {
                     handleAccountEditSubmit(account.source_id, data)
                   }
                   submissionError={submissionError}
+                  isPending={updateAccountMutation.isPending}
                   editData={{
                     email: account.email,
                     role: account.role as InviteTokenRole,

--- a/frontend/src/app/staff/_components/account/AccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/AccountTableForm.tsx
@@ -17,12 +17,14 @@ interface AccountTableFormProps {
   onSubmit: (data: AccountTableFormValues) => void | Promise<void>;
   editData?: AccountTableFormValues;
   submissionError?: string | null;
+  isPending?: boolean;
 }
 
 export default function AccountTableForm({
   onSubmit,
   editData,
   submissionError,
+  isPending,
 }: AccountTableFormProps) {
   const form = useForm<AccountTableFormValues>({
     resolver: zodResolver(accountTableFormSchema),
@@ -41,6 +43,7 @@ export default function AccountTableForm({
       onSubmit={onSubmit}
       submitLabel={isEditMode ? "Save Changes" : "Send Invite"}
       submissionError={submissionError}
+      pending={isPending}
     >
       <TextField
         control={form.control}

--- a/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
+++ b/frontend/src/app/staff/_components/account/PoliceAccountTableForm.tsx
@@ -31,6 +31,7 @@ interface Props {
   editData?: { email: string; role: PoliceRole; is_verified: boolean };
   submissionError?: string | null;
   disableVerificationToggle?: boolean;
+  isPending?: boolean;
 }
 
 export default function PoliceAccountTableForm({
@@ -38,6 +39,7 @@ export default function PoliceAccountTableForm({
   editData,
   submissionError,
   disableVerificationToggle = false,
+  isPending,
 }: Props) {
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -58,6 +60,7 @@ export default function PoliceAccountTableForm({
       onSubmit={handleValid}
       submitLabel="Save Changes"
       submissionError={submissionError}
+      pending={isPending}
     >
       <TextField
         control={form.control}

--- a/frontend/src/app/staff/_components/incident/IncidentTable.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTable.tsx
@@ -39,7 +39,7 @@ function truncateDescription(
 }
 
 export const IncidentTable = () => {
-  const { openSnackbar } = useSnackbar();
+  const { openSnackbar, snackbarPromise } = useSnackbar();
   const {
     mode,
     row,
@@ -53,7 +53,11 @@ export const IncidentTable = () => {
 
   const createMutation = useCreateIncident({
     onError: (error: Error) => {
-      setSubmissionError(getErrorMessage(error));
+      setSubmissionError(
+        getErrorMessage(error, {
+          fallback: "Failed to save the incident. Please try again.",
+        })
+      );
     },
     onSuccess: () => {
       openSnackbar("Incident created successfully", "success");
@@ -63,7 +67,11 @@ export const IncidentTable = () => {
 
   const updateMutation = useUpdateIncidentInLocation({
     onError: (error: Error) => {
-      setSubmissionError(getErrorMessage(error));
+      setSubmissionError(
+        getErrorMessage(error, {
+          fallback: "Failed to save the incident. Please try again.",
+        })
+      );
     },
     onSuccess: () => {
       openSnackbar("Incident updated successfully", "success");
@@ -71,14 +79,7 @@ export const IncidentTable = () => {
     },
   });
 
-  const deleteMutation = useDeleteIncident({
-    onError: (error: Error) => {
-      console.error("Failed to delete incident:", error);
-    },
-    onSuccess: () => {
-      openSnackbar("Incident deleted successfully", "success");
-    },
-  });
+  const deleteMutation = useDeleteIncident();
 
   const columns: ColumnDef<IncidentDto>[] = [
     {
@@ -203,7 +204,12 @@ export const IncidentTable = () => {
         rowActions={[
           editAction<IncidentDto>({ onClick: openEdit }),
           deleteAction<IncidentDto>({
-            onClick: (incident) => deleteMutation.mutate(incident.id),
+            onClick: (incident) =>
+              snackbarPromise(deleteMutation.mutateAsync(incident.id), {
+                loading: "Deleting incident...",
+                success: "Incident deleted successfully",
+                error: "Failed to delete incident",
+              }),
             resourceName: "Incident",
             description: (incident) =>
               `Are you sure you want to delete this incident at ${formatAddress(incident.location, ["street_number", "street_name", "unit"])}? This action cannot be undone.`,
@@ -233,6 +239,7 @@ export const IncidentTable = () => {
               <IncidentTableForm
                 onSubmit={(data) => createMutation.mutate(data)}
                 submissionError={submissionError}
+                isPending={createMutation.isPending}
               />
             ),
           },
@@ -247,6 +254,7 @@ export const IncidentTable = () => {
                   updateMutation.mutate({ id: incident.id, payload: data })
                 }
                 submissionError={submissionError}
+                isPending={updateMutation.isPending}
               />
             ),
           },

--- a/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
+++ b/frontend/src/app/staff/_components/incident/IncidentTableForm.tsx
@@ -41,12 +41,14 @@ interface IncidentTableFormProps {
   onSubmit: (data: IncidentCreateDto) => void | Promise<void>;
   editData?: IncidentDto;
   submissionError?: string | null;
+  isPending?: boolean;
 }
 
 export default function IncidentTableForm({
   onSubmit,
   editData,
   submissionError,
+  isPending,
 }: IncidentTableFormProps) {
   const initialAddressSelection: AutocompleteResult | null = editData?.location
     ? {
@@ -90,6 +92,7 @@ export default function IncidentTableForm({
       onSubmit={handleValid}
       submitLabel="Save"
       submissionError={submissionError}
+      pending={isPending}
     >
       <AddressField
         control={form.control}

--- a/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
+++ b/frontend/src/app/staff/_components/location/IncidentSidebarCard.tsx
@@ -18,13 +18,17 @@ import { ChevronDown, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 
 type IncidentSidebarCardProps = {
-  incidents: NestedIncidentDto;
+  incident: NestedIncidentDto;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onDeleteIncidentAction: (incidentId: number) => void;
   onEditIncidentAction: (incident: NestedIncidentDto) => void;
 };
 
 function IncidentSidebarCard({
-  incidents,
+  incident,
+  open,
+  onOpenChange,
   onDeleteIncidentAction,
   onEditIncidentAction,
 }: IncidentSidebarCardProps) {
@@ -32,7 +36,7 @@ function IncidentSidebarCard({
   const role = session?.role;
   return (
     <div>
-      <Collapsible>
+      <Collapsible open={open} onOpenChange={onOpenChange}>
         <div>
           <div className="flex flex-row w-full items-center justify-left py-2 px-2 rounded cursor-pointer hover:bg-muted transition-colors">
             <CollapsibleTrigger className="flex-1 text-left group" asChild>
@@ -40,12 +44,12 @@ function IncidentSidebarCard({
                 <ChevronDown className="mr-2 size-4 transition-transform duration-100 group-data-[state=open]:rotate-180" />
                 <div className="flex items-center gap-10">
                   <p className="text-sm whitespace-nowrap">
-                    {format(incidents.incident_datetime, "MM/dd")}
+                    {format(incident.incident_datetime, "MM/dd/yy")}
                   </p>
                   <p className="text-sm w-20 whitespace-nowrap">
-                    {formatTime(incidents.incident_datetime)}
+                    {formatTime(incident.incident_datetime)}
                   </p>
-                  <IncidentFlag type={incidents.severity} hoverCard />
+                  <IncidentFlag type={incident.severity} hoverCard />
                 </div>
               </div>
             </CollapsibleTrigger>
@@ -59,13 +63,13 @@ function IncidentSidebarCard({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
                   <DropdownMenuItem
-                    onClick={() => onEditIncidentAction?.(incidents)}
+                    onClick={() => onEditIncidentAction?.(incident)}
                   >
                     <Pencil className="mr-2 size-4" />
                     Edit
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => onDeleteIncidentAction(incidents.id)}
+                    onClick={() => onDeleteIncidentAction(incident.id)}
                     variant="destructive"
                   >
                     <Trash2 className="mr-2 size-4" />
@@ -80,10 +84,10 @@ function IncidentSidebarCard({
         <CollapsibleContent>
           <div className="py-2 px-6">
             <p className="text-sm italic">
-              Reference ID: {incidents.reference_id || "None"}
+              Reference ID: {incident.reference_id || "None"}
             </p>
-            {incidents.description ? (
-              <p className="text-sm">Description: {incidents.description}</p>
+            {incident.description ? (
+              <p className="text-sm">Description: {incident.description}</p>
             ) : (
               <p className="text-sm italic">No description provided.</p>
             )}

--- a/frontend/src/app/staff/_components/location/LocationTable.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTable.tsx
@@ -23,10 +23,11 @@ import LocationTableForm from "./LocationTableForm";
 
 const LOCATION_ERROR_OPTIONS = {
   status: { 409: "This location already exists" },
+  fallback: "Failed to save the location. Please try again.",
 } as const;
 
 export const LocationTable = () => {
-  const { openSnackbar } = useSnackbar();
+  const { openSnackbar, snackbarPromise } = useSnackbar();
   const exportMutation = useDownloadLocationsCsv();
   const {
     mode,
@@ -58,14 +59,7 @@ export const LocationTable = () => {
     },
   });
 
-  const deleteMutation = useDeleteLocation({
-    onError: () => {
-      openSnackbar("Failed to delete location.", "error");
-    },
-    onSuccess: () => {
-      openSnackbar("Location deleted successfully", "success");
-    },
-  });
+  const deleteMutation = useDeleteLocation();
 
   const columns: ColumnDef<LocationDto>[] = [
     {
@@ -150,7 +144,12 @@ export const LocationTable = () => {
         rowActions={[
           editAction<LocationDto>({ onClick: openEdit }),
           deleteAction<LocationDto>({
-            onClick: (location) => deleteMutation.mutate(location.id),
+            onClick: (location) =>
+              snackbarPromise(deleteMutation.mutateAsync(location.id), {
+                loading: "Deleting location...",
+                success: "Location deleted successfully",
+                error: "Failed to delete location",
+              }),
             resourceName: "Location",
             description: (location) =>
               `Are you sure you want to delete location ${location.formatted_address}? This action cannot be undone.`,
@@ -176,6 +175,7 @@ export const LocationTable = () => {
                   })
                 }
                 submissionError={submissionError}
+                isPending={createMutation.isPending}
               />
             ),
           },
@@ -198,6 +198,7 @@ export const LocationTable = () => {
                   holdExpiration: location.hold_expiration || null,
                 }}
                 submissionError={submissionError}
+                isPending={updateMutation.isPending}
               />
             ),
           },

--- a/frontend/src/app/staff/_components/location/LocationTableForm.tsx
+++ b/frontend/src/app/staff/_components/location/LocationTableForm.tsx
@@ -28,12 +28,14 @@ interface LocationTableFormProps {
   onSubmit: (data: LocationTableFormValues) => void | Promise<void>;
   editData?: LocationTableFormValues;
   submissionError?: string | null;
+  isPending?: boolean;
 }
 
 export default function LocationTableForm({
   onSubmit,
   editData,
   submissionError,
+  isPending,
 }: LocationTableFormProps) {
   const initialAddressSelection: AutocompleteResult | null =
     editData?.address && editData?.placeId
@@ -63,6 +65,7 @@ export default function LocationTableForm({
       onSubmit={onSubmit}
       submitLabel="Save Changes"
       submissionError={submissionError}
+      pending={isPending}
     >
       <AddressField
         control={form.control}

--- a/frontend/src/app/staff/_components/party/PartyTable.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTable.tsx
@@ -40,14 +40,15 @@ const PARTY_ERROR_OPTIONS = {
   status: {
     404: "Party not found",
   },
+  fallback: "Failed to update the party. Please try again.",
 } as const;
 
-const getPartyErrorMessage = (error: Error) =>
+const getPartyErrorMessage = (error: unknown) =>
   getPartyValidationError(error)?.message ??
   getErrorMessage(error, PARTY_ERROR_OPTIONS);
 
 export const PartyTable = () => {
-  const { openSnackbar } = useSnackbar();
+  const { openSnackbar, snackbarPromise } = useSnackbar();
   const {
     mode,
     row,
@@ -61,7 +62,7 @@ export const PartyTable = () => {
   const exportMutation = useDownloadPartiesCsv();
 
   const createMutation = useCreateAdminParty({
-    onError: (error: Error) => {
+    onError: (error: unknown) => {
       setSubmissionError(getPartyErrorMessage(error));
     },
     onSuccess: () => {
@@ -71,7 +72,7 @@ export const PartyTable = () => {
   });
 
   const updateMutation = useUpdateAdminParty({
-    onError: (error: Error) => {
+    onError: (error: unknown) => {
       setSubmissionError(getPartyErrorMessage(error));
     },
     onSuccess: () => {
@@ -79,24 +80,8 @@ export const PartyTable = () => {
       closeSidebar();
     },
   });
-
-  const cancelMutation = useCancelAdminParty({
-    onError: (error: Error) => {
-      openSnackbar(getPartyErrorMessage(error), "error");
-    },
-    onSuccess: () => {
-      openSnackbar("Party cancelled successfully", "success");
-    },
-  });
-
-  const restoreMutation = useRestoreAdminParty({
-    onError: (error: Error) => {
-      openSnackbar(getPartyErrorMessage(error), "error");
-    },
-    onSuccess: () => {
-      openSnackbar("Party restored successfully", "success");
-    },
-  });
+  const cancelMutation = useCancelAdminParty();
+  const restoreMutation = useRestoreAdminParty();
 
   const buildPayload = (data: PartyTableFormValues) => {
     // Construct party datetime
@@ -122,17 +107,12 @@ export const PartyTable = () => {
     return payload;
   };
 
-  const handleCreateSubmit = async (data: PartyTableFormValues) => {
-    const payload = buildPayload(data);
-    createMutation.mutate(payload);
+  const handleCreateSubmit = (data: PartyTableFormValues) => {
+    createMutation.mutate(buildPayload(data));
   };
 
-  const handleEditSubmit = async (
-    partyId: number,
-    data: PartyTableFormValues
-  ) => {
-    const payload = buildPayload(data);
-    updateMutation.mutate({ id: partyId, payload });
+  const handleEditSubmit = (partyId: number, data: PartyTableFormValues) => {
+    updateMutation.mutate({ id: partyId, payload: buildPayload(data) });
   };
 
   const columns: ColumnDef<PartyDto>[] = [
@@ -282,7 +262,12 @@ export const PartyTable = () => {
             icon: <Ban className="mr-2 size-4" />,
             variant: "destructive",
             isVisible: (party) => party.status !== PartyStatus.CANCELLED,
-            onClick: (party) => cancelMutation.mutate(party.id),
+            onClick: (party) =>
+              snackbarPromise(cancelMutation.mutateAsync(party.id), {
+                loading: "Cancelling party...",
+                success: "Party cancelled successfully",
+                error: (err) => getPartyErrorMessage(err),
+              }),
             confirm: {
               title: "Cancel Party",
               description: (party) =>
@@ -300,7 +285,12 @@ export const PartyTable = () => {
             label: "Restore",
             icon: <Undo2 className="mr-2 size-4" />,
             isVisible: (party) => party.status === PartyStatus.CANCELLED,
-            onClick: (party) => restoreMutation.mutate(party.id),
+            onClick: (party) =>
+              snackbarPromise(restoreMutation.mutateAsync(party.id), {
+                loading: "Restoring party...",
+                success: "Party restored successfully",
+                error: (err) => getPartyErrorMessage(err),
+              }),
           } satisfies RowAction<PartyDto>,
         ]}
         exportMutation={exportMutation}
@@ -317,6 +307,7 @@ export const PartyTable = () => {
               <PartyTableForm
                 onSubmit={handleCreateSubmit}
                 submissionError={submissionError}
+                isPending={createMutation.isPending}
               />
             ),
           },
@@ -329,6 +320,7 @@ export const PartyTable = () => {
                 onSubmit={(data) => handleEditSubmit(party.id, data)}
                 editData={party}
                 submissionError={submissionError}
+                isPending={updateMutation.isPending}
               />
             ),
           },

--- a/frontend/src/app/staff/_components/party/PartyTableForm.tsx
+++ b/frontend/src/app/staff/_components/party/PartyTableForm.tsx
@@ -75,12 +75,14 @@ interface PartyTableFormProps {
   onSubmit: (data: PartyTableFormValues) => void | Promise<void>;
   editData?: PartyDto;
   submissionError?: string | null;
+  isPending?: boolean;
 }
 
 export default function PartyTableForm({
   onSubmit,
   editData,
   submissionError,
+  isPending,
 }: PartyTableFormProps) {
   const { data: session } = useSession();
   const isAdmin = session?.role === "admin";
@@ -113,6 +115,7 @@ export default function PartyTableForm({
       onSubmit={onSubmit}
       submitLabel="Save Changes"
       submissionError={submissionError}
+      pending={isPending}
     >
       <AddressField
         control={form.control}
@@ -184,6 +187,7 @@ export default function PartyTableForm({
                   field.onChange(student?.student_id ?? undefined)
                 }
                 placeholder="Search by name, PID, email, onyen, etc..."
+                autoComplete={false}
                 error={fieldState.error?.message}
               />
             </FormControl>

--- a/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
+++ b/frontend/src/app/staff/_components/shared/details/IncidentInfoChipDetails.tsx
@@ -1,5 +1,6 @@
 import IncidentDialog from "@/components/IncidentDialog";
 import { Button } from "@/components/ui/button";
+import { useSnackbar } from "@/contexts/SnackbarContext";
 import { IncidentCreateDto } from "@/lib/api/incident/incident.types";
 import {
   useCreateIncidentInLocation,
@@ -18,7 +19,7 @@ import IncidentSidebarCard from "../../location/IncidentSidebarCard";
 import { ConfirmDialog } from "../dialog/ConfirmDialog";
 import { useSidebar } from "../sidebar/SidebarContext";
 
-type IncidentSidebarProps = {
+type Props = {
   incidents: NestedIncidentDto[];
   location: LocationDto;
 };
@@ -31,51 +32,76 @@ type ModalState =
 export default function IncidentInfoChipDetails({
   incidents,
   location,
-}: IncidentSidebarProps) {
+}: Props) {
   const { data: session } = useSession();
   const role = session?.role;
   const { headerActionNode } = useSidebar();
+  const { snackbarPromise } = useSnackbar();
 
   const [modalState, setModalState] = useState<ModalState>(null);
   const [confirmStateDelete, setConfirmStateDelete] = useState<number | null>(
     null
   );
+  const [openIncidentIds, setOpenIncidentIds] = useState<Set<number>>(
+    new Set()
+  );
 
-  const deleteMutation = useDeleteIncidentInLocation({
-    onSuccess: () => {
-      setConfirmStateDelete(null);
-    },
-  });
+  const setIncidentOpen = (id: number, open: boolean) => {
+    setOpenIncidentIds((prev) => {
+      const next = new Set(prev);
+      if (open) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  const deleteMutation = useDeleteIncidentInLocation();
 
   const handleDelete = () => {
     if (confirmStateDelete === null) return;
-    deleteMutation.mutate(confirmStateDelete);
+    setConfirmStateDelete(null);
+    snackbarPromise(deleteMutation.mutateAsync(confirmStateDelete), {
+      loading: "Deleting incident...",
+      success: "Incident deleted successfully",
+      error: "Failed to delete incident",
+    });
   };
 
-  const createMutation = useCreateIncidentInLocation({
-    onSuccess: () => {
-      setModalState(null);
-    },
-  });
+  const createMutation = useCreateIncidentInLocation();
 
-  const updateMutation = useUpdateIncidentInLocation({
-    onSuccess: () => {
-      setModalState(null);
-    },
-  });
+  const handleCreateIncident = (data: IncidentCreateDto) => {
+    setModalState(null);
+    snackbarPromise(createMutation.mutateAsync(data), {
+      loading: "Creating incident...",
+      success: "Incident created successfully",
+      error: "Failed to create incident",
+    });
+  };
+
+  const updateMutation = useUpdateIncidentInLocation();
 
   const handleEditIncident = (data: IncidentCreateDto) => {
     if (modalState?.mode !== "edit") return;
-    updateMutation.mutate({
-      id: modalState.incident.id,
-      payload: {
-        location_place_id: location.google_place_id,
-        incident_datetime: data.incident_datetime,
-        description: data.description,
-        severity: data.severity,
-        reference_id: data.reference_id ?? null,
-      },
-    });
+    const incidentId = modalState.incident.id;
+    setModalState(null);
+    setIncidentOpen(incidentId, true);
+    snackbarPromise(
+      updateMutation.mutateAsync({
+        id: incidentId,
+        payload: {
+          location_place_id: location.google_place_id,
+          incident_datetime: data.incident_datetime,
+          description: data.description,
+          severity: data.severity,
+          reference_id: data.reference_id ?? null,
+        },
+      }),
+      {
+        loading: "Updating incident...",
+        success: "Incident updated successfully",
+        error: "Failed to update incident",
+      }
+    );
   };
 
   return (
@@ -103,8 +129,10 @@ export default function IncidentInfoChipDetails({
         ) : (
           incidents.map((incident) => (
             <IncidentSidebarCard
-              incidents={incident}
+              incident={incident}
               key={incident.id}
+              open={openIncidentIds.has(incident.id)}
+              onOpenChange={(open) => setIncidentOpen(incident.id, open)}
               onDeleteIncidentAction={setConfirmStateDelete}
               onEditIncidentAction={(incident: NestedIncidentDto) => {
                 setModalState({ mode: "edit", incident });
@@ -142,7 +170,7 @@ export default function IncidentInfoChipDetails({
         onSubmit={
           modalState?.mode === "edit"
             ? handleEditIncident
-            : createMutation.mutate
+            : handleCreateIncident
         }
         location={location}
       />

--- a/frontend/src/app/staff/_components/student/StudentTable.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTable.tsx
@@ -11,7 +11,11 @@ import {
 } from "@/lib/api/student/admin-student.queries";
 import { StudentDto } from "@/lib/api/student/student.types";
 import { getErrorMessage } from "@/lib/errors";
-import { formatAddress, isFromThisSchoolYear } from "@/lib/utils";
+import {
+  formatAddress,
+  formatPhoneNumber,
+  isFromThisSchoolYear,
+} from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import LocationInfoChipDetails from "../shared/details/LocationInfoChipDetails";
 import { FormSidebar } from "../shared/sidebar/FormSidebar";
@@ -27,6 +31,7 @@ const STUDENT_ERROR_OPTIONS = {
     404: "Student not found",
     409: "This phone number is taken by another student",
   },
+  fallback: "Failed to update the student. Please try again.",
 } as const;
 
 const toEditData = (student: StudentDto) => ({
@@ -37,17 +42,31 @@ const toEditData = (student: StudentDto) => ({
 });
 
 export const StudentTable = () => {
-  const { openSnackbar } = useSnackbar();
-  const { mode, row, openEdit, closeSidebar } =
-    useFormSidebarState<StudentDto>();
+  const { openSnackbar, snackbarPromise } = useSnackbar();
+  const {
+    mode,
+    row,
+    submissionError,
+    setSubmissionError,
+    openEdit,
+    closeSidebar,
+  } = useFormSidebarState<StudentDto>();
 
   const exportMutation = useDownloadStudentsCsv();
 
-  const checkboxMutation = useUpdateIsRegistered();
+  const checkboxMutation = useUpdateIsRegistered({
+    onError: (error) =>
+      openSnackbar(
+        getErrorMessage(error, {
+          fallback: "Failed to update registration status.",
+        }),
+        "error"
+      ),
+  });
 
   const editFormMutation = useUpdateStudent({
     onError: (error) => {
-      openSnackbar(getErrorMessage(error, STUDENT_ERROR_OPTIONS), "error");
+      setSubmissionError(getErrorMessage(error, STUDENT_ERROR_OPTIONS));
     },
     onSuccess: () => {
       closeSidebar();
@@ -55,14 +74,7 @@ export const StudentTable = () => {
     },
   });
 
-  const deleteMutation = useDeleteStudent({
-    onError: (error) => {
-      console.error("Failed to delete student:", error);
-    },
-    onSuccess: () => {
-      openSnackbar("Student deleted successfully", "success");
-    },
-  });
+  const deleteMutation = useDeleteStudent();
 
   const columns: ColumnDef<StudentDto>[] = [
     {
@@ -101,9 +113,7 @@ export const StudentTable = () => {
       enableColumnFilter: true,
       cell: ({ row }) => {
         const number = row.getValue("phone_number") as string;
-        return number
-          ? `(${number.slice(0, 3)}) ${number.slice(3, 6)}-${number.slice(6, 10)}`
-          : "—";
+        return formatPhoneNumber(number) || "—";
       },
       meta: { filter: { type: "text", backendField: "phone_number" } },
     },
@@ -203,7 +213,12 @@ export const StudentTable = () => {
         rowActions={[
           editAction<StudentDto>({ onClick: openEdit }),
           deleteAction<StudentDto>({
-            onClick: (student) => deleteMutation.mutate(student.id),
+            onClick: (student) =>
+              snackbarPromise(deleteMutation.mutateAsync(student.id), {
+                loading: "Deleting student...",
+                success: "Student deleted successfully",
+                error: "Failed to delete student",
+              }),
             resourceName: "Student",
             description: (student) =>
               `Are you sure you want to delete ${student.first_name} ${student.last_name}? This action cannot be undone.`,
@@ -226,6 +241,8 @@ export const StudentTable = () => {
                   editFormMutation.mutate({ id: student.id, data })
                 }
                 editData={toEditData(student)}
+                submissionError={submissionError}
+                isPending={editFormMutation.isPending}
               />
             ),
           },

--- a/frontend/src/app/staff/_components/student/StudentTableForm.tsx
+++ b/frontend/src/app/staff/_components/student/StudentTableForm.tsx
@@ -46,12 +46,14 @@ interface StudentTableFormProps {
   onSubmit: (data: StudentTableFormValues) => void | Promise<void>;
   editData?: Partial<StudentTableFormValues>;
   submissionError?: string | null;
+  isPending?: boolean;
 }
 
 export default function StudentTableForm({
   onSubmit,
   editData,
   submissionError,
+  isPending,
 }: StudentTableFormProps) {
   const initialResidenceSelection: AutocompleteResult | null =
     editData?.residence
@@ -93,6 +95,7 @@ export default function StudentTableForm({
       onSubmit={onSubmit}
       submitLabel="Save Changes"
       submissionError={submissionError}
+      pending={isPending}
     >
       <TextField
         control={form.control}

--- a/frontend/src/components/IncidentDialog.tsx
+++ b/frontend/src/components/IncidentDialog.tsx
@@ -63,7 +63,7 @@ export default function IncidentDialog({
   incident,
   defaultSeverity = "in_person_warning",
   onSubmit,
-  isSubmitting = false,
+  isSubmitting,
 }: IncidentDialogProps) {
   const defaultDatetime = incident?.incident_datetime ?? new Date();
 

--- a/frontend/src/components/StudentSearch.tsx
+++ b/frontend/src/components/StudentSearch.tsx
@@ -27,6 +27,7 @@ interface StudentSearchProps {
   placeholder?: string;
   className?: string;
   disabled?: boolean;
+  autoComplete?: boolean;
   adminStudentService?: AdminStudentService;
   error?: string;
 }
@@ -87,6 +88,7 @@ export default function StudentSearch({
   placeholder = "Search by name, PID, email, onyen, or phone...",
   className,
   disabled = false,
+  autoComplete = true,
   adminStudentService = new AdminStudentService(),
   error: externalError,
 }: StudentSearchProps) {
@@ -307,6 +309,7 @@ export default function StudentSearch({
               placeholder={placeholder}
               disabled={disabled}
               readOnly={!!selectedStudent}
+              autoComplete={autoComplete ? "on" : "off"}
               className={cn(
                 "pr-16",
                 selectedStudent &&

--- a/frontend/src/components/form/SubmitButton.tsx
+++ b/frontend/src/components/form/SubmitButton.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Loader2 } from "lucide-react";
 
 type SubmitButtonProps = React.ComponentProps<typeof Button> & {
   /** Whether a submit is in progress (disables + swaps the label). */
@@ -21,11 +23,26 @@ export function SubmitButton({
   label,
   pendingLabel = "Submitting...",
   disabled,
+  className,
   ...props
 }: SubmitButtonProps) {
   return (
-    <Button type="submit" {...props} disabled={pending || disabled}>
-      {pending ? pendingLabel : label}
+    <Button
+      type="submit"
+      {...props}
+      // Override the base `transition-all`: animating width on a `w-fit` button
+      // makes it briefly blow out to the container width on the pending swap.
+      className={cn("transition-colors", className)}
+      disabled={pending || disabled}
+    >
+      {pending ? (
+        <>
+          <Loader2 className="size-4 animate-spin" />
+          {pendingLabel}
+        </>
+      ) : (
+        label
+      )}
     </Button>
   );
 }

--- a/frontend/src/contexts/SnackbarContext.tsx
+++ b/frontend/src/contexts/SnackbarContext.tsx
@@ -5,6 +5,12 @@ import { toast } from "sonner";
 
 type ToastType = "success" | "error" | "warning" | "info" | "loading";
 
+interface PromiseOptions<T> {
+  loading: string;
+  success: string | ((data: T) => string);
+  error: string | ((err: unknown) => string);
+}
+
 interface SnackbarContextType {
   openSnackbar: (message: string, type: ToastType, duration?: number) => void;
   success: (message: string, duration?: number) => void;
@@ -12,6 +18,7 @@ interface SnackbarContextType {
   warning: (message: string, duration?: number) => void;
   info: (message: string, duration?: number) => void;
   loading: (message: string) => void;
+  snackbarPromise: <T>(p: Promise<T>, options: PromiseOptions<T>) => void;
 }
 
 const SnackbarContext = createContext<SnackbarContextType | undefined>(
@@ -55,6 +62,13 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
     openSnackbar(message, "info", duration);
   const loading = (message: string) => openSnackbar(message, "loading");
 
+  const snackbarPromise = <T,>(
+    p: Promise<T>,
+    options: PromiseOptions<T>
+  ): void => {
+    void toast.promise(p, options);
+  };
+
   const value: SnackbarContextType = {
     openSnackbar,
     success,
@@ -62,6 +76,7 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
     warning,
     info,
     loading,
+    snackbarPromise,
   };
 
   return (

--- a/frontend/src/lib/api/account/account.queries.ts
+++ b/frontend/src/lib/api/account/account.queries.ts
@@ -9,10 +9,7 @@ import type {
   PoliceAccountDto,
   PoliceAccountUpdate,
 } from "@/lib/api/police/police.types";
-import {
-  ListQueryParams,
-  ServerTableParams,
-} from "@/lib/api/shared/query-params";
+import { ServerTableParams } from "@/lib/api/shared/query-params";
 import { OptimisticMutationOptions, PaginatedResponse } from "@/lib/shared";
 import {
   UseQueryOptions,
@@ -217,12 +214,6 @@ export function useUpdatePoliceAccount(
       queryClient.invalidateQueries({ queryKey: AGGREGATE_ACCOUNTS_KEY });
       options?.onSuccess?.(...params);
     },
-  });
-}
-
-export function useDownloadAccountsCsv() {
-  return useMutation<void, Error, ListQueryParams | undefined>({
-    mutationFn: (params) => accountService.downloadAccountsCsv(params),
   });
 }
 

--- a/frontend/src/lib/api/apiClient.ts
+++ b/frontend/src/lib/api/apiClient.ts
@@ -1,7 +1,6 @@
 import type { RefreshTokenResponse } from "@/lib/api/auth/auth.types";
 import { signOut } from "@/lib/auth/signout";
 import { clientEnv } from "@/lib/config/env.client";
-import { getErrorMessage } from "@/lib/errors";
 import axios, { AxiosRequestConfig, AxiosRequestHeaders } from "axios";
 import { getServerSession } from "next-auth";
 import { getSession } from "next-auth/react";
@@ -153,12 +152,10 @@ export const setupErrorInterceptor = (showError: (message: string) => void) => {
   apiClient.interceptors.response.use(
     (response) => response,
     (error) => {
-      // Skip 401 errors (handled by token refresh interceptor)
-      if (error.response?.status === 401) {
+      if ((error.response?.status ?? 0) < 500) {
         return Promise.reject(error);
       }
-
-      showError(getErrorMessage(error));
+      showError("Something went wrong. Please try again.");
       return Promise.reject(error);
     }
   );

--- a/frontend/src/lib/api/incident/incident.queries.ts
+++ b/frontend/src/lib/api/incident/incident.queries.ts
@@ -10,7 +10,6 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useRef } from "react";
 import { IncidentService } from "./incident.service";
 import {
   IncidentCreateDto,
@@ -81,9 +80,15 @@ export function useUpdateIncident<TContext = unknown>(
   >
 ) {
   const queryClient = useQueryClient();
-  const previousByIdRef = useRef<IncidentDto | undefined>(undefined);
 
-  return useMutation<IncidentDto, Error, UpdateIncidentVars, TContext>({
+  // Combine our rollback snapshot with the consumer's onMutate result so both
+  // ride the per-invocation context channel
+  type MutationContext = {
+    previous: IncidentDto | undefined;
+    consumer: TContext;
+  };
+
+  return useMutation<IncidentDto, Error, UpdateIncidentVars, MutationContext>({
     ...options,
     mutationFn: ({ id, payload }: UpdateIncidentVars) =>
       incidentService.updateIncident(id, payload),
@@ -91,39 +96,53 @@ export function useUpdateIncident<TContext = unknown>(
     onMutate: async ({ id, payload }, context) => {
       await queryClient.cancelQueries({ queryKey: INCIDENTS_KEY });
 
-      previousByIdRef.current = queryClient.getQueryData<IncidentDto>([
+      const previous = queryClient.getQueryData<IncidentDto>([
         ...INCIDENTS_KEY,
         id,
       ]);
 
-      if (previousByIdRef.current) {
+      if (previous) {
         queryClient.setQueryData<IncidentDto>([...INCIDENTS_KEY, id], {
-          ...previousByIdRef.current,
+          ...previous,
           ...payload,
           incident_datetime:
             payload.incident_datetime instanceof Date
               ? payload.incident_datetime
-              : (previousByIdRef.current.incident_datetime ?? new Date()),
+              : (previous.incident_datetime ?? new Date()),
         });
         options?.onOptimisticUpdate?.({ id, payload });
       }
 
-      return (await options?.onMutate?.({ id, payload }, context)) as TContext;
+      const consumer = (await options?.onMutate?.(
+        { id, payload },
+        context
+      )) as TContext;
+      return { previous, consumer };
     },
 
     onError: (error, vars, onMutateResult, context) => {
-      if (previousByIdRef.current) {
+      if (onMutateResult?.previous) {
         queryClient.setQueryData(
           [...INCIDENTS_KEY, vars.id],
-          previousByIdRef.current
+          onMutateResult.previous
         );
       }
-      options?.onError?.(error, vars, onMutateResult, context);
+      options?.onError?.(error, vars, onMutateResult?.consumer, context);
     },
 
-    onSuccess: (...params) => {
+    onSuccess: (data, vars, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: INCIDENTS_KEY });
-      options?.onSuccess?.(...params);
+      options?.onSuccess?.(data, vars, onMutateResult.consumer, context);
+    },
+
+    onSettled: (data, error, vars, onMutateResult, context) => {
+      options?.onSettled?.(
+        data,
+        error,
+        vars,
+        onMutateResult?.consumer,
+        context
+      );
     },
   });
 }
@@ -132,21 +151,24 @@ export function useDeleteIncident<TContext = unknown>(
   options?: OptimisticMutationOptions<void, Error, number, TContext>
 ) {
   const queryClient = useQueryClient();
-  const previousQueriesRef = useRef<
-    ReturnType<typeof queryClient.getQueriesData<PaginatedIncidentsResponse>>
-  >([]);
 
-  return useMutation<void, Error, number, TContext>({
+  type MutationContext = {
+    previous: ReturnType<
+      typeof queryClient.getQueriesData<PaginatedIncidentsResponse>
+    >;
+    consumer: TContext;
+  };
+
+  return useMutation<void, Error, number, MutationContext>({
     ...options,
     mutationFn: (id: number) => incidentService.deleteIncident(id),
 
     onMutate: async (id, context) => {
       await queryClient.cancelQueries({ queryKey: INCIDENTS_KEY });
 
-      previousQueriesRef.current =
-        queryClient.getQueriesData<PaginatedIncidentsResponse>({
-          queryKey: INCIDENTS_KEY,
-        });
+      const previous = queryClient.getQueriesData<PaginatedIncidentsResponse>({
+        queryKey: INCIDENTS_KEY,
+      });
 
       queryClient.setQueriesData<PaginatedIncidentsResponse>(
         { queryKey: INCIDENTS_KEY },
@@ -155,19 +177,24 @@ export function useDeleteIncident<TContext = unknown>(
       );
 
       options?.onOptimisticUpdate?.(id);
-      return (await options?.onMutate?.(id, context)) as TContext;
+      const consumer = (await options?.onMutate?.(id, context)) as TContext;
+      return { previous, consumer };
     },
 
     onError: (error, id, onMutateResult, context) => {
-      previousQueriesRef.current.forEach(([queryKey, data]) => {
+      onMutateResult?.previous.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
-      options?.onError?.(error, id, onMutateResult, context);
+      options?.onError?.(error, id, onMutateResult?.consumer, context);
     },
 
-    onSuccess: (...params) => {
+    onSuccess: (data, id, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: INCIDENTS_KEY });
-      options?.onSuccess?.(...params);
+      options?.onSuccess?.(data, id, onMutateResult.consumer, context);
+    },
+
+    onSettled: (data, error, id, onMutateResult, context) => {
+      options?.onSettled?.(data, error, id, onMutateResult?.consumer, context);
     },
   });
 }

--- a/frontend/src/lib/api/location/location.queries.ts
+++ b/frontend/src/lib/api/location/location.queries.ts
@@ -7,10 +7,12 @@ import {
 import {
   IncidentCreateDto,
   IncidentDto,
+  NestedIncidentDto,
 } from "@/lib/api/incident/incident.types";
 import { ListQueryParams } from "@/lib/api/shared/query-params";
 import { OptimisticMutationOptions, PaginatedResponse } from "@/lib/shared";
 import {
+  QueryClient,
   QueryKey,
   UseQueryOptions,
   keepPreviousData,
@@ -18,12 +20,23 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { compareAsc } from "date-fns";
 import { LocationService } from "./location.service";
 import { LocationCreate, LocationDto } from "./location.types";
 
 const locationService = new LocationService();
 
 export const LOCATIONS_KEY = ["locations"] as const;
+
+function setLocationsCache(
+  queryClient: QueryClient,
+  updateLocation: (loc: LocationDto) => LocationDto
+) {
+  queryClient.setQueriesData<PaginatedResponse<LocationDto>>(
+    { queryKey: LOCATIONS_KEY },
+    (old) => (old ? { ...old, items: old.items.map(updateLocation) } : old)
+  );
+}
 
 type UpdateLocationVars = {
   id: number;
@@ -104,12 +117,54 @@ type LocationsSnapshot = [
 ][];
 
 export function useCreateIncidentInLocation(
-  options?: OptimisticMutationOptions<IncidentDto, Error, IncidentCreateDto>
+  options?: OptimisticMutationOptions<
+    IncidentDto,
+    Error,
+    IncidentCreateDto,
+    { previousLocations: LocationsSnapshot }
+  >
 ) {
   const queryClient = useQueryClient();
 
   return useCreateIncident({
     ...options,
+    onMutate: async (vars, context) => {
+      await queryClient.cancelQueries({ queryKey: LOCATIONS_KEY });
+
+      const previousLocations = queryClient.getQueriesData<
+        PaginatedResponse<LocationDto>
+      >({ queryKey: LOCATIONS_KEY });
+
+      const optimisticIncident: NestedIncidentDto = {
+        id: -Date.now(),
+        incident_datetime: vars.incident_datetime,
+        description: vars.description,
+        severity: vars.severity,
+        reference_id: vars.reference_id,
+      };
+
+      setLocationsCache(queryClient, (loc) =>
+        loc.google_place_id === vars.location_place_id
+          ? {
+              ...loc,
+              // Keep incidents ordered earliest-first to match the backend's
+              // `order_by` so the optimistic entry lands in its final position.
+              incidents: [...loc.incidents, optimisticIncident].sort((a, b) =>
+                compareAsc(a.incident_datetime, b.incident_datetime)
+              ),
+            }
+          : loc
+      );
+
+      await options?.onMutate?.(vars, context);
+      return { previousLocations };
+    },
+    onError: (error, vars, onMutateResult, context) => {
+      onMutateResult?.previousLocations.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      options?.onError?.(error, vars, onMutateResult, context);
+    },
     onSuccess: (...params) => {
       queryClient.invalidateQueries({ queryKey: LOCATIONS_KEY });
       options?.onSuccess?.(...params);
@@ -136,21 +191,12 @@ export function useUpdateIncidentInLocation(
         PaginatedResponse<LocationDto>
       >({ queryKey: LOCATIONS_KEY });
 
-      queryClient.setQueriesData<PaginatedResponse<LocationDto>>(
-        { queryKey: LOCATIONS_KEY },
-        (old) =>
-          old
-            ? {
-                ...old,
-                items: old.items.map((loc) => ({
-                  ...loc,
-                  incidents: loc.incidents.map((inc) =>
-                    inc.id === vars.id ? { ...inc, ...vars.payload } : inc
-                  ),
-                })),
-              }
-            : old
-      );
+      setLocationsCache(queryClient, (loc) => ({
+        ...loc,
+        incidents: loc.incidents.map((inc) =>
+          inc.id === vars.id ? { ...inc, ...vars.payload } : inc
+        ),
+      }));
 
       await options?.onMutate?.(vars, context);
       return { previousLocations };
@@ -192,19 +238,10 @@ export function useDeleteIncidentInLocation(
         PaginatedResponse<LocationDto>
       >({ queryKey: LOCATIONS_KEY });
 
-      queryClient.setQueriesData<PaginatedResponse<LocationDto>>(
-        { queryKey: LOCATIONS_KEY },
-        (old) =>
-          old
-            ? {
-                ...old,
-                items: old.items.map((loc) => ({
-                  ...loc,
-                  incidents: loc.incidents.filter((inc) => inc.id !== id),
-                })),
-              }
-            : old
-      );
+      setLocationsCache(queryClient, (loc) => ({
+        ...loc,
+        incidents: loc.incidents.filter((inc) => inc.id !== id),
+      }));
 
       await options?.onMutate?.(id, context);
       return { previousLocations };

--- a/frontend/src/lib/api/party/admin-party.queries.ts
+++ b/frontend/src/lib/api/party/admin-party.queries.ts
@@ -7,7 +7,6 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useRef } from "react";
 import { PartyService } from "./party.service";
 import {
   AdminCreatePartyDto,
@@ -73,20 +72,26 @@ export function useCancelAdminParty<TContext = unknown>(
   options?: OptimisticMutationOptions<PartyDto, Error, number, TContext>
 ) {
   const queryClient = useQueryClient();
-  const previousQueriesRef = useRef<
-    ReturnType<typeof queryClient.getQueriesData<PaginatedResponse<PartyDto>>>
-  >([]);
 
-  return useMutation<PartyDto, Error, number, TContext>({
+  // Combine our rollback snapshot with the consumer's onMutate result so both
+  // ride the per-invocation context channel
+  type MutationContext = {
+    previous: ReturnType<
+      typeof queryClient.getQueriesData<PaginatedResponse<PartyDto>>
+    >;
+    consumer: TContext;
+  };
+
+  return useMutation<PartyDto, Error, number, MutationContext>({
     ...options,
     mutationFn: (id: number) => partyService.cancelParty(id),
 
     onMutate: async (id, context) => {
       await queryClient.cancelQueries({ queryKey: PARTIES_KEY });
 
-      previousQueriesRef.current = queryClient.getQueriesData<
-        PaginatedResponse<PartyDto>
-      >({ queryKey: PARTIES_KEY });
+      const previous = queryClient.getQueriesData<PaginatedResponse<PartyDto>>({
+        queryKey: PARTIES_KEY,
+      });
 
       queryClient.setQueriesData<PaginatedResponse<PartyDto>>(
         { queryKey: PARTIES_KEY },
@@ -102,19 +107,24 @@ export function useCancelAdminParty<TContext = unknown>(
       );
 
       options?.onOptimisticUpdate?.(id);
-      return (await options?.onMutate?.(id, context)) as TContext;
+      const consumer = (await options?.onMutate?.(id, context)) as TContext;
+      return { previous, consumer };
     },
 
     onError: (error, id, onMutateResult, context) => {
-      previousQueriesRef.current.forEach(([queryKey, data]) => {
+      onMutateResult?.previous.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
-      options?.onError?.(error, id, onMutateResult, context);
+      options?.onError?.(error, id, onMutateResult?.consumer, context);
     },
 
-    onSuccess: (...params) => {
+    onSuccess: (data, id, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: PARTIES_KEY });
-      options?.onSuccess?.(...params);
+      options?.onSuccess?.(data, id, onMutateResult.consumer, context);
+    },
+
+    onSettled: (data, error, id, onMutateResult, context) => {
+      options?.onSettled?.(data, error, id, onMutateResult?.consumer, context);
     },
   });
 }
@@ -123,20 +133,26 @@ export function useRestoreAdminParty<TContext = unknown>(
   options?: OptimisticMutationOptions<PartyDto, Error, number, TContext>
 ) {
   const queryClient = useQueryClient();
-  const previousQueriesRef = useRef<
-    ReturnType<typeof queryClient.getQueriesData<PaginatedResponse<PartyDto>>>
-  >([]);
 
-  return useMutation<PartyDto, Error, number, TContext>({
+  // Combine our rollback snapshot with the consumer's onMutate result so both
+  // ride the per-invocation context channel
+  type MutationContext = {
+    previous: ReturnType<
+      typeof queryClient.getQueriesData<PaginatedResponse<PartyDto>>
+    >;
+    consumer: TContext;
+  };
+
+  return useMutation<PartyDto, Error, number, MutationContext>({
     ...options,
     mutationFn: (id: number) => partyService.restoreParty(id),
 
     onMutate: async (id, context) => {
       await queryClient.cancelQueries({ queryKey: PARTIES_KEY });
 
-      previousQueriesRef.current = queryClient.getQueriesData<
-        PaginatedResponse<PartyDto>
-      >({ queryKey: PARTIES_KEY });
+      const previous = queryClient.getQueriesData<PaginatedResponse<PartyDto>>({
+        queryKey: PARTIES_KEY,
+      });
 
       queryClient.setQueriesData<PaginatedResponse<PartyDto>>(
         { queryKey: PARTIES_KEY },
@@ -152,19 +168,24 @@ export function useRestoreAdminParty<TContext = unknown>(
       );
 
       options?.onOptimisticUpdate?.(id);
-      return (await options?.onMutate?.(id, context)) as TContext;
+      const consumer = (await options?.onMutate?.(id, context)) as TContext;
+      return { previous, consumer };
     },
 
     onError: (error, id, onMutateResult, context) => {
-      previousQueriesRef.current.forEach(([queryKey, data]) => {
+      onMutateResult?.previous.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
-      options?.onError?.(error, id, onMutateResult, context);
+      options?.onError?.(error, id, onMutateResult?.consumer, context);
     },
 
-    onSuccess: (...params) => {
+    onSuccess: (data, id, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: PARTIES_KEY });
-      options?.onSuccess?.(...params);
+      options?.onSuccess?.(data, id, onMutateResult.consumer, context);
+    },
+
+    onSettled: (data, error, id, onMutateResult, context) => {
+      options?.onSettled?.(data, error, id, onMutateResult?.consumer, context);
     },
   });
 }

--- a/frontend/src/lib/api/party/party.queries.ts
+++ b/frontend/src/lib/api/party/party.queries.ts
@@ -2,14 +2,12 @@ import { PartyService } from "@/lib/api/party/party.service";
 import {
   CreatePartyDto,
   MY_PARTIES_KEY,
-  PARTIES_KEY,
   PartyDto,
   StudentCreatePartyDto,
 } from "@/lib/api/party/party.types";
 import { ListQueryParams } from "@/lib/api/shared/query-params";
 import StudentService from "@/lib/api/student/student.service";
 import { CURRENT_STUDENT_KEY } from "@/lib/api/student/student.types";
-import { OptimisticMutationOptions } from "@/lib/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const partyService = new PartyService();
@@ -39,26 +37,6 @@ export function useRegisterParty() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: MY_PARTIES_KEY });
       queryClient.invalidateQueries({ queryKey: CURRENT_STUDENT_KEY });
-    },
-  });
-}
-
-/**
- * Hook to create a new party registration
- */
-export function useCreateParty(
-  options?: OptimisticMutationOptions<PartyDto, Error, CreatePartyDto>
-) {
-  const queryClient = useQueryClient();
-
-  return useMutation<PartyDto, Error, CreatePartyDto>({
-    ...options,
-    mutationFn: (data) => partyService.createParty(data),
-    onSuccess: (...params) => {
-      // Invalidate all party queries using prefix matching
-      // This will invalidate ["parties"], ["parties", "me"], ["parties", ...dates], etc.
-      queryClient.invalidateQueries({ queryKey: PARTIES_KEY });
-      options?.onSuccess?.(...params);
     },
   });
 }


### PR DESCRIPTION
Tightens up user-facing feedback across the app: errors and successes are now shown exactly once (no more snackbar double-dipping against inline form errors), optimistic mutations get sonner loading→success/error promise toasts, and call sites surface tailored messages for the specific status codes they can actually hit. On the backend, every route is now exhaustively documented with the response codes it can return, which is what drove the frontend error-handling audit.

Changes:

**Snackbars & error feedback**
- Added a `snackbarPromise` helper wrapping `toast.promise` (loading/success/error) and used it everywhere an optimistic mutation fires (delete/cancel/restore, create-incident), so the user sees a loading state then a single terminal toast.
- Audited the frontend for double-shown feedback: removed redundant `onSuccess`/`onError` snackbar handlers so an error shows exactly once and a success shows exactly once.
- Populated `getErrorMessage` status maps + fallbacks across new-party, profile, notifications, and the staff/police tables; added the `Send Invite` 409 "account with this email already exists" message.
- `apiClient` interceptor now only surfaces a generic global toast for 5xx; 4xx are handled at the call site where a meaningful message is available.

**Forms & loading state**
- Plumbed `isPending` into the table forms and added a spinner (`Loader2`) to `SubmitButton`, with a `transition-colors` override to avoid the width-animation glitch on the pending label swap.
- We deliberately opted **not** to add optimistic updates for the table create/edit forms — those keep a normal pending→submit flow (inline `submissionError` + spinner), and optimistic updates are reserved for the row-level mutations (delete/cancel/restore/incident create) where the result is unambiguous.
- Fixed a stale inline error in `StudentTable` by using `useFormSidebarState`'s `submissionError` (resets on open/close) instead of a separate local state.
- `StudentSearch` gained an `autoComplete` prop so the party form can disable browser autofill.

**Query services (#400)**
- Reworked the optimistic mutation hooks to drop the shared `useRef` snapshot in favor of a per-invocation context channel (`{ previous, consumer }`), correctly threading the consumer's `onMutate` result through `onError`/`onSuccess`/`onSettled`.
- Extracted a `setLocationsCache` helper and gave create-incident-in-location an optimistic insert (sorted to match backend ordering).
- Removed unused hooks (`useCreateParty`, `useDownloadAccountsCsv`).

**Backend route docs**
- Exhaustively documented `responses` (status code + description) on every route across account, auth, incident, location, notification, party, police, and student routers; party rule codes are derived from the `PartyRule` enum.
- Ordered a location's incidents earliest-first (`incident_datetime` asc) and let the edited incident card auto-expand in the sidebar.

Closes #427
Closes #400