### PR TITLE
Narrow address autocomplete to residences in the Chapel Hill area

### DIFF
--- a/backend/src/modules/location/location_service.py
+++ b/backend/src/modules/location/location_service.py
@@ -96,6 +96,16 @@ def get_gmaps_client() -> googlemaps.Client:
     return googlemaps.Client(key=env.GOOGLE_MAPS_API_KEY)
 
 
+# Place types that indicate a specific dwelling rather than a whole street.
+# A bare street comes back as `route`-only with no street number, which is not a
+# valid residence to register, so we drop those from autocomplete suggestions.
+_PRECISE_ADDRESS_TYPES = frozenset({"street_address", "premise", "subpremise"})
+
+
+def _is_precise_address(prediction_types: list[str]) -> bool:
+    return any(t in _PRECISE_ADDRESS_TYPES for t in prediction_types)
+
+
 def _incident_count_subquery(severity: IncidentSeverity | None = None):
     q = select(func.count()).where(IncidentEntity.location_id == LocationEntity.id)
     if severity is not None:
@@ -265,7 +275,10 @@ class LocationService:
         return location_entity.to_dto()
 
     async def autocomplete_address(self, input_text: str) -> list[AutocompleteResult]:
-        # Autocomplete an address using Google Maps Places API. Biased towards Chapel Hill, NC area
+        # Autocomplete an address using Google Maps Places API, restricted to the
+        # Chapel Hill, NC area (roughly the Triangle). location + radius only bias
+        # results, so strict_bounds is required to actually fence out far-away
+        # matches (e.g. same street name in another state).
         with _googlemaps_error_handler("Failed to autocomplete address"):
             try:
                 autocomplete_result = await asyncio.to_thread(
@@ -275,13 +288,17 @@ class LocationService:
                     types="address",
                     language="en",
                     location=(35.9132, -79.0558),  # Chapel Hill, NC coordinates
-                    radius=50000,  # 50km radius around Chapel Hill
+                    radius=10_000,  # meter radius around Chapel Hill
+                    strict_bounds=True,  # restrict to the radius, not just bias
                 )
             except googlemaps.exceptions.ApiError as e:
                 raise GoogleMapsAPIException(f"API error ({e.status}): {e!s}") from e
 
             suggestions = []
             for prediction in autocomplete_result:
+                # Skip bare streets (route-only); only suggest specific addresses.
+                if not _is_precise_address(prediction.get("types", [])):
+                    continue
                 suggestion = AutocompleteResult(
                     formatted_address=prediction["description"],
                     google_place_id=prediction["place_id"],

--- a/backend/test/modules/location/location_service_test.py
+++ b/backend/test/modules/location/location_service_test.py
@@ -272,7 +272,33 @@ class TestLocationServiceGoogleMapsAutocomplete:
             types="address",
             language="en",
             location=(35.9132, -79.0558),
-            radius=50000,
+            radius=10_000,
+            strict_bounds=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_autocomplete_filters_out_bare_streets(self):
+        """Route-only predictions (whole streets) should be dropped."""
+        self.gmaps_utils.mock_autocomplete_predictions(count=2, types=["route"])
+
+        results = await self.location_service.autocomplete_address("Cedar Falls Road")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_autocomplete_keeps_subpremise_addresses(self):
+        """Unit/apartment addresses (subpremise) are precise and kept."""
+        mock_predictions = self.gmaps_utils.mock_autocomplete_predictions(
+            count=1, types=["subpremise"]
+        )
+
+        results = await self.location_service.autocomplete_address("140 W Franklin St")
+
+        assert len(results) == 1
+        self.gmaps_utils.assert_autocomplete_matches(
+            result=results[0],
+            expected_description=mock_predictions[0]["description"],
+            expected_place_id=mock_predictions[0]["place_id"],
         )
 
     @pytest.mark.asyncio

--- a/backend/test/modules/location/location_utils.py
+++ b/backend/test/modules/location/location_utils.py
@@ -182,17 +182,24 @@ class GmapsMockUtils:
         self.mock_autocomplete = mock_autocomplete
 
     def mock_autocomplete_predictions(
-        self, count: int = 2, **overrides: Unpack[LocationOverrides]
+        self,
+        count: int = 2,
+        types: list[str] | None = None,
+        **overrides: Unpack[LocationOverrides],
     ) -> list[dict]:
         """Generate mock autocomplete predictions for Google Maps API testing.
 
         Args:
             count: Number of predictions to generate
+            types: Place types to attach to each prediction. Defaults to a precise
+                address (``["street_address"]``); pass ``["route"]`` to simulate a
+                bare street.
             **overrides: Optional overrides for specific fields
 
         Returns:
             List of mock prediction dictionaries matching Google Maps API format
         """
+        prediction_types = types if types is not None else ["street_address"]
         predictions = []
         for _ in range(count):
             data = self.location_utils.get_or_default(
@@ -203,6 +210,7 @@ class GmapsMockUtils:
                 {
                     "description": data["formatted_address"],
                     "place_id": data["google_place_id"],
+                    "types": prediction_types,
                 }
             )
 

--- a/frontend/src/app/(student)/_components/info/PartyRegistrationInfo.tsx
+++ b/frontend/src/app/(student)/_components/info/PartyRegistrationInfo.tsx
@@ -151,6 +151,12 @@ export default function PartyRegistrationInfo({
               courtyards) cannot be registered.
             </li>
             <li>
+              If the police should show up at your residence, be respectful. Let
+              them know you registered and be sure to shut your party down. If
+              you ignore your warning, whether by phone or by the police, you
+              are likely to get a citation.
+            </li>
+            <li>
               Residences that receive two consecutive warnings on registered
               parties from Chapel Hill police will lose party registration
               privileges for 90 days, enforced as a hold on the residence (see

--- a/frontend/src/app/police/page.tsx
+++ b/frontend/src/app/police/page.tsx
@@ -231,6 +231,7 @@ export default function PolicePage() {
                 value={searchAddress?.formatted_address || ""}
                 onSelect={setSearchAddress}
                 placeholder="Search by address..."
+                browserAutocomplete={false}
               />
             </div>
             <div className="flex flex-col gap-2 order-1 sm:order-2">

--- a/frontend/src/components/AddressSearch.tsx
+++ b/frontend/src/components/AddressSearch.tsx
@@ -32,6 +32,7 @@ interface AddressSearchProps {
   error?: string;
   chapelHillOnly?: boolean;
   id?: string;
+  browserAutocomplete?: boolean;
 }
 
 /**
@@ -48,6 +49,7 @@ export default function AddressSearch({
   error: externalError,
   chapelHillOnly = false,
   id,
+  browserAutocomplete = true,
 }: AddressSearchProps) {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState(
@@ -266,6 +268,7 @@ export default function AddressSearch({
                   "bg-muted/50 text-muted-foreground cursor-not-allowed",
                 displayError && "border-destructive"
               )}
+              autoComplete={browserAutocomplete ? "on" : "off"}
               aria-label="Address search input"
               aria-describedby={displayError ? "address-error" : undefined}
               aria-invalid={!!displayError}
@@ -325,7 +328,8 @@ export default function AddressSearch({
                 searchTerm.trim().length >= 3 &&
                 suggestions.length === 0 && (
                   <CommandEmpty>
-                    No addresses found. Try a different search.
+                    No addresses found. Make sure to include the full street
+                    address.
                   </CommandEmpty>
                 )}
               {!isLoading && suggestions.length > 0 && (


### PR DESCRIPTION
Address autocomplete previously surfaced results that aren't valid residences to register: bare streets (a whole road with no house number) and addresses far outside the area (`location` + `radius` only *bias* legacy Place Autocomplete, so identically-named streets in other states leaked through). This tightens suggestions to specific dwellings near Chapel Hill, and makes the empty state more actionable.

Changes:

- Filter out bare-street (route-only) predictions in `autocomplete_address`; only suggest precise addresses (`street_address`, `premise`, `subpremise`)
- Add `strict_bounds=True` so results are restricted to the radius around Chapel Hill instead of merely biased, and tighten the radius to 10km
- Add a `browserAutocomplete` prop to `AddressSearch` (default on) and disable the native browser autocomplete on the police search so it doesn't fight the custom dropdown
- Update the empty-state copy to "No addresses found. Make sure to include the full street address."
- Extend the gmaps test util with prediction `types` and add coverage for bare-street filtering vs. precise addresses

Closes #462