### PR TITLE
feat: key IdP account upsert on PID and remove rate limiter

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
   "tzdata~=2025.2",
   "aiosmtplib~=3.0.0",
   "alembic~=1.16.0",
-  "slowapi~=0.1.0",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,12 +1,6 @@
-from typing import cast
-
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.middleware import SlowAPIMiddleware
-from slowapi.util import get_remote_address
 from src.core.config import env
 from src.modules.account.account_router import account_router
 from src.modules.auth.auth_router import router as auth_router
@@ -17,18 +11,8 @@ from src.modules.party.party_router import party_router
 from src.modules.police.police_router import police_router
 from src.modules.student.student_router import student_router
 from starlette.middleware.base import RequestResponseEndpoint
-from starlette.types import ExceptionHandler
-
-# If deployed behind a reverse proxy (e.g. nginx, Caddy, AWS ALB), replace
-# get_remote_address with a function that reads request.headers["X-Forwarded-For"].
-# Using get_remote_address behind a proxy means all users share one rate limit bucket.
-# Using X-Forwarded-For without a proxy allows clients to spoof their IP and bypass limits.
-limiter = Limiter(key_func=get_remote_address, default_limits=["300/minute"])
 
 app = FastAPI()
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, cast(ExceptionHandler, _rate_limit_exceeded_handler))
-app.add_middleware(SlowAPIMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/src/modules/account/account_service.py
+++ b/backend/src/modules/account/account_service.py
@@ -288,7 +288,7 @@ class AccountService:
 
     async def upsert_idp_account(self, data: AccountData) -> AccountDto:
         try:
-            account_entity = await self.get_account_entity_by(onyen=data.onyen)
+            account_entity = await self.get_account_entity_by(pid=data.pid)
         except AccountNotFoundException as e:
             if data.role != AccountRole.STUDENT:
                 raise ForbiddenException(detail="No matching account found") from e
@@ -300,7 +300,7 @@ class AccountService:
         account_entity.first_name = data.first_name
         account_entity.last_name = data.last_name
         account_entity.email = data.email
-        account_entity.pid = data.pid
+        account_entity.onyen = data.onyen
         self.session.add(account_entity)
         await self.session.commit()
         await self.session.refresh(account_entity)

--- a/backend/test/modules/auth/auth_router_test.py
+++ b/backend/test/modules/auth/auth_router_test.py
@@ -61,7 +61,7 @@ class TestAuthRouter:
     async def test_exchange_student_creates_account_if_not_found(
         self, account_utils: AccountTestUtils
     ) -> None:
-        """Student exchange creates a new account when onyen doesn't exist."""
+        """Student exchange creates a new account when pid doesn't exist."""
         account_data = await account_utils.next_data(role="student")
 
         response = await self.unauthenticated_client.post(
@@ -94,8 +94,8 @@ class TestAuthRouter:
             email="newemail@unc.edu",
             first_name="Updated",
             last_name="Name",
-            pid="987654321",
-            onyen=existing.onyen,
+            pid=existing.pid,
+            onyen="newonyen",
             role=AccountRole.STUDENT,
         )
 


### PR DESCRIPTION
This PR resolves two related backend cleanups: switching the account uniqueness key used during IdP login to PID, and removing the in-app rate limiter now that a reverse proxy is being introduced.

Changes:

- Key the student IdP account upsert (`upsert_idp_account`) on `pid` instead of `onyen` when looking up an existing account, treating PID as the stable identity and overwriting `onyen` from the IdP payload — consistent with how `provision_staff_account` already matches staff by PID (#466)
- Remove the slowapi rate limiter from `main.py` (limiter setup, exception handler, and `SlowAPIMiddleware`) and drop the `slowapi` dependency from `backend/pyproject.toml`, since the new reverse proxy will handle rate limiting (#467)
- Update auth exchange tests to reflect PID-based matching

Closes #466
Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)