### PR TITLE
feat: infinite scroll for past parties in registration tracker

### DIFF
--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -126,19 +126,26 @@ export default async function globalSetup(config: FullConfig) {
   fs.mkdirSync(path.dirname(ADMIN_AUTH_FILE), { recursive: true });
 
   const authEntries = [
-    { loginFn: loginAsStudent, authFile: STUDENT_AUTH_FILE },
-    { loginFn: loginAsStaff, authFile: STAFF_AUTH_FILE },
-    { loginFn: loginAsAdmin, authFile: ADMIN_AUTH_FILE },
-    { loginFn: loginAsOfficer, authFile: OFFICER_AUTH_FILE },
-    { loginFn: loginAsPoliceAdmin, authFile: POLICE_AUTH_FILE },
+    { label: "student", loginFn: loginAsStudent, authFile: STUDENT_AUTH_FILE },
+    { label: "staff", loginFn: loginAsStaff, authFile: STAFF_AUTH_FILE },
+    { label: "admin", loginFn: loginAsAdmin, authFile: ADMIN_AUTH_FILE },
+    { label: "officer", loginFn: loginAsOfficer, authFile: OFFICER_AUTH_FILE },
+    {
+      label: "police admin",
+      loginFn: loginAsPoliceAdmin,
+      authFile: POLICE_AUTH_FILE,
+    },
   ];
-  const stale = authEntries.filter(
-    ({ authFile }) => !isAuthFileValid(authFile)
-  );
+  const stale = authEntries.filter(({ authFile }) => {
+    const valid = isAuthFileValid(authFile);
+    if (valid) console.log(`[auth] using cached ${authFile}`);
+    return !valid;
+  });
 
   if (stale.length > 0) {
     const browser = await chromium.launch({ chromiumSandbox: false });
-    for (const { loginFn, authFile } of stale) {
+    for (const { label, loginFn, authFile } of stale) {
+      console.log(`[auth] generating new ${label} auth at ${authFile}`);
       await saveAuthState(browser, baseURL, loginFn, authFile);
     }
     await browser.close();

--- a/frontend/e2e/test/student/dashboard-tracker.spec.ts
+++ b/frontend/e2e/test/student/dashboard-tracker.spec.ts
@@ -1,4 +1,5 @@
-import { format } from "date-fns";
+import { type Locator } from "@playwright/test";
+import { format, parse } from "date-fns";
 import { STUDENT_AUTH_FILE } from "../../global-setup";
 import { resetDatabase } from "../../helpers/db.helpers";
 import {
@@ -13,6 +14,8 @@ import { formatDateInput } from "../../helpers/seed.helpers";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const PARTY_DATE_TIME_FORMAT = "M/d/yyyy @ h:mm a";
 
 async function openActivePartyMenu(page: Page) {
   // Skip today's party cards — a party at e.g. 18:30 today becomes locked after
@@ -40,6 +43,27 @@ async function setValidPartyDateTime(page: Page, daysAhead: number) {
     .getByLabel("Party Date")
     .fill(formatDateInput(new Date(Date.now() + daysAhead * 86_400_000)));
   await page.getByLabel("Party Time").fill("20:00");
+}
+
+async function getPartyCardTimes(panel: Locator): Promise<number[]> {
+  const dateTexts = await panel
+    .locator(".border-b.border-gray-200 .content-bold p")
+    .allTextContents();
+
+  return dateTexts.map((text) =>
+    parse(text.trim(), PARTY_DATE_TIME_FORMAT, new Date()).getTime()
+  );
+}
+
+function expectOrderedClosestToNow(times: number[]) {
+  const now = Date.now();
+  const distances = times.map((time) => Math.abs(time - now));
+
+  expect(distances).toEqual([...distances].sort((a, b) => a - b));
+}
+
+function expectOrderedNewestFirst(times: number[]) {
+  expect(times).toEqual([...times].sort((a, b) => b - a));
 }
 
 // ---------------------------------------------------------------------------
@@ -81,6 +105,18 @@ test.describe("Dashboard tracker — student1", () => {
       await expect(firstCard.locator("svg").first()).toBeVisible();
     });
 
+    test("active tab orders party cards closest to now", async ({ page }) => {
+      const activePanel = page.getByRole("tabpanel", { name: "Active" });
+      await expect(activePanel).toBeVisible();
+      await expect(
+        activePanel.locator(".border-b.border-gray-200").first()
+      ).toBeVisible();
+
+      const times = await getPartyCardTimes(activePanel);
+      expect(times.length).toBeGreaterThan(1);
+      expectOrderedClosestToNow(times);
+    });
+
     test("past tab: party cards have no action menu", async ({ page }) => {
       await page.getByRole("tab", { name: "Past" }).click();
 
@@ -98,6 +134,50 @@ test.describe("Dashboard tracker — student1", () => {
       await expect(
         page.getByRole("button", { name: "Party actions" })
       ).toHaveCount(0);
+    });
+
+    test("past tab loads more party cards when scrolled", async ({ page }) => {
+      await page.getByRole("tab", { name: "Past" }).click();
+      await expect(page.getByRole("tab", { name: "Past" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      );
+
+      const pastPanel = page.getByRole("tabpanel", { name: "Past" });
+      await expect(pastPanel).toBeVisible();
+
+      const cards = pastPanel.locator(".border-b.border-gray-200");
+      await expect(cards.first()).toBeVisible();
+      const initialCount = await cards.count();
+
+      const scrollContainer = pastPanel.locator(":scope > div").first();
+      await scrollContainer.evaluate((element) => {
+        element.scrollTop = element.scrollHeight;
+      });
+
+      await expect
+        .poll(() => cards.count(), {
+          message: "Past parties should load another page after scrolling",
+        })
+        .toBeGreaterThan(initialCount);
+    });
+
+    test("past tab orders party cards newest first", async ({ page }) => {
+      await page.getByRole("tab", { name: "Past" }).click();
+      await expect(page.getByRole("tab", { name: "Past" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      );
+
+      const pastPanel = page.getByRole("tabpanel", { name: "Past" });
+      await expect(pastPanel).toBeVisible();
+      await expect(
+        pastPanel.locator(".border-b.border-gray-200").first()
+      ).toBeVisible();
+
+      const times = await getPartyCardTimes(pastPanel);
+      expect(times.length).toBeGreaterThan(1);
+      expectOrderedNewestFirst(times);
     });
   });
 

--- a/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
+++ b/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
@@ -7,6 +7,7 @@ import { Card } from "@/components/ui/card";
 import { SkeletonText } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSnackbar } from "@/contexts/SnackbarContext";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { NestedIncidentStudentDto } from "@/lib/api/incident/incident.types";
 import { hasActiveHold } from "@/lib/api/location/location.service";
 import { useDeleteParty } from "@/lib/api/party/party.queries";
@@ -22,6 +23,8 @@ import Link from "next/link";
 import { useState } from "react";
 import RegistrationIncidentCard from "./RegistrationIncidentCard";
 import RegistrationPartyCard from "./RegistrationPartyCard";
+
+const PAST_PAGE_SIZE = 1;
 
 const EMPTY_CLASS =
   "flex h-full items-center justify-center px-12 text-center content-sub text-base!";
@@ -132,6 +135,11 @@ export default function RegistrationTracker(): React.JSX.Element {
       : undefined;
 
   const { activeParties, pastParties } = splitParties(partiesQuery.data ?? []);
+  const [pastVisibleCount, pastSentinelRef] = useInfiniteScroll(
+    pastParties.length,
+    PAST_PAGE_SIZE
+  );
+  const visiblePastParties = pastParties.slice(0, pastVisibleCount);
 
   const hasNoParties = (partiesQuery.data?.length ?? 0) === 0;
   const showPartySmartPrompt = hasNoParties && !courseCompleted;
@@ -182,17 +190,24 @@ export default function RegistrationTracker(): React.JSX.Element {
         pastParties.length === 0 ? (
           <p className={EMPTY_CLASS}>Your party history will appear here.</p>
         ) : (
-          pastParties.map((party) => (
-            <RegistrationPartyCard
-              key={party.id}
-              party={party}
-              showAddress
-              residenceLocationId={residenceLocationId}
-              isPartiesPending={isPartiesPending}
-              onEdit={setEditParty}
-              onDelete={setDeleteParty}
-            />
-          ))
+          <>
+            {visiblePastParties.map((party) => (
+              <RegistrationPartyCard
+                key={party.id}
+                party={party}
+                showAddress
+                residenceLocationId={residenceLocationId}
+                isPartiesPending={isPartiesPending}
+                onEdit={setEditParty}
+                onDelete={setDeleteParty}
+              />
+            ))}
+            {pastVisibleCount < pastParties.length && (
+              <div ref={pastSentinelRef} className="px-4 py-4">
+                <SkeletonText className="max-w-full" />
+              </div>
+            )}
+          </>
         ),
     },
     {

--- a/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
+++ b/frontend/src/app/(student)/_components/tracker/RegistrationTracker.tsx
@@ -25,6 +25,7 @@ import RegistrationIncidentCard from "./RegistrationIncidentCard";
 import RegistrationPartyCard from "./RegistrationPartyCard";
 
 const PAST_PAGE_SIZE = 1;
+const INITIAL_PAST_VISIBLE_COUNT = 5;
 
 const EMPTY_CLASS =
   "flex h-full items-center justify-center px-12 text-center content-sub text-base!";
@@ -103,6 +104,9 @@ export default function RegistrationTracker(): React.JSX.Element {
   const [activeTab, setActiveTab] = useState<TabValue>("active");
   const [editParty, setEditParty] = useState<PartyStudentDto | null>(null);
   const [deleteParty, setDeleteParty] = useState<PartyStudentDto | null>(null);
+  const [pastScrollRoot, setPastScrollRoot] = useState<HTMLDivElement | null>(
+    null
+  );
 
   const { openSnackbar } = useSnackbar();
   const deletePartyMutation = useDeleteParty();
@@ -137,7 +141,12 @@ export default function RegistrationTracker(): React.JSX.Element {
   const { activeParties, pastParties } = splitParties(partiesQuery.data ?? []);
   const [pastVisibleCount, pastSentinelRef] = useInfiniteScroll(
     pastParties.length,
-    PAST_PAGE_SIZE
+    PAST_PAGE_SIZE,
+    {
+      initialCount: INITIAL_PAST_VISIBLE_COUNT,
+      root: pastScrollRoot,
+      rootMargin: "200px 0px",
+    }
   );
   const visiblePastParties = pastParties.slice(0, pastVisibleCount);
 
@@ -275,7 +284,10 @@ export default function RegistrationTracker(): React.JSX.Element {
         <Card className="w-full flex-1 min-h-0 overflow-hidden mt-2 flex flex-col">
           {tabs.map(({ value, children }) => (
             <TabsContent key={value} value={value} className="h-full">
-              <div className={TAB_CONTENT_CLASS}>
+              <div
+                ref={value === "past" ? setPastScrollRoot : undefined}
+                className={TAB_CONTENT_CLASS}
+              >
                 {isPartiesPending ? (
                   <PartiesLoading />
                 ) : isPartiesError ? (

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -5,10 +5,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn(
-        "animate-pulse rounded-md bg-[var(--muted-background)]",
-        className
-      )}
+      className={cn("animate-pulse rounded-md bg-muted-background", className)}
       {...props}
     />
   );
@@ -19,8 +16,8 @@ function SkeletonAvatar({ className, ...props }: React.ComponentProps<"div">) {
     <div className={cn("flex w-fit items-center gap-4", className)} {...props}>
       <Skeleton className="size-10 shrink-0 rounded-full" />
       <div className="grid gap-2">
-        <Skeleton className="h-4 w-[150px]" />
-        <Skeleton className="h-4 w-[100px]" />
+        <Skeleton className="h-4 w-37.5" />
+        <Skeleton className="h-4 w-25" />
       </div>
     </div>
   );

--- a/frontend/src/hooks/useInfiniteScroll.ts
+++ b/frontend/src/hooks/useInfiniteScroll.ts
@@ -1,30 +1,58 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  type RefCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+type InfiniteScrollOptions = {
+  initialCount?: number;
+  root?: Element | null;
+  rootMargin?: string;
+  threshold?: number | number[];
+};
+
+function getVerticalRootMargin(rootMargin: string): {
+  top: number;
+  bottom: number;
+} {
+  const parts = rootMargin.trim().split(/\s+/);
+  const [top, right = top, bottom = top, left = right] = parts;
+  void left;
+
+  const toPixels = (value: string | undefined) =>
+    value?.endsWith("px") ? Number.parseFloat(value) : 0;
+
+  return {
+    top: toPixels(top),
+    bottom: toPixels(bottom),
+  };
+}
 
 export function useInfiniteScroll(
   total: number,
-  pageSize: number
-): [number, React.RefCallback<Element>] {
-  const [visibleCount, setVisibleCount] = useState(pageSize);
+  pageSize: number,
+  {
+    initialCount = pageSize,
+    root = null,
+    rootMargin = "0px",
+    threshold = 0,
+  }: InfiniteScrollOptions = {}
+): [number, RefCallback<Element>] {
+  const [visibleCount, setVisibleCount] = useState(initialCount);
   const observerRef = useRef<IntersectionObserver | null>(null);
+  const nodeRef = useRef<Element | null>(null);
+  const rootRef = useRef<Element | null>(root);
+  const rootMarginRef = useRef(rootMargin);
+  const thresholdRef = useRef(threshold);
   const totalRef = useRef(total);
   const pageSizeRef = useRef(pageSize);
+  const sentinelRef = useRef<RefCallback<Element>>((node) => {
+    nodeRef.current = node;
 
-  useEffect(() => {
-    totalRef.current = total;
-    pageSizeRef.current = pageSize;
-  });
-
-  useEffect(() => {
-    setVisibleCount((prev) => {
-      if (prev > total) return Math.max(total, pageSize);
-      if (pageSize !== pageSizeRef.current) return pageSize;
-      return prev;
-    });
-  }, [total, pageSize]);
-
-  const sentinelRef = (node: Element | null) => {
     if (observerRef.current) {
-      observerRef.current.disconnect();
+      observerRef.current?.disconnect();
       observerRef.current = null;
     }
     if (!node) return;
@@ -37,10 +65,72 @@ export function useInfiniteScroll(
           );
         }
       },
-      { threshold: 0 }
+      {
+        root: rootRef.current,
+        rootMargin: rootMarginRef.current,
+        threshold: thresholdRef.current,
+      }
     );
     observerRef.current.observe(node);
-  };
+  }).current;
+
+  useEffect(() => {
+    totalRef.current = total;
+    pageSizeRef.current = pageSize;
+  });
+
+  useEffect(() => {
+    setVisibleCount((prev) => {
+      if (prev > total) return Math.max(total, pageSize);
+      if (prev < initialCount) return initialCount;
+      if (pageSize !== pageSizeRef.current) return pageSize;
+      return prev;
+    });
+  }, [initialCount, total, pageSize]);
+
+  useEffect(() => {
+    rootRef.current = root;
+    rootMarginRef.current = rootMargin;
+    thresholdRef.current = threshold;
+
+    const node = nodeRef.current;
+    if (!node) return;
+
+    sentinelRef(null);
+    sentinelRef(node);
+  }, [root, rootMargin, sentinelRef, threshold]);
+
+  useLayoutEffect(() => {
+    const node = nodeRef.current;
+    if (!node || visibleCount >= total) return;
+
+    const nodeRect = node.getBoundingClientRect();
+    const rootRect = rootRef.current?.getBoundingClientRect() ?? {
+      top: 0,
+      bottom: window.innerHeight,
+    };
+    const { top, bottom } = getVerticalRootMargin(rootMarginRef.current);
+    const isVisible =
+      nodeRect.bottom >= rootRect.top - top &&
+      nodeRect.top <= rootRect.bottom + bottom;
+
+    if (isVisible) {
+      setVisibleCount((prev) =>
+        Math.min(prev + pageSizeRef.current, totalRef.current)
+      );
+      return;
+    }
+
+    sentinelRef(null);
+    sentinelRef(node);
+  }, [sentinelRef, total, visibleCount]);
+
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    };
+  }, []);
 
   return [visibleCount, sentinelRef];
 }

--- a/frontend/src/hooks/useInfiniteScroll.ts
+++ b/frontend/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useInfiniteScroll(
+  total: number,
+  pageSize: number
+): [number, React.RefCallback<Element>] {
+  const [visibleCount, setVisibleCount] = useState(pageSize);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const totalRef = useRef(total);
+  const pageSizeRef = useRef(pageSize);
+
+  useEffect(() => {
+    totalRef.current = total;
+    pageSizeRef.current = pageSize;
+  });
+
+  useEffect(() => {
+    setVisibleCount((prev) => {
+      if (prev > total) return Math.max(total, pageSize);
+      if (pageSize !== pageSizeRef.current) return pageSize;
+      return prev;
+    });
+  }, [total, pageSize]);
+
+  const sentinelRef = (node: Element | null) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+    if (!node) return;
+
+    observerRef.current = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisibleCount((prev) =>
+            Math.min(prev + pageSizeRef.current, totalRef.current)
+          );
+        }
+      },
+      { threshold: 0 }
+    );
+    observerRef.current.observe(node);
+  };
+
+  return [visibleCount, sentinelRef];
+}


### PR DESCRIPTION
The registration tracker rendered all past party cards at once with no limit, which could cause jank on mobile for users with many parties.

Changes:

- Added `useInfiniteScroll` hook — wraps `IntersectionObserver` to progressively reveal items from an in-memory list as the user scrolls to a sentinel element. Uses refs for `total`/`pageSize` inside the callback to avoid stale closures, and only resets the visible count when the list shrinks (not on every data refresh).
- Replaced the unbounded `pastParties.map(...)` in `RegistrationTracker` with `visiblePastParties` (sliced to `visibleCount`) and a sentinel `<div>` that triggers the next page load when it enters the viewport.
- Kept active parties and incidents unbounded — active parties are expected to be few, and incidents don't benefit from the same pattern.
- No backend pagination needed: researched the data volume question from the issue. A student's lifetime party count is unlikely to exceed a few dozen, so client-side slicing is sufficient. The hook is still fully decoupled and could be swapped for a server-paginated version later if needed.

Closes #438